### PR TITLE
fix/epic6-signup-wizard

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -165,7 +165,12 @@ def signup(request: SignupRequest):
                 {"Name": "name", "Value": request.name},
             ]
         )
-        return {"success": True, "data": {"message": "인증 코드가 이메일로 발송되었습니다."}}
+        # 이메일 인증 없이 자동 확인 처리
+        cognito.admin_confirm_sign_up(
+            UserPoolId=settings.cognito_user_pool_id,
+            Username=request.email,
+        )
+        return {"success": True, "data": {"message": "회원가입이 완료되었습니다."}}
     except ClientError as e:
         error_code = e.response["Error"]["Code"]
         if error_code == "UsernameExistsException":

--- a/frontend/app/(auth)/connect/page.tsx
+++ b/frontend/app/(auth)/connect/page.tsx
@@ -47,7 +47,7 @@ export default function ConnectPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center">
       <Card className="w-full max-w-lg">
         <CardHeader>
           <CardTitle>AWS 계정 연동</CardTitle>

--- a/frontend/app/(auth)/signup/page.tsx
+++ b/frontend/app/(auth)/signup/page.tsx
@@ -1,4 +1,4 @@
-// frontend/app/(auth)/login/page.tsx
+// frontend/app/(auth)/signup/page.tsx
 'use client'
 
 import { useState } from 'react'
@@ -7,48 +7,43 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { apiClient } from '@/lib/api'
-import { useAuthStore } from '@/store/authStore'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
-const loginSchema = z.object({
+const signupSchema = z.object({
+  name: z.string().min(2, '이름은 2자 이상이어야 합니다.'),
   email: z.string().email('올바른 이메일을 입력하세요.'),
-  password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.'),
+  password: z
+    .string()
+    .min(8, '비밀번호는 8자 이상이어야 합니다.')
+    .regex(/[A-Z]/, '대문자를 포함해야 합니다.')
+    .regex(/[0-9]/, '숫자를 포함해야 합니다.')
+    .regex(/[^A-Za-z0-9]/, '특수문자를 포함해야 합니다.'),
 })
-type LoginForm = z.infer<typeof loginSchema>
+type SignupForm = z.infer<typeof signupSchema>
 
-export default function LoginPage() {
+export default function SignupPage() {
   const router = useRouter()
-  const { setAuth } = useAuthStore()
-  const [error, setError] = useState<string>('')
+  const [error, setError] = useState('')
 
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
-  } = useForm<LoginForm>({ resolver: zodResolver(loginSchema) })
+  } = useForm<SignupForm>({ resolver: zodResolver(signupSchema) })
 
-  const onSubmit = async (data: LoginForm) => {
+  const onSubmit = async (data: SignupForm) => {
     setError('')
     try {
-      const res = await apiClient.post('/api/auth/login', data)
-      const { access_token, user } = res.data.data
-
-      setAuth(user, access_token)
-
-      // §12-2 전환 로직: AWS 미연동 → SCR-C-02, 연동 완료 → SCR-C-03
-      if (!user.aws_connected) {
-        router.push('/connect')
-      } else {
-        router.push('/dashboard')
-      }
+      await apiClient.post('/api/auth/signup', data)
+      router.push(`/login`)
     } catch (err: unknown) {
       const msg =
         (err as { response?: { data?: { error?: { message?: string } } } })
           ?.response?.data?.error?.message ||
-        '로그인에 실패했습니다.'
+        '회원가입에 실패했습니다.'
       setError(msg)
     }
   }
@@ -59,11 +54,22 @@ export default function LoginPage() {
         <CardHeader className="text-center">
           <div className="text-3xl font-bold text-teal-600">⚡ AutoOps</div>
           <CardTitle className="text-sm text-gray-500 font-normal mt-1">
-            멀티클라우드 인프라 자동화 플랫폼
+            회원가입
           </CardTitle>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <div>
+              <label className="text-sm font-medium">이름</label>
+              <Input
+                {...register('name')}
+                placeholder="홍길동"
+                className="mt-1"
+              />
+              {errors.name && (
+                <p className="text-red-500 text-xs mt-1">{errors.name.message}</p>
+              )}
+            </div>
             <div>
               <label className="text-sm font-medium">이메일</label>
               <Input
@@ -87,6 +93,9 @@ export default function LoginPage() {
               {errors.password && (
                 <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>
               )}
+              <p className="text-xs text-gray-400 mt-1">
+                8자 이상, 대문자·숫자·특수문자 포함
+              </p>
             </div>
 
             {error && (
@@ -102,25 +111,24 @@ export default function LoginPage() {
             >
               {isSubmitting ? (
                 <span className="flex items-center gap-2">
-                  <span className="animate-spin">⏳</span> 로그인 중...
+                  <span className="animate-spin">⏳</span> 가입 중...
                 </span>
               ) : (
-                '로그인'
+                '회원가입'
               )}
             </Button>
+
+            <p className="text-center text-sm text-gray-500">
+              이미 계정이 있으신가요?{' '}
+              <button
+                type="button"
+                className="text-teal-600 hover:underline"
+                onClick={() => router.push('/login')}
+              >
+                로그인
+              </button>
+            </p>
           </form>
-
-          <p className="text-center text-sm text-gray-500 mt-4">
-            계정이 없으신가요?{' '}
-            <button
-              type="button"
-              className="text-teal-600 hover:underline"
-              onClick={() => router.push('/signup')}
-            >
-              회원가입
-            </button>
-          </p>
-
         </CardContent>
       </Card>
     </div>

--- a/frontend/app/projects/new/NewProjectPageContent.tsx
+++ b/frontend/app/projects/new/NewProjectPageContent.tsx
@@ -9,7 +9,7 @@ import { IntentAnalysis } from '@/components/craftops/IntentAnalysis'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 
-type WizardPhase = 'project-create' | 'step1' | '2-1' | '2-2' | '2-3' | '2-4' | '2-5' | '2-6' | 'validate'
+type WizardPhase = 'project-create' | 'step1' | '2-1' | '2-2' | '2-3' | '2-4' | '2-5' | '2-6' | 'summary' | 'validate'
 
 export default function NewProjectPageContent() {
   const router       = useRouter()
@@ -28,6 +28,17 @@ export default function NewProjectPageContent() {
   const [isSubmitting, setIsSubmitting]     = useState(false)
   const [namingPreview, setNamingPreview]   = useState<string[]>([])
   const [stepConfigs, setStepConfigs]       = useState<Record<string, Record<string, unknown>>>({})
+  const [cidrError, setCidrError]           = useState('')
+
+  const validateCIDR = (cidr: string): boolean => {
+    const cidrRegex = /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$/
+    if (!cidrRegex.test(cidr)) return false
+    const [ip, prefix] = cidr.split('/')
+    const parts = ip.split('.').map(Number)
+    if (parts.some((p) => p > 255)) return false
+    if (parseInt(prefix) > 32) return false
+    return true
+  }
 
   const handleCreateProject = async () => {
     setIsSubmitting(true)
@@ -68,9 +79,8 @@ export default function NewProjectPageContent() {
       const nextStep = data.next_step
       if (nextStep) {
         setPhase(nextStep as WizardPhase)
-      } else {
-        router.push(`/projects/${projectId}/validate`)
       }
+      // next_step 없으면 summary로 이동
     } finally {
       setIsSubmitting(false)
     }
@@ -139,7 +149,7 @@ export default function NewProjectPageContent() {
     )
   }
 
-  if (phase === '2-1') {
+if (phase === '2-1') {
     return (
       <div className="p-6">
         <WizardLayout
@@ -161,24 +171,24 @@ export default function NewProjectPageContent() {
               <label className="text-sm font-medium">리소스 네이밍 규칙</label>
               <div className="grid grid-cols-2 gap-2 mt-1">
                 <div>
-                  <p className="text-xs text-gray-500">프리픽스</p>
-                  <Input value={projectForm.prefix} readOnly className="bg-gray-50" />
+                  <p className="text-xs text-[#9ca3af]">프리픽스</p>
+                  <Input value={projectForm.prefix} readOnly className="border-white/10 text-white" style={{ backgroundColor: '#121214' }} />
                 </div>
                 <div>
-                  <p className="text-xs text-gray-500">환경</p>
-                  <Input value={projectForm.environment} readOnly className="bg-gray-50" />
+                  <p className="text-xs text-[#9ca3af]">환경</p>
+                  <Input value={projectForm.environment} readOnly className="border-white/10 text-white" style={{ backgroundColor: '#121214' }} />
                 </div>
               </div>
             </div>
             {namingPreview.length > 0 && (
-              <div className="bg-gray-50 rounded p-3">
-                <p className="text-xs text-gray-500 mb-1">네이밍 미리보기</p>
+              <div className="bg-black/30 border border-white/8 rounded p-3">
+                <p className="text-xs text-[#9ca3af] mb-1">네이밍 미리보기</p>
                 <div className="text-xs space-y-0.5">
                   {namingPreview.slice(0, 5).map((n) => (
                     <p key={n} className="font-mono">{n}</p>
                   ))}
                   {namingPreview.length > 5 && (
-                    <p className="text-gray-400">... 외 {namingPreview.length - 5}개</p>
+                    <p className="text-[#9ca3af]">... 외 {namingPreview.length - 5}개</p>
                   )}
                 </div>
               </div>
@@ -197,11 +207,15 @@ export default function NewProjectPageContent() {
           completedSteps={completedSteps}
           sidekick="VPC CIDR 입력 시 서브넷 4개(prod) 또는 2개(dev/staging)가 자동 분배됩니다."
           onPrev={() => setPhase('2-1')}
-          onNext={() =>
-            handleSaveStep('2-2', {
-              vpc_cidr: (stepConfigs['2-2']?.vpc_cidr as string) || '10.0.0.0/16',
-            })
-          }
+          onNext={() => {
+            const cidr = (stepConfigs['2-2']?.vpc_cidr as string) || '10.0.0.0/16'
+            if (!validateCIDR(cidr)) {
+              setCidrError('올바른 CIDR 형식이 아닙니다. 예) 10.0.0.0/16')
+              return
+            }
+            setCidrError('')
+            handleSaveStep('2-2', { vpc_cidr: cidr })
+          }}
           isSubmitting={isSubmitting}
         >
           <div className="space-y-3">
@@ -209,16 +223,25 @@ export default function NewProjectPageContent() {
               <label className="text-sm font-medium">VPC CIDR</label>
               <Input
                 defaultValue="10.0.0.0/16"
-                onChange={(e) =>
+                className={`mt-1 ${cidrError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
+                onChange={(e) => {
+                  const val = e.target.value
                   setStepConfigs((prev) => ({
                     ...prev,
-                    '2-2': { ...prev['2-2'], vpc_cidr: e.target.value },
+                    '2-2': { ...prev['2-2'], vpc_cidr: val },
                   }))
-                }
+                  if (cidrError) {
+                    setCidrError(validateCIDR(val) ? '' : '올바른 CIDR 형식이 아닙니다. 예) 10.0.0.0/16')
+                  }
+                }}
               />
-              <p className="text-xs text-gray-500 mt-1">
-                서브넷 자동 분배 (prod: Public 2 + Private 2 / dev·staging: Public 1 + Private 1)
-              </p>
+              {cidrError ? (
+                <p className="text-red-500 text-xs mt-1">⚠️ {cidrError}</p>
+              ) : (
+                <p className="text-xs text-[#9ca3af] mt-1">
+                  서브넷 자동 분배 (prod: Public 2 + Private 2 / dev·staging: Public 1 + Private 1)
+                </p>
+              )}
             </div>
           </div>
         </WizardLayout>
@@ -237,7 +260,7 @@ export default function NewProjectPageContent() {
           onNext={() => handleSaveStep('2-3', {})}
           isSubmitting={isSubmitting}
         >
-          <div className="space-y-2 text-sm bg-gray-50 rounded p-3">
+          <div className="space-y-2 text-sm bg-[#121214] rounded p-3">
             <p className="font-medium">자동 구성 내용</p>
             <p>SG-ALB: 443, 80 ← 0.0.0.0/0</p>
             <p>SG-App: 8080 ← SG-ALB</p>
@@ -269,10 +292,11 @@ export default function NewProjectPageContent() {
               <Input
                 value={`${projectForm.prefix}-${projectForm.environment}-alb`}
                 readOnly
-                className="bg-gray-50"
+                className="border-white/10 text-white"
+                style={{ backgroundColor: '#121214' }}
               />
             </div>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-[#9ca3af]">
               서브넷: Public 자동 배치 / 보안그룹: SG-ALB 자동 연결 / HTTPS:443 리스너
             </p>
           </div>
@@ -306,11 +330,11 @@ export default function NewProjectPageContent() {
             <div className="grid grid-cols-2 gap-2">
               <div>
                 <label className="text-sm font-medium">vCPU</label>
-                <Input defaultValue="1" readOnly className="bg-gray-50" />
+                <Input defaultValue="1" readOnly className="border-white/10 text-white" style={{ backgroundColor: '#121214' }} />
               </div>
               <div>
                 <label className="text-sm font-medium">메모리 (MB)</label>
-                <Input defaultValue="2048" readOnly className="bg-gray-50" />
+                <Input defaultValue="2048" readOnly className="border-white/10 text-white" style={{ backgroundColor: '#121214' }} />
               </div>
             </div>
             <div>
@@ -344,10 +368,13 @@ export default function NewProjectPageContent() {
               : 'dev 환경: Multi-AZ OFF / 백업 0일 / 암호화 OFF'
           }
           onPrev={() => setPhase('2-5')}
-          onNext={() => handleSaveStep('2-6', {})}
+          onNext={async () => {
+            await handleSaveStep('2-6', {})
+            setPhase('summary')
+          }}
           isSubmitting={isSubmitting}
         >
-          <div className="space-y-2 text-sm bg-gray-50 rounded p-3">
+          <div className="space-y-2 text-sm bg-[#121214] rounded p-3">
             <p className="font-medium">자동 적용 설정 ({projectForm.environment})</p>
             <p>엔진: PostgreSQL 15</p>
             <p>인스턴스: {isProd ? 'db.t3.medium' : 'db.t3.micro'}</p>
@@ -356,6 +383,117 @@ export default function NewProjectPageContent() {
             <p>암호화: {isProd ? 'ON' : 'OFF'}</p>
           </div>
         </WizardLayout>
+      </div>
+    )
+  }
+
+  if (phase === 'summary') {
+    const isProd        = projectForm.environment === 'prod'
+    const vpcCidr       = (stepConfigs['2-2']?.vpc_cidr as string) || '10.0.0.0/16'
+    const albName       = `${projectForm.prefix}-${projectForm.environment}-alb`
+    const containerImage = (stepConfigs['2-5']?.container_image as string) || '-'
+
+    return (
+      <div className="px-6 py-8 md:px-12 md:py-12 max-w-2xl space-y-4">
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold">📋 리소스 요약</h1>
+          <span className="text-sm text-[#9ca3af]">배포 전 최종 확인</span>
+        </div>
+
+        <div className="space-y-3">
+          {/* 기본 설정 */}
+          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
+            <p className="font-medium text-sm text-[#9ca3af]">기본 설정</p>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <p className="text-[#9ca3af]">프로젝트명</p>
+              <p className="font-mono">{projectForm.name}</p>
+              <p className="text-[#9ca3af]">네이밍 규칙</p>
+              <p className="font-mono">{projectForm.prefix}-{projectForm.environment}-*</p>
+              <p className="text-[#9ca3af]">리전</p>
+              <p className="font-mono">{projectForm.region}</p>
+              <p className="text-[#9ca3af]">환경</p>
+              <p className="font-mono">{projectForm.environment}</p>
+            </div>
+          </div>
+
+          {/* 네트워크 */}
+          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
+            <p className="font-medium text-sm text-[#9ca3af]">네트워크</p>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <p className="text-[#9ca3af]">VPC CIDR</p>
+              <p className="font-mono">{vpcCidr}</p>
+              <p className="text-[#9ca3af]">서브넷 구성</p>
+              <p className="font-mono">{isProd ? 'Public 2 + Private 2' : 'Public 1 + Private 1'}</p>
+              <p className="text-[#9ca3af]">NAT Gateway</p>
+              <p className="font-mono">{isProd ? '생성' : '미생성'}</p>
+            </div>
+          </div>
+
+          {/* 보안 그룹 */}
+          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
+            <p className="font-medium text-sm text-[#9ca3af]">보안 그룹</p>
+            <div className="text-sm space-y-1">
+              <p className="font-mono">SG-ALB: 443, 80 ← 0.0.0.0/0</p>
+              <p className="font-mono">SG-App: 8080 ← SG-ALB</p>
+              <p className="font-mono">SG-DB: 5432 ← SG-App</p>
+            </div>
+          </div>
+
+          {/* ALB */}
+          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
+            <p className="font-medium text-sm text-[#9ca3af]">ALB</p>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <p className="text-[#9ca3af]">이름</p>
+              <p className="font-mono">{albName}</p>
+              <p className="text-[#9ca3af]">리스너</p>
+              <p className="font-mono">HTTPS:443</p>
+            </div>
+          </div>
+
+          {/* ECS */}
+          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
+            <p className="font-medium text-sm text-[#9ca3af]">ECS Fargate</p>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <p className="text-[#9ca3af]">vCPU</p>
+              <p className="font-mono">1</p>
+              <p className="text-[#9ca3af]">메모리</p>
+              <p className="font-mono">2048 MB</p>
+              <p className="text-[#9ca3af]">컨테이너 이미지</p>
+              <p className="font-mono text-xs break-all">{containerImage}</p>
+              <p className="text-[#9ca3af]">최소 태스크</p>
+              <p className="font-mono">{isProd ? '2' : '1'}</p>
+              <p className="text-[#9ca3af]">오토스케일링</p>
+              <p className="font-mono">{isProd ? 'ON (CPU 70%)' : 'OFF'}</p>
+            </div>
+          </div>
+
+          {/* RDS */}
+          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
+            <p className="font-medium text-sm text-[#9ca3af]">RDS PostgreSQL</p>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <p className="text-[#9ca3af]">인스턴스</p>
+              <p className="font-mono">{isProd ? 'db.t3.medium' : 'db.t3.micro'}</p>
+              <p className="text-[#9ca3af]">Multi-AZ</p>
+              <p className="font-mono">{isProd ? 'ON' : 'OFF'}</p>
+              <p className="text-[#9ca3af]">백업 보존</p>
+              <p className="font-mono">{isProd ? '30일' : '0일'}</p>
+              <p className="text-[#9ca3af]">암호화</p>
+              <p className="font-mono">{isProd ? 'ON' : 'OFF'}</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-between pt-2">
+          <Button variant="outline" onClick={() => setPhase('2-6')}>
+            ← 설정 수정
+          </Button>
+          <Button
+            className="bg-teal-600 hover:bg-teal-700"
+            onClick={() => projectId && router.push(`/projects/${projectId}/validate`)}
+          >
+            검증 시작하기 →
+          </Button>
+        </div>
       </div>
     )
   }

--- a/frontend/components/craftops/IntentAnalysis.tsx
+++ b/frontend/components/craftops/IntentAnalysis.tsx
@@ -19,7 +19,6 @@ interface Props {
   onComplete: (result: AnalysisResult) => void
 }
 
-// §12-5 리소스 이름 매핑
 const RESOURCE_LABELS: Record<string, string> = {
   vpc:            'VPC + Subnet 4개 + IGW + NAT Gateway',
   security_group: 'Security Group 3개',
@@ -57,12 +56,11 @@ export function IntentAnalysis({ projectId, onComplete }: Props) {
 
   return (
     <div className="space-y-4">
-      {/* §12-5: 자연어 입력 영역 */}
       <div className="space-y-2">
         <label className="text-sm font-medium">인프라 요구사항을 자연어로 입력하세요</label>
         <Textarea
           value={prompt}
-          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setPrompt(e.target.value)}   
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setPrompt(e.target.value)}
           placeholder="예) 프로덕션용 Python API 서버, PostgreSQL DB, 오레곤 리전, 오토스케일링 필요"
           rows={4}
         />
@@ -88,15 +86,14 @@ export function IntentAnalysis({ projectId, onComplete }: Props) {
         </Alert>
       )}
 
-      {/* §12-5: AI 분석 결과 */}
       {result && (
-        <Card className="border-teal-200 bg-teal-50">
+        <Card className="border-white/8 bg-[#121214]">
           <CardContent className="p-4 space-y-3">
-            <p className="font-medium text-teal-800">── AI 분석 결과 ──</p>
+            <p className="font-medium text-[#9ca3af]">── AI 분석 결과 ──</p>
             <div className="space-y-1">
               {result.resources.map((r) => (
                 <div key={r} className="flex items-center gap-2 text-sm">
-                  <span className="text-green-600">✅</span>
+                  <span className="text-emerald-400">✅</span>
                   <span>{RESOURCE_LABELS[r] ?? r}</span>
                 </div>
               ))}

--- a/frontend/components/craftops/WizardLayout.tsx
+++ b/frontend/components/craftops/WizardLayout.tsx
@@ -43,9 +43,8 @@ export function WizardLayout({
     <div className="grid grid-cols-3 gap-6">
       {/* 왼쪽: 설정 폼 영역 */}
       <div className="col-span-2 space-y-4">
-        {/* 단계 헤더 */}
         <div>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-[#9ca3af]">
             Step 2-{stepIndex + 1} / 6
           </p>
           <h2 className="text-xl font-bold">
@@ -53,22 +52,19 @@ export function WizardLayout({
           </h2>
         </div>
 
-        {/* 폼 컨텐츠 */}
         {children}
 
-        {/* Sidekick AI 권장 메시지 */}
         {sidekick && (
-          <div className="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-700">
+          <div className="bg-blue-500/10 border border-blue-500/20 rounded p-3 text-sm text-blue-400">
             💡 {sidekick}
           </div>
         )}
 
-        {/* 이전/다음 버튼 */}
         <div className="flex justify-between pt-4">
           <button
             onClick={onPrev}
             disabled={!onPrev}
-            className="text-gray-600 hover:text-gray-800 disabled:opacity-30"
+            className="text-[#9ca3af] hover:text-white disabled:opacity-30 transition-colors"
           >
             ← 이전
           </button>
@@ -82,28 +78,26 @@ export function WizardLayout({
         </div>
       </div>
 
-      {/* 오른쪽: 의존성 트리 — §12-6 */}
+      {/* 오른쪽: 의존성 트리 */}
       <div className="col-span-1">
-        <div className="border rounded p-4 space-y-2 sticky top-4">
-          <p className="text-sm font-medium text-gray-600">── 의존성 트리 ──</p>
+        <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2 sticky top-4">
+          <p className="text-sm font-medium text-[#9ca3af]">── 의존성 트리 ──</p>
           {STEPS.map((step) => {
-            const isDone = completedSteps.includes(step.id)
+            const isDone    = completedSteps.includes(step.id)
             const isCurrent = step.id === currentStep
             return (
               <div
                 key={step.id}
-                className={`text-sm flex items-center gap-2${
-                  isCurrent ? 'font-bold text-teal-600' : ''
+                className={`text-sm flex items-center gap-2 ${
+                  isCurrent ? 'font-bold text-teal-400' : 'text-[#9ca3af]'
                 }`}
               >
-                <span>
-                  {isDone ? '✅' : isCurrent ? '⏳' : '⬜'}
-                </span>
+                <span>{isDone ? '✅' : isCurrent ? '⏳' : '⬜'}</span>
                 <span>{step.label}</span>
               </div>
             )
           })}
-          <p className="text-xs text-gray-500 pt-2">총 16개 리소스</p>
+          <p className="text-xs text-[#9ca3af] pt-2">총 16개 리소스</p>
         </div>
       </div>
     </div>

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-8 w-full min-w-0 rounded-lg border border-input px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       {...props}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@hookform/resolvers": "^5.2.2",
+        "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.99.2",
         "axios": "^1.15.2",
         "class-variance-authority": "^0.7.1",
@@ -22,7 +22,7 @@
         "shadcn": "^4.4.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
-        "zod": "^4.3.6",
+        "zod": "^3.25.76",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -818,14 +818,11 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
-      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
-      "dependencies": {
-        "@standard-schema/utils": "^0.3.0"
-      },
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
       "peerDependencies": {
-        "react-hook-form": "^7.55.0"
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3228,11 +3225,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -9503,14 +9495,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/shadcn/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -10808,9 +10792,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.2.2",
+    "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.99.2",
     "axios": "^1.15.2",
     "class-variance-authority": "^0.7.1",
@@ -23,7 +23,7 @@
     "shadcn": "^4.4.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
-    "zod": "^4.3.6",
+    "zod": "^3.25.76",
     "zustand": "^5.0.12"
   },
   "devDependencies": {


### PR DESCRIPTION
1. frontend/app/projects/new/page.tsx — 신규 추가
가이드에 없던 파일. Epic 7에서 NewProjectPageContent.tsx로 분리되어 있어서 page.tsx는 Suspense wrapper만 있어야 함.
2. frontend/app/projects/new/NewProjectPageContent.tsx — 신규 추가
가이드에 없던 파일. 기존 new/page.tsx 위저드 코드가 이 파일로 이동 + 아래 수정사항 포함.

WizardPhase에 'summary' 추가
validateCIDR 함수 + cidrError 상태 추가

3. CIDR 유효성 검사 + 빨간색 강조

4. onNext에서 summary로 이동
phase === 'summary' 리소스 요약 페이지 추가
handleSaveStep — next_step 없을 때 router.push 제거
readOnly Input에 style={{ backgroundColor: '#121214' }} 추가

5. frontend/components/craftops/WizardLayout.tsx — 수정
다크테마 적용 (bg, text 색상 전부 변경)

6. frontend/components/craftops/IntentAnalysis.tsx — 수정
AI 분석 결과 카드 다크테마 적용

7. frontend/components/ui/input.tsx — 수정
bg-transparent 제거

8. frontend/lib/api.ts — 수정
typeof window !== 'undefined' SSR 대응 추가

9. frontend/types/index.ts — 수정
DRStatus → DRStatusValue 이름 변경
User, AWSAccount, Project, Deployment, ValidationResult, SecurityIssue, WSEvent 타입 추가, Confidence 타입 추가

10. frontend/app/(auth)/signup/page.tsx — 신규 추가
회원가입 페이지

11. frontend/app/(auth)/login/page.tsx — 수정
회원가입 링크 추가

12. backend/app/api/auth.py — 수정
signup, confirm API 추가 + admin_confirm_sign_up 자동 확인 처리