### PR TITLE
fix(epic8): E2E 통합 테스트 수정사항

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.core.database import get_db
+from app.core.auth import get_current_user
 from app.models.user import User
 
 router = APIRouter()
@@ -210,3 +211,17 @@ def confirm(request: ConfirmRequest):
             status_code=500,
             detail={"code": "INTERNAL_ERROR", "message": str(e)}
         )
+
+@router.get("/me")
+def get_me(
+    current_user: User = Depends(get_current_user),
+):
+    """현재 로그인한 유저 정보 반환"""
+    return {
+        "success": True,
+        "data": {
+            "user_id":  current_user.user_id,
+            "email":    current_user.email,
+            "name":     current_user.name,
+        },
+    }

--- a/backend/app/services/craftops/gemini_client.py
+++ b/backend/app/services/craftops/gemini_client.py
@@ -154,7 +154,7 @@ class GeminiClient:
             [system_prompt, user_message],
             generation_config=genai.GenerationConfig(
                 temperature=0.1,
-                max_output_tokens=8192,
+                max_output_tokens=32768,
             ),
         )
 
@@ -188,7 +188,7 @@ class GeminiClient:
             [system_prompt, user_message],
             generation_config=genai.GenerationConfig(
                 temperature=0.05,     # 수정 시 더욱 보수적인 temperature
-                max_output_tokens=8192,
+                max_output_tokens=32768,
             ),
         )
 
@@ -227,7 +227,7 @@ class GeminiClient:
             [system_prompt, user_message],
             generation_config=genai.GenerationConfig(
                 temperature=0.05,
-                max_output_tokens=8192,
+                max_output_tokens=32768,
             ),
         )
 

--- a/backend/app/services/craftops/validator.py
+++ b/backend/app/services/craftops/validator.py
@@ -58,7 +58,12 @@ class ValidationLoop:
         # ① terraform validate + Self-Correction Loop
         current_hcl = hcl_code
         self._write_hcl(work_dir, current_hcl)
-        self._run_cmd(["terraform", "init", "-backend=false"], work_dir)
+        init_result = self._run_cmd(["terraform", "init", "-backend=false", "-no-color"], work_dir)
+        if init_result["returncode"] != 0:
+            result.validate_passed = False
+            result.validate_error = init_result["stderr"] or init_result["stdout"]
+            result.validate_manual_edit_required = True
+            return result
 
         for attempt in range(1, self.MAX_CORRECTION_ATTEMPTS + 1):
             vr = self._run_cmd(["terraform", "validate", "-json"], work_dir)

--- a/frontend/app/(auth)/connect/page.tsx
+++ b/frontend/app/(auth)/connect/page.tsx
@@ -1,7 +1,7 @@
 // frontend/app/(auth)/connect/page.tsx
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { apiClient } from '@/lib/api'
 import { Button } from '@/components/ui/button'
@@ -9,13 +9,40 @@ import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
+const AUTOOPS_ACCOUNT_ID  = '611058323802'
+const CF_TEMPLATE_URL = 'https://autoops-cf-templates.s3.us-west-2.amazonaws.com/autoops-role.yaml'
+  
+
 export default function ConnectPage() {
   const router = useRouter()
+
+  const [userId, setUserId]   = useState('')
   const [roleArn, setRoleArn] = useState('')
-  const [alias, setAlias] = useState('')
+  const [alias, setAlias]     = useState('')
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState('')
-  const [status, setStatus] = useState<'idle' | 'verifying' | 'success' | 'error'>('idle')
+  const [error, setError]     = useState('')
+  const [status, setStatus]   = useState<'idle' | 'verifying' | 'success' | 'error'>('idle')
+
+  // 현재 로그인 유저 ID 조회 (ExternalId 주입용)
+  useEffect(() => {
+    apiClient
+      .get('/api/auth/me')
+      .then((res) => setUserId(res.data.data.user_id))
+      .catch(() => {})
+  }, [])
+
+  const handleOpenCloudFormation = () => {
+    const params = new URLSearchParams({
+      templateURL:              CF_TEMPLATE_URL,
+      stackName:                'AutoOpsRole',
+      param_ExternalId:         userId,
+      param_AutoOpsAccountId:   AUTOOPS_ACCOUNT_ID,
+    })
+    window.open(
+      `https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?${params.toString()}`,
+      '_blank'
+    )
+  }
 
   const handleConnect = async () => {
     if (!roleArn.trim()) {
@@ -29,7 +56,7 @@ export default function ConnectPage() {
 
     try {
       await apiClient.post('/api/accounts/connect', {
-        role_arn: roleArn,
+        role_arn:      roleArn,
         account_alias: alias || null,
       })
       setStatus('success')
@@ -47,60 +74,66 @@ export default function ConnectPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <Card className="w-full max-w-lg">
+    <div className="min-h-screen flex items-center justify-center bg-[#000000]">
+      <Card className="w-full max-w-lg bg-[#121214] border border-white/8">
         <CardHeader>
-          <CardTitle>AWS 계정 연동</CardTitle>
+          <CardTitle className="text-white">AWS 계정 연동</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
+
           {/* Step 1 — IAM Role 생성 안내 */}
           <div className="space-y-2">
-            <p className="text-sm font-medium">Step 1. IAM Role 자동 생성</p>
+            <p className="text-sm font-medium text-white">Step 1. IAM Role 자동 생성</p>
             <Button
               variant="outline"
-              className="w-full text-left justify-start"
-              onClick={() => {
-                // CloudFormation 스택 링크 — §16-4
-                window.open(
-                  'https://console.aws.amazon.com/cloudformation/home#/stacks/create',
-                  '_blank'
-                )
-              }}
+              className="w-full text-left justify-start border-white/10 text-[#9ca3af] hover:bg-white/5 hover:text-white"
+              onClick={handleOpenCloudFormation}
+              disabled={!userId}
             >
               🔗 AWS 콘솔에서 AutoOpsRole 생성하기
             </Button>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-[#9ca3af]">
               CloudFormation으로 AutoOpsRole + AutoOpsRDSExportRole 자동 생성
             </p>
+            {!userId && (
+              <p className="text-xs text-yellow-400">
+                ⏳ 사용자 정보 로딩 중...
+              </p>
+            )}
           </div>
 
           {/* Step 2 — Role ARN 입력 */}
           <div className="space-y-2">
-            <p className="text-sm font-medium">Step 2. 생성된 Role ARN 입력</p>
+            <p className="text-sm font-medium text-white">Step 2. 생성된 Role ARN 입력</p>
+            <p className="text-xs text-[#9ca3af]">
+              CloudFormation 스택 완료 후 [출력] 탭에서 AutoOpsRoleArn 값을 복사하세요.
+            </p>
             <Input
               value={roleArn}
               onChange={(e) => setRoleArn(e.target.value)}
               placeholder="arn:aws:iam::123456789012:role/AutoOpsRole"
+              className="bg-black/30 border-white/10 text-white placeholder:text-[#9ca3af]"
             />
             <Input
               value={alias}
               onChange={(e) => setAlias(e.target.value)}
               placeholder="계정 별칭 (선택)"
+              className="bg-black/30 border-white/10 text-white placeholder:text-[#9ca3af]"
             />
           </div>
 
-          {/* 상태 표시 — §12-3 */}
+          {/* 상태 표시 */}
           {status === 'verifying' && (
-            <Alert>
-              <AlertDescription className="flex items-center gap-2">
+            <Alert className="border-blue-500/20 bg-blue-500/5">
+              <AlertDescription className="flex items-center gap-2 text-blue-400">
                 <span className="animate-spin">⏳</span>
                 AWS 계정 접근을 확인하고 있습니다...
               </AlertDescription>
             </Alert>
           )}
           {status === 'success' && (
-            <Alert className="border-green-500 bg-green-50">
-              <AlertDescription className="text-green-700">
+            <Alert className="border-emerald-500/20 bg-emerald-500/5">
+              <AlertDescription className="text-emerald-400">
                 ✅ 연동 성공! 대시보드로 이동합니다...
               </AlertDescription>
             </Alert>
@@ -112,11 +145,11 @@ export default function ConnectPage() {
           )}
 
           <Button
-            className="w-full bg-teal-600 hover:bg-teal-700"
+            className="w-full bg-teal-600 hover:bg-teal-700 text-white"
             onClick={handleConnect}
-            disabled={isLoading}
+            disabled={isLoading || !roleArn.trim()}
           >
-            연동 확인
+            {isLoading ? '확인 중...' : '연동 확인'}
           </Button>
         </CardContent>
       </Card>


### PR DESCRIPTION
- auth.py: /me 엔드포인트 추가 (connect 페이지 ExternalId 주입용)
- config.py: allowed_origins 환경변수 추가
- main.py: CORS allowed_origins 환경변수화 (CloudFront 도메인 허용)
- validator.py: terraform init 결과 체크 추가 (silent fail 방지)
- gemini_client.py: max_output_tokens 8192→32768 (HCL truncation 수정)
- connect/page.tsx: CloudFormation URL에 templateURL + ExternalId 자동 주입"