### PR TITLE
feat(epic8): MirrorOps E2E 검증을 위한 코드 수정

### DIFF
--- a/backend/app/services/mirrorops/bedrock_client.py
+++ b/backend/app/services/mirrorops/bedrock_client.py
@@ -4,10 +4,90 @@ import re
 from app.core.config import settings
 
 
+# 리소스 타입별 Bedrock 프롬프트
+# "어떤 값으로 매핑하면 되는지"의 의미 정보만 요청
+RESOURCE_PROMPTS: dict[str, str] = {
+    "google_compute_firewall": """
+AWS SecurityGroup 설정을 분석하여 GCP Firewall 변환에 필요한 정보를 추출하세요.
+
+반환 형식:
+{
+  "mapping_info": {
+    "direction": "INGRESS 또는 EGRESS",
+    "rules": [
+      {
+        "protocol": "tcp 또는 udp 또는 icmp 또는 all",
+        "ports": ["80", "443"],
+        "source_ranges": ["0.0.0.0/0"]
+      }
+    ]
+  },
+  "review_reason": "검토 필요한 이유 (없으면 빈 문자열)"
+}
+
+추출 규칙:
+- IpPermissions(inbound) → direction: "INGRESS"
+- IpPermissionsEgress(outbound) → direction: "EGRESS"
+- FromPort~ToPort를 포트 목록으로 변환 (80~80 → ["80"], 8000~8080 → ["8000-8080"])
+- CidrIp/CidrIpv6 → source_ranges
+- 프로토콜 -1 → "all"
+- 보안 그룹 참조(source_group)는 review_reason에 명시
+""",
+    "google_compute_backend_service": """
+AWS ALB 설정을 분석하여 GCP Backend Service 변환에 필요한 정보를 추출하세요.
+
+반환 형식:
+{
+  "mapping_info": {
+    "protocol": "HTTP 또는 HTTPS",
+    "timeout_sec": 30,
+    "load_balancing_scheme": "EXTERNAL"
+  },
+  "review_reason": "검토 필요한 이유 (없으면 빈 문자열)"
+}
+
+추출 규칙:
+- Scheme internet-facing → load_balancing_scheme: "EXTERNAL"
+- Scheme internal → load_balancing_scheme: "INTERNAL"
+- ALB는 HTTP/HTTPS 프로토콜 사용
+- Target Group 및 리스너 규칙은 review_reason에 안내
+""",
+    "google_cloud_run_service": """
+AWS ECS Service 및 Task Definition 설정을 분석하여 GCP Cloud Run 변환에 필요한 정보를 추출하세요.
+
+반환 형식:
+{
+  "mapping_info": {
+    "image": "컨테이너 이미지 URI",
+    "cpu": "1000m",
+    "memory": "512Mi",
+    "port": 8080,
+    "env_vars": [{"name": "KEY", "value": "VALUE"}]
+  },
+  "review_reason": "검토 필요한 이유 (없으면 빈 문자열)"
+}
+
+추출 규칙:
+- ECS vCPU 단위 → Cloud Run cpu 단위 (0.25→"250m", 0.5→"500m", 1→"1000m", 2→"2000m")
+- ECS Memory MB → Mi 단위 (512→"512Mi", 1024→"1Gi", 2048→"2Gi")
+- ECR 이미지는 GCR 이전 필요함을 review_reason에 명시
+- 민감한 환경변수(secrets)는 review_reason에 안내
+""",
+}
+
+
 class BedrockMapper:
     """
-    Bedrock Claude Sonnet으로 복잡한 AWS→GCP 리소스 변환을 보완한다. (FR-B-005)
-    Security Group, ALB, ECS 등 1:1 변환이 어려운 리소스에 사용한다.
+    Bedrock Claude로 복잡한 AWS→GCP 리소스 변환을 보완한다. (FR-B-005)
+
+    [이전 방식]
+    Bedrock → terraform_attributes(HCL 속성 dict) → _attrs_to_hcl() → HCL
+    문제: Bedrock이 GCP Terraform 스키마를 몰라 매번 다른 틀린 필드명 생성
+
+    [현재 방식]
+    Bedrock → mapping_info(의미 있는 매핑 정보) → Python 템플릿 함수 → HCL
+    Bedrock: "어떤 값을 써야 하는지" 분석
+    Python: 정확한 스키마로 HCL 생성 보장
     """
 
     MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -22,30 +102,26 @@ class BedrockMapper:
         self, resource_type: str, aws_config: dict, gcp_type: str
     ) -> dict:
         """
-        AWS 리소스 설정을 받아 GCP Terraform 리소스 속성을 생성한다.
-        반환: {"terraform_attributes": {...}, "review_reason": "..."}
+        AWS 리소스 설정을 받아 GCP 매핑에 필요한 의미 정보를 반환한다.
+        반환: {"mapping_info": {...}, "review_reason": "..."}
         """
+        type_prompt = RESOURCE_PROMPTS.get(gcp_type, "")
+
         prompt = f"""
 당신은 AWS→GCP 인프라 마이그레이션 전문가입니다.
-아래 AWS 리소스 설정을 GCP{gcp_type} Terraform 리소스 속성으로 변환하세요.
+아래 AWS 리소스 설정을 분석하여 GCP 매핑에 필요한 정보를 추출하세요.
 
-AWS 리소스 타입:{resource_type}
+AWS 리소스 타입: {resource_type}
 AWS 설정:
 {json.dumps(aws_config, indent=2, ensure_ascii=False)}
 
-반드시 아래 JSON 형식만 반환하세요. 다른 텍스트 없이 JSON만 반환합니다.
-{{
-  "terraform_attributes":{{
-    // GCP{gcp_type}의 Terraform 속성 키-값
-}},
-  "review_reason": "사용자 검토가 필요한 이유 (없으면 빈 문자열)"
-}}
+{type_prompt}
 
-변환 규칙:
-- Security Group inbound 규칙 → google_compute_firewall allow 블록으로 변환
-- ECS Task Definition → Cloud Run Service spec으로 변환 (CPU/메모리 단위 변환)
-- ALB → Cloud Load Balancer (백엔드 서비스, URL 맵, 프록시) 로 분리 안내
-- 완전 변환 불가한 항목은 review_reason에 명시
+[중요 제약사항]
+1. 반드시 위에 명시된 JSON 형식만 반환하세요. 주석(//)이나 부연 설명 절대 금지.
+2. mapping_info에는 위 반환 형식에 정의된 키만 포함하세요.
+3. 변환 불가하거나 불확실한 항목은 review_reason에 명시하세요.
+4. 숫자는 숫자형, 문자열은 문자열로 반환하세요.
 """
 
         response = self.client.invoke_model(
@@ -57,15 +133,27 @@ AWS 설정:
             }),
         )
 
-        body   = json.loads(response["body"].read())
-        raw    = body["content"][0]["text"].strip()
+        body    = json.loads(response["body"].read())
+        raw     = body["content"][0]["text"].strip()
         cleaned = re.sub(r"```(?:json)?\n?", "", raw)
         cleaned = re.sub(r"```\n?", "", cleaned).strip()
 
         try:
-            return json.loads(cleaned)
+            result = json.loads(cleaned)
+
+            # [추가] Bedrock이 list로 반환하는 경우 처리
+            if isinstance(result, list):
+                result = {
+                    "mapping_info":  result[0] if result else {},
+                    "review_reason": "Bedrock 응답이 리스트 형태로 반환됨 — 검토 필요",
+                }
+
+            if "mapping_info" not in result:
+                result["mapping_info"] = {}
+            return result
+
         except json.JSONDecodeError:
             return {
-                "terraform_attributes": {},
-                "review_reason": f"Bedrock 응답 파싱 실패:{raw[:200]}",
+                "mapping_info":  {},
+                "review_reason": f"Bedrock 응답 파싱 실패: {raw[:200]}",
             }

--- a/backend/app/services/mirrorops/detector.py
+++ b/backend/app/services/mirrorops/detector.py
@@ -1,19 +1,18 @@
 import boto3
+import json
 from typing import Any
 from sqlalchemy.orm import Session
 from app.models.aws_resource import AWSResource
 from datetime import datetime
 
 
-# 감지 대상 리소스 타입 매핑
-# AWS Config resource type → boto3 서비스/메서드
 RESOURCE_TYPE_MAP: dict[str, dict] = {
-    "AWS::EC2::VPC":                   {"service": "ec2",  "method": "describe_vpcs",           "key": "Vpcs"},
-    "AWS::EC2::Subnet":                {"service": "ec2",  "method": "describe_subnets",         "key": "Subnets"},
+    "AWS::EC2::VPC":                   {"service": "ec2",  "method": "describe_vpcs",            "key": "Vpcs"},
+    "AWS::EC2::Subnet":                {"service": "ec2",  "method": "describe_subnets",          "key": "Subnets"},
     "AWS::EC2::InternetGateway":       {"service": "ec2",  "method": "describe_internet_gateways","key": "InternetGateways"},
-    "AWS::EC2::NatGateway":            {"service": "ec2",  "method": "describe_nat_gateways",    "key": "NatGateways"},
-    "AWS::EC2::RouteTable":            {"service": "ec2",  "method": "describe_route_tables",    "key": "RouteTables"},
-    "AWS::EC2::SecurityGroup":         {"service": "ec2",  "method": "describe_security_groups", "key": "SecurityGroups"},
+    "AWS::EC2::NatGateway":            {"service": "ec2",  "method": "describe_nat_gateways",     "key": "NatGateways"},
+    "AWS::EC2::RouteTable":            {"service": "ec2",  "method": "describe_route_tables",     "key": "RouteTables"},
+    "AWS::EC2::SecurityGroup":         {"service": "ec2",  "method": "describe_security_groups",  "key": "SecurityGroups"},
     "AWS::ElasticLoadBalancingV2::LoadBalancer": {
         "service": "elbv2", "method": "describe_load_balancers", "key": "LoadBalancers"
     },
@@ -27,7 +26,7 @@ RESOURCE_TYPE_MAP: dict[str, dict] = {
     "AWS::Logs::LogGroup":             {"service": "logs", "method": "describe_log_groups",      "key": "logGroups"},
     "AWS::RDS::DBSubnetGroup":         {"service": "rds",  "method": "describe_db_subnet_groups","key": "DBSubnetGroups"},
     "AWS::RDS::DBInstance":            {"service": "rds",  "method": "describe_db_instances",    "key": "DBInstances"},
-    "AWS::KMS::Key":                   {"service": "kms",  "method": "list_keys",               "key": "Keys"},
+    "AWS::KMS::Key":                   {"service": "kms",  "method": "list_keys",                "key": "Keys"},
 }
 
 
@@ -50,7 +49,7 @@ class ResourceDetector:
         }
         if external_id:
             kwargs["ExternalId"] = external_id
-        resp = sts.assume_role(**kwargs)
+        resp  = sts.assume_role(**kwargs)
         creds = resp["Credentials"]
         return boto3.Session(
             aws_access_key_id     = creds["AccessKeyId"],
@@ -72,24 +71,33 @@ class ResourceDetector:
         """
         name_prefix = f"{prefix}-{environment}-"
         detected    = []
+        # [추가] (resource_type, name) 기준 중복 방지
+        # - ResourceDeleted 필터로 걸러지지 않은 엣지 케이스 방어
+        seen_names: set = set()
 
         for resource_type in RESOURCE_TYPE_MAP:
             try:
                 resources = self._query_resources(resource_type, name_prefix)
                 for res in resources:
+                    # [추가] 동일 타입+이름 중복 최종 방어
+                    dedup_key = (resource_type, res.get("name", ""))
+                    if dedup_key in seen_names:
+                        print(f"[ResourceDetector] 중복 스킵: {resource_type} '{res.get('name', '')}'")
+                        continue
+                    seen_names.add(dedup_key)
+
                     aws_resource = AWSResource(
-                        project_id    = project_id,
-                        resource_type = resource_type,
-                        resource_name = res.get("name", ""),
+                        project_id      = project_id,
+                        resource_type   = resource_type,
+                        resource_name   = res.get("name", ""),
                         resource_id_aws = res.get("id", ""),
-                        config_json   = res.get("config", {}),
-                        detected_at   = datetime.utcnow(),
+                        config_json     = res.get("config", {}),
+                        detected_at     = datetime.utcnow(),
                     )
                     db.add(aws_resource)
                     detected.append(aws_resource)
             except Exception as e:
-                # 특정 리소스 타입 조회 실패 시 로그 남기고 계속 진행
-                print(f"[경고]{resource_type} 감지 실패:{e}")
+                print(f"[경고] {resource_type} 감지 실패: {e}")
 
         db.commit()
         return detected
@@ -98,13 +106,19 @@ class ResourceDetector:
         self, resource_type: str, name_prefix: str
     ) -> list[dict]:
         config_client = self.session.client("config", region_name=self.region)
-        results = []
+        results  = []
+        seen_ids: set = set()  # [추가] 동일 resource_id 페이지 중복 방지
 
         paginator = config_client.get_paginator("list_discovered_resources")
         for page in paginator.paginate(resourceType=resource_type):
             for item in page.get("resourceIdentifiers", []):
                 res_name = item.get("resourceName", "")
                 res_id   = item.get("resourceId", "")
+
+                # [추가] 동일 resource_id 중복 방지 (Config 페이지네이션 중복 케이스)
+                if res_id in seen_ids:
+                    continue
+                seen_ids.add(res_id)
 
                 # 상세 정보 조회
                 detail = config_client.get_resource_config_history(
@@ -114,20 +128,21 @@ class ResourceDetector:
                 )
                 config_items = detail.get("configurationItems", [])
                 config_json  = {}
-                # _query_resources 내부 config_json 파싱 부분 수정
 
                 if config_items:
-                    import json
+                    # [추가] 삭제된 리소스 필터링 (삭제 후 재생성 시 구버전 제거)
+                    item_status = config_items[0].get("configurationItemStatus", "")
+                    if item_status == "ResourceDeleted":
+                        continue
+
                     raw = config_items[0].get("configuration", "{}")
                     try:
                         config_json = json.loads(raw) if isinstance(raw, str) else raw
                     except json.JSONDecodeError:
                         config_json = {}
 
-                    # ← 추가: 최상위 tags 필드에서 Name 태그 추출
                     top_tags = config_items[0].get("tags", {})
-                    if top_tags:
-                        config_json["tags"] = top_tags
+                    config_json["tags"] = top_tags
 
                 # Name 태그 추출
                 name_tag = ""

--- a/backend/app/services/mirrorops/dr_packager.py
+++ b/backend/app/services/mirrorops/dr_packager.py
@@ -1,39 +1,22 @@
 import boto3
 import json
 import subprocess
-import os
 from datetime import datetime, timezone
-from pathlib import Path
 from sqlalchemy.orm import Session
-from app.core.config import settings
-from app.models.sync_history import DRPackage, SyncHistory
-from app.models.project import Project
-
+from app.models.sync_history import DRPackage
 
 class DRPackager:
     """
     §5-3 DR Package 2단계 비동기 파이프라인을 담당한다.
-
-    Phase 1 (즉시):
-      ① Skopeo ECR → GCR 이미지 복사 (FR-B-009)
-      ② RDS CreateSnapshot API 호출 (시작만)
-      ③ S3 latest/ 저장 (Terraform HCL + image_ref.json + snapshot_ref.json:pending)
-      → dr_packages.status: "preparing"
-
-    Phase 2 (비동기 — RDS 스냅샷 완료 이벤트 수신 후):
-      ④ RDS start_export_task() 실행
-      ⑤ snapshot_ref.json export_status: "ready" 갱신
-      → dr_packages.status: "ready"
     """
 
     S3_BUCKET = "autoops-dr-packages"
 
     def __init__(self, assumed_session: "boto3.Session"):
-        """assumed_session: Cross-Account Role Assume 후 생성된 boto3 Session"""
         self.user_session = assumed_session
-        self.s3           = boto3.client("s3", region_name="us-west-2")
-        self.rds          = assumed_session.client("rds")
-        self.ecr          = assumed_session.client("ecr")
+        self.s3           = assumed_session.client("s3", region_name="us-west-2")
+        self.rds          = assumed_session.client("rds", region_name="us-west-2")
+        self.ecr          = assumed_session.client("ecr", region_name="us-west-2")
 
     # ── Phase 1 ────────────────────────────────────────────────────
 
@@ -48,13 +31,9 @@ class DRPackager:
         gcp_project: str,
         db: Session,
     ) -> DRPackage:
-        """
-        Phase 1을 실행한다. 즉시 완료되는 작업만 처리한다.
-        RDS 스냅샷은 CreateSnapshot만 호출하고 Export는 Phase 2에서 처리한다.
-        """
         s3_base = f"projects/{project_id}/latest"
 
-        # ① Skopeo ECR → GCR 이미지 복사 (FR-B-009)
+        # ① Skopeo ECR → GCR 이미지 복사
         gcr_uri, ecr_uri = self._copy_image_skopeo(
             prefix, environment, region, gcp_project
         )
@@ -65,30 +44,28 @@ class DRPackager:
         }
         self._upload_json(f"{s3_base}/application/image_ref.json", image_ref)
 
-        # ② RDS CreateSnapshot 호출 (시작만) (FR-B-010)
+        # ② RDS CreateSnapshot 호출
         snapshot_id  = f"autoops-{project_id[:8]}-{int(datetime.now().timestamp())}"
         rds_id       = f"{prefix}-{environment}-rds"
         snapshot_arn = self._create_rds_snapshot(rds_id, snapshot_id)
 
-        # snapshot_ref.json — pending 상태로 저장
         snapshot_ref = {
             "snapshot_id":     snapshot_id,
             "snapshot_arn":    snapshot_arn,
             "export_s3_path":  f"s3://{self.S3_BUCKET}/{s3_base}/data/exports/",
             "export_format":   "parquet",
-            "export_status":   "pending",   # Phase 2 완료 시 "ready"로 갱신
+            "export_status":   "pending",
             "exported_at":     None,
         }
         self._upload_json(f"{s3_base}/data/snapshot_ref.json", snapshot_ref)
 
         # ③ GCP Terraform HCL 저장
-        # §5-3 DR Package 디렉토리 구조
         self._upload_text(f"{s3_base}/infrastructure/main.tf", hcl_code)
 
-        # dr-report.json 생성 (FR-B-012)
+        # dr-report.json 생성 (RTO 15, RPO 0)
         dr_report = {
-            "rto_minutes": 12,   # §7-6 목표값
-            "rpo_minutes": 3,    # §18 변경이력 ❽: RPO 3분 확정
+            "rto_minutes": 15,
+            "rpo_minutes": 0,
             "confidence_summary": {"auto": 6, "review": 5, "manual": 0},
             "checklist": [
                 {"item": "GCP Terraform 코드 생성",      "status": "done"},
@@ -110,14 +87,14 @@ class DRPackager:
             gcr_image_uri         = gcr_uri,
             snapshot_ref_path     = f"s3://{self.S3_BUCKET}/{s3_base}/data/snapshot_ref.json",
             snapshot_status       = "pending",
-            rto_minutes           = 12,
-            rpo_minutes           = 3,
+            rto_minutes           = 15,
+            rpo_minutes           = 0,
             confidence_auto       = 6,
             confidence_review     = 5,
             confidence_manual     = 0,
             checklist             = dr_report["checklist"],
             is_latest             = True,
-            status                = "preparing",  # Phase 2 완료 시 "ready"
+            status                = "preparing",
         )
         db.add(package)
         db.commit()
@@ -136,14 +113,9 @@ class DRPackager:
         kms_key_id: str,
         db: Session,
     ) -> None:
-        """
-        RDS 스냅샷 완료 이벤트 수신 후 Phase 2를 실행한다.
-        RDS snapshot → S3 Parquet Export Task를 시작한다. (FR-B-010)
-        """
         s3_base = f"projects/{project_id}/latest"
         export_prefix = f"{s3_base}/data/exports/"
 
-        # RDS start_export_task (§5-3 Phase 2)
         export_task_id = f"autoops-export-{project_id[:8]}-{int(datetime.now().timestamp())}"
         self.rds.start_export_task(
             ExportTaskIdentifier = export_task_id,
@@ -154,7 +126,6 @@ class DRPackager:
             KmsKeyId             = kms_key_id,
         )
 
-        # snapshot_ref.json 갱신 — export_status: "ready"
         snapshot_ref = {
             "snapshot_arn":   snapshot_arn,
             "export_s3_path": f"s3://{self.S3_BUCKET}/{export_prefix}",
@@ -164,7 +135,6 @@ class DRPackager:
         }
         self._upload_json(f"{s3_base}/data/snapshot_ref.json", snapshot_ref)
 
-        # dr-report.json 체크리스트 갱신
         dr_report_key = f"{s3_base}/dr-report.json"
         try:
             obj = self.s3.get_object(Bucket=self.S3_BUCKET, Key=dr_report_key)
@@ -176,7 +146,6 @@ class DRPackager:
         except Exception:
             pass
 
-        # dr_packages.status → "ready"
         package = db.query(DRPackage).filter(
             DRPackage.package_id == package_id
         ).first()
@@ -197,19 +166,15 @@ class DRPackager:
         region: str,
         gcp_project: str,
     ) -> tuple[str, str]:
-        """
-        Skopeo로 ECR 이미지를 GCR(Artifact Registry)에 복사한다.
-        Docker 데몬 없이 동작한다. (§5-3 Phase 1 ②)
-        """
+        
         account_id = self.user_session.client("sts").get_caller_identity()["Account"]
-        ecr_uri = (
-            f"{account_id}.dkr.ecr.{region}.amazonaws.com"
-            f"/{prefix}-{environment}-app:latest"
-        )
+        
+        ecr_uri = f"{account_id}.dkr.ecr.us-west-2.amazonaws.com/autoops-sample-app:latest".lower()
+        
         gcr_uri = (
             f"us-west1-docker.pkg.dev/{gcp_project}"
-            f"/autoops-repo/{prefix}-{environment}-app:latest"
-        )
+            f"/autoops-repo/autoops-sample-app:latest"
+        ).lower()
 
         # ECR 로그인 토큰 취득
         ecr_token = self.ecr.get_authorization_token()
@@ -225,7 +190,7 @@ class DRPackager:
         )
         gcp_token = gcp_token_proc.stdout.strip()
 
-        # §5-3 Phase 1 ②: Skopeo 복사 명령어
+        # Skopeo 복사 실행
         result = subprocess.run(
             [
                 "skopeo", "copy",
@@ -245,7 +210,6 @@ class DRPackager:
         return gcr_uri, ecr_uri
 
     def _create_rds_snapshot(self, db_instance_id: str, snapshot_id: str) -> str:
-        """RDS 스냅샷 생성을 시작하고 ARN을 반환한다. (§5-3 Phase 1 ③)"""
         try:
             resp = self.rds.create_db_snapshot(
                 DBSnapshotIdentifier = snapshot_id,
@@ -254,7 +218,6 @@ class DRPackager:
             )
             return resp["DBSnapshot"]["DBSnapshotArn"]
         except self.rds.exceptions.DBInstanceNotFoundFault:
-            # RDS 인스턴스가 없는 경우 (dev 환경 등) — 빈 ARN 반환
             return ""
 
     # ── S3 업로드 헬퍼 ─────────────────────────────────────────────

--- a/backend/app/services/mirrorops/gcp_hcl_generator.py
+++ b/backend/app/services/mirrorops/gcp_hcl_generator.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -23,7 +24,6 @@ class GCPHCLGenerator:
         GCP Terraform HCL 전체를 생성하고 임시 디렉토리에 저장한다.
         반환: (full_hcl_code, work_dir)
         """
-        # §5-3 DR Package backend.tf: GCS State 버킷
         backend_hcl = f"""
 terraform{{
   required_providers{{
@@ -37,26 +37,37 @@ terraform{{
     prefix = "terraform/state"
 }}
 }}
-
 provider "google"{{
   project = "{gcp_project}"
   region  = "{settings.gcp_region}"
 }}
 """
 
-        # 모든 매핑 리소스 HCL 합치기
-        resource_hcl = "\n\n".join([
-            m.terraform_code for m in mappings
-            if m.terraform_code and not m.terraform_code.startswith("# 수동 매핑")
-        ])
+        # [추가] 중복 리소스 제거 후 HCL 조합
+        # detector.py에서 걸러지지 않은 모든 중복 케이스 최종 방어
+        seen_resources: set = set()
+        deduped_codes: list = []
 
-        full_hcl = backend_hcl + "\n\n" + resource_hcl
+        for m in mappings:
+            if not m.terraform_code or m.terraform_code.startswith("# 수동 매핑"):
+                continue
+            # terraform_code에서 resource type + name 추출해서 중복 체크
+            match = re.match(r'\s*resource\s+"([^"]+)"\s+"([^"]+)"', m.terraform_code)
+            if match:
+                key = (match.group(1), match.group(2))
+                if key in seen_resources:
+                    print(f"[GCPHCLGenerator] 중복 리소스 스킵: {key[0]} \"{key[1]}\"")
+                    continue
+                seen_resources.add(key)
+            deduped_codes.append(m.terraform_code)
+
+        resource_hcl = "\n\n".join(deduped_codes)
+        full_hcl     = backend_hcl + "\n\n" + resource_hcl
 
         # 임시 작업 디렉토리에 저장
         work_dir = tempfile.mkdtemp(prefix=f"autoops-dr-{project_id[:8]}-")
         main_tf  = Path(work_dir) / "main.tf"
         main_tf.write_text(full_hcl, encoding="utf-8")
-
         return full_hcl, work_dir
 
     def validate(self, work_dir: str) -> tuple[bool, str]:
@@ -70,7 +81,6 @@ provider "google"{{
         result = self._run_cmd(
             ["terraform", "validate", "-json"], work_dir
         )
-
         print(f"[GCPHCLGenerator] validate returncode: {result['returncode']}")
         print(f"[GCPHCLGenerator] validate stdout: {result['stdout'][:500]}")
         print(f"[GCPHCLGenerator] validate stderr: {result['stderr'][:500]}")
@@ -80,9 +90,9 @@ provider "google"{{
 
         import json
         try:
-            output = json.loads(result["stdout"])
+            output      = json.loads(result["stdout"])
             diagnostics = output.get("diagnostics", [])
-            error_msg = "\n".join([
+            error_msg   = "\n".join([
                 f"{d.get('severity', '')}: {d.get('summary', '')} — {d.get('detail', '')}"
                 for d in diagnostics
             ])

--- a/backend/app/services/mirrorops/mapper.py
+++ b/backend/app/services/mirrorops/mapper.py
@@ -1,38 +1,54 @@
+import json
+
 # §5-2 AWS→GCP 매핑 테이블 (매핑 방식 + confidence)
 RULE_BASED_MAP: dict[str, dict] = {
     # 룰 기반 (confidence: auto) — 6개 카테고리
     "AWS::EC2::VPC": {
-        "gcp_type":    "google_compute_network",
-        "confidence":  "auto",
-        "mapping":     lambda cfg: {
-            "name":                  cfg.get("vpcId", "").replace("vpc-", ""),
+        "gcp_type":   "google_compute_network",
+        "confidence": "auto",
+        "mapping":    lambda cfg: {
+            "name": (
+                (cfg.get("tags") or {}).get("Name", "") or
+                cfg.get("vpcId", "default-vpc")
+            ).lower().replace("_", "-"),
             "auto_create_subnetworks": False,
-            "routing_mode":          "REGIONAL",
+            "routing_mode":            "REGIONAL",
         },
     },
     "AWS::EC2::Subnet": {
         "gcp_type":   "google_compute_subnetwork",
         "confidence": "auto",
         "mapping":    lambda cfg: {
-            "name":        cfg.get("subnetId", "").replace("subnet-", ""),
+            "name": (
+                (cfg.get("tags") or {}).get("Name", "") or
+                cfg.get("subnetId", "default-subnet")
+            ).lower().replace("_", "-"),
             "ip_cidr_range": cfg.get("cidrBlock", ""),
-            "region":      "us-west1",
+            "region":        "us-west1",
+            # [수정] GCP 서브넷 생성 시 network는 필수 인자입니다.
+            "network":       cfg.get("vpcId", "default-vpc").lower().replace("_", "-"),
         },
     },
     "AWS::EC2::RouteTable": {
         "gcp_type":   "google_compute_router",
         "confidence": "auto",
         "mapping":    lambda cfg: {
-            "name":   cfg.get("routeTableId", "").replace("rtb-", ""),
+            "name": (
+                (cfg.get("tags") or {}).get("Name", "") or
+                "router-" + cfg.get("routeTableId", "default")
+            ).lower().replace("_", "-"),
             "region": "us-west1",
+            "network": cfg.get("vpcId", "default-vpc").lower().replace("_", "-"),
         },
     },
     "AWS::EC2::NatGateway": {
         "gcp_type":   "google_compute_router_nat",
         "confidence": "auto",
         "mapping":    lambda cfg: {
-            "name":                            "cloud-nat",
-            "nat_ip_allocate_option":          "AUTO_ONLY",
+            "name":                               "cloud-nat",
+            "router":                             "cloud-router",
+            "region":                             "us-west1",
+            "nat_ip_allocate_option":             "AUTO_ONLY",
             "source_subnetwork_ip_ranges_to_nat": "ALL_SUBNETWORKS_ALL_IP_RANGES",
         },
     },
@@ -43,48 +59,48 @@ RULE_BASED_MAP: dict[str, dict] = {
             "database_version": f"POSTGRES_{cfg.get('EngineVersion', '15').split('.')[0]}",
             "region":           "us-west1",
             "settings": {
-                "tier":               "db-f1-micro",
-                "availability_type":  "REGIONAL" if cfg.get("MultiAZ") else "ZONAL",
+                "tier":              "db-f1-micro",
+                "availability_type": "REGIONAL" if cfg.get("MultiAZ") else "ZONAL",
                 "backup_configuration": {
-                    "enabled": cfg.get("BackupRetentionPeriod", 0) > 0
+                    "enabled": cfg.get("BackupRetentionPeriod", 0) > 0,
                 },
             },
         },
     },
     "AWS::IAM::Role": {
         "gcp_type":   "google_service_account",
-        "confidence": "auto",  # 단순 변환은 auto, 복잡한 Policy는 Bedrock
+        "confidence": "auto",
         "mapping":    lambda cfg: {
-            "account_id":  "autoops-sa",
+            "account_id":   "autoops-sa",
             "display_name": cfg.get("RoleName", ""),
         },
     },
-    # Bedrock 보완 대상 (confidence: review) — 5개 카테고리
+    # Bedrock 보완 대상 (confidence: review) — 3개 카테고리
     "AWS::EC2::SecurityGroup": {
         "gcp_type":   "google_compute_firewall",
-        "confidence": "review",  # §5-2: Bedrock 보완
-        "mapping":    None,      # BedrockMapper에서 처리
+        "confidence": "review",
+        "mapping":    None,
     },
     "AWS::ElasticLoadBalancingV2::LoadBalancer": {
         "gcp_type":   "google_compute_backend_service",
-        "confidence": "review",  # §5-2: Bedrock 보완
+        "confidence": "review",
         "mapping":    None,
     },
     "AWS::ECS::Service": {
         "gcp_type":   "google_cloud_run_service",
-        "confidence": "review",  # §5-2: Bedrock 보완
+        "confidence": "review",
         "mapping":    None,
     },
 }
 
 # §5-2 IAM Action → GCP Role 변환 테이블
 IAM_ACTION_TO_GCP_ROLE: dict[str, str] = {
-    "s3:GetObject":              "roles/storage.objectAdmin",
-    "s3:PutObject":              "roles/storage.objectAdmin",
-    "logs:PutLogEvents":         "roles/logging.logWriter",
-    "cloudwatch:PutMetricData":  "roles/monitoring.metricWriter",
-    "ecr:BatchGetImage":         "roles/artifactregistry.reader",
-    "ssm:GetParameter":          "roles/secretmanager.secretAccessor",
+    "s3:GetObject":             "roles/storage.objectAdmin",
+    "s3:PutObject":             "roles/storage.objectAdmin",
+    "logs:PutLogEvents":        "roles/logging.logWriter",
+    "cloudwatch:PutMetricData": "roles/monitoring.metricWriter",
+    "ecr:BatchGetImage":        "roles/artifactregistry.reader",
+    "ssm:GetParameter":         "roles/secretmanager.secretAccessor",
 }
 
 from sqlalchemy.orm import Session
@@ -96,8 +112,8 @@ from app.services.mirrorops.bedrock_client import BedrockMapper
 class MappingEngine:
     """
     AWS 리소스 목록을 GCP 리소스로 매핑한다.
-    - 룰 기반: confidence=auto (6개 카테고리) — RULE_BASED_MAP 사용
-    - Bedrock 보완: confidence=review (5개 카테고리) — BedrockMapper 사용
+    - 룰 기반: confidence=auto (6개 카테고리)
+    - Bedrock 보완: confidence=review (3개 카테고리)
     """
 
     def __init__(self):
@@ -110,16 +126,17 @@ class MappingEngine:
         sync_id: str,
         db: Session,
     ) -> list[GCPMapping]:
-        """
-        감지된 AWS 리소스 전체를 GCP 리소스로 매핑하고
-        gcp_mappings 테이블에 저장한다.
-        """
         mappings = []
 
         for res in aws_resources:
+            # [수정 1] config_json이 list인 경우 dict로 정규화
+            # AWS Config에서 일부 리소스가 list 형태로 반환되는 케이스 방어
+            config_json = res.config_json or {}
+            if isinstance(config_json, list):
+                config_json = config_json[0] if config_json else {}
+
             rule = RULE_BASED_MAP.get(res.resource_type)
             if not rule:
-                # 매핑 규칙 없는 리소스 → manual confidence
                 mapping = self._create_manual_mapping(res, project_id, sync_id)
                 db.add(mapping)
                 mappings.append(mapping)
@@ -127,7 +144,7 @@ class MappingEngine:
 
             if rule["confidence"] == "auto" and rule["mapping"]:
                 # 룰 기반 변환 (FR-B-004)
-                attrs = rule["mapping"](res.config_json or {})
+                attrs = rule["mapping"](config_json)  # 정규화된 config_json 사용
                 hcl   = self._attrs_to_hcl(rule["gcp_type"], res.resource_name, attrs)
                 mapping = GCPMapping(
                     resource_id       = res.resource_id,
@@ -144,12 +161,25 @@ class MappingEngine:
                 # Bedrock 보완 변환 (FR-B-005)
                 result = self.bedrock.map_resource(
                     resource_type = res.resource_type,
-                    aws_config    = res.config_json or {},
+                    aws_config    = config_json,      # 정규화된 config_json 사용
                     gcp_type      = rule["gcp_type"],
                 )
-                attrs        = result.get("terraform_attributes", {})
+
+                # [수정 2] result 또는 mapping_info가 list인 경우 방어
+                if isinstance(result, list):
+                    result = result[0] if result else {}
+
+                mapping_info  = result.get("mapping_info", {})
+                if isinstance(mapping_info, list):
+                    mapping_info = mapping_info[0] if mapping_info else {}
+
                 review_reason = result.get("review_reason", "")
-                hcl          = self._attrs_to_hcl(rule["gcp_type"], res.resource_name, attrs)
+
+                hcl = self._generate_hcl_from_mapping_info(
+                    gcp_type     = rule["gcp_type"],
+                    name         = res.resource_name,
+                    mapping_info = mapping_info,
+                )
                 mapping = GCPMapping(
                     resource_id       = res.resource_id,
                     project_id        = project_id,
@@ -162,7 +192,6 @@ class MappingEngine:
                     user_confirmed    = False,
                 )
 
-            # IAM Role의 경우 추가로 Policy → GCP Role 변환 (FR-B-006)
             if res.resource_type == "AWS::IAM::Role":
                 mapping = self._apply_iam_mapping(mapping, res)
 
@@ -172,15 +201,132 @@ class MappingEngine:
         db.commit()
         return mappings
 
+    # ──────────────────────────────────────────────────────────
+    # review 리소스용 HCL 템플릿 함수들
+    # ──────────────────────────────────────────────────────────
+
+    def _generate_hcl_from_mapping_info(
+        self, gcp_type: str, name: str, mapping_info: dict
+    ) -> str:
+        if gcp_type == "google_compute_firewall":
+            return self._generate_firewall_hcl(name, mapping_info)
+        elif gcp_type == "google_compute_backend_service":
+            return self._generate_backend_service_hcl(name, mapping_info)
+        elif gcp_type == "google_cloud_run_service":
+            return self._generate_cloud_run_hcl(name, mapping_info)
+        else:
+            return f'# review 필요: {gcp_type} — {name}'
+
+    def _generate_firewall_hcl(self, name: str, info: dict) -> str:
+        # [수정] GCP 리소스명 정규식 통과를 위해 소문자 및 하이픈으로 강제 변환
+        gcp_name  = name.lower().replace("_", "-")
+        tf_name   = gcp_name.replace("-", "_")
+        direction = info.get("direction", "INGRESS")
+        rules     = info.get("rules", [{"protocol": "all", "source_ranges": ["0.0.0.0/0"]}])
+
+        # [수정] VPC 이름 동적 추론 (예: DD-prod-sg-db -> dd-prod-vpc)
+        name_parts = name.split("-")
+        vpc_name = "default"
+        if len(name_parts) >= 2:
+            vpc_name = f"{name_parts[0]}-{name_parts[1]}-vpc".lower()
+
+        if not isinstance(rules, list):
+            rules = [{"protocol": "all", "source_ranges": ["0.0.0.0/0"]}]
+
+        allow_blocks = ""
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            ports_line = ""
+            if rule.get("ports"):
+                ports_line = f'\n    ports    = {json.dumps(rule["ports"])}'
+            allow_blocks += f"""
+  allow {{
+    protocol = "{rule.get('protocol', 'all')}"{ports_line}
+  }}"""
+
+        source_ranges = json.dumps(
+            rules[0].get("source_ranges", ["0.0.0.0/0"])
+            if rules and isinstance(rules[0], dict) else ["0.0.0.0/0"]
+        )
+
+        return f'''resource "google_compute_firewall" "{tf_name}" {{
+  name          = "{gcp_name}"
+  network       = "{vpc_name}"
+  direction     = "{direction}"
+  source_ranges = {source_ranges}
+{allow_blocks}
+}}'''
+
+    def _generate_backend_service_hcl(self, name: str, info: dict) -> str:
+        # [수정] 대문자 에러 방지용 소문자 변환
+        gcp_name              = name.lower().replace("_", "-")
+        tf_name               = gcp_name.replace("-", "_")
+        protocol              = info.get("protocol", "HTTP")
+        timeout_sec           = info.get("timeout_sec", 30)
+        load_balancing_scheme = info.get("load_balancing_scheme", "EXTERNAL")
+
+        return f'''resource "google_compute_backend_service" "{tf_name}" {{
+  name                  = "{gcp_name}"
+  protocol              = "{protocol}"
+  timeout_sec           = {timeout_sec}
+  load_balancing_scheme = "{load_balancing_scheme}"
+}}'''
+
+    def _generate_cloud_run_hcl(self, name: str, info: dict) -> str:
+        # [수정] 대문자 에러 방지용 소문자 변환
+        gcp_name = name.lower().replace("_", "-")
+        tf_name  = gcp_name.replace("-", "_")
+        image    = info.get("image", "gcr.io/cloudrun/hello")
+        cpu      = info.get("cpu", "1000m")
+        memory   = info.get("memory", "512Mi")
+        port     = info.get("port", 8080)
+
+        env_block = ""
+        for env in info.get("env_vars", []):
+            if not isinstance(env, dict):
+                continue
+            env_block += f"""
+        env {{
+          name  = "{env.get('name', '')}"
+          value = "{env.get('value', '')}"
+        }}"""
+
+        return f'''resource "google_cloud_run_service" "{tf_name}" {{
+  name     = "{gcp_name}"
+  location = "us-west1"
+
+  template {{
+    spec {{
+      containers {{
+        image = "{image}"
+        ports {{
+          container_port = {port}
+        }}
+        resources {{
+          limits = {{
+            cpu    = "{cpu}"
+            memory = "{memory}"
+          }}
+        }}{env_block}
+      }}
+    }}
+  }}
+}}'''
+
+    # ──────────────────────────────────────────────────────────
+    # 기존 메서드들 (auto 리소스용)
+    # ──────────────────────────────────────────────────────────
+
     def _apply_iam_mapping(
         self, mapping: GCPMapping, res: AWSResource
     ) -> GCPMapping:
-        """
-        §5-2 IAM Action → GCP Role 변환 테이블 적용 (FR-B-006)
-        표준 Action은 룰 기반, 복잡한 Condition은 Bedrock 보완.
-        완전 커스텀 정책은 manual 표시.
-        """
-        policies = (res.config_json or {}).get("AssumeRolePolicyDocument", {})
+        # [수정 3] config_json이 list인 경우 dict로 정규화
+        config = res.config_json or {}
+        if isinstance(config, list):
+            config = config[0] if config else {}
+
+        policies   = config.get("AssumeRolePolicyDocument", {})
         statements = policies.get("Statement", [])
         gcp_roles  = []
 
@@ -194,9 +340,8 @@ class MappingEngine:
                     gcp_roles.append(gcp_role)
 
         if gcp_roles:
-            # HCL에 GCP 역할 바인딩 추가
             extra_hcl = "\n".join([
-                f'# GCP Role Binding:{role}' for role in set(gcp_roles)
+                f'# GCP Role Binding: {role}' for role in set(gcp_roles)
             ])
             mapping.terraform_code += f"\n\n{extra_hcl}"
 
@@ -211,7 +356,7 @@ class MappingEngine:
             sync_id           = sync_id,
             gcp_resource_type = "unknown",
             gcp_resource_name = res.resource_name,
-            terraform_code    = f"# 수동 매핑 필요:{res.resource_type}",
+            terraform_code    = f"# 수동 매핑 필요: {res.resource_type}",
             confidence        = "manual",
             review_reason     = "자동 변환 규칙이 없습니다. 수동으로 GCP 리소스를 설정하세요.",
             user_confirmed    = False,
@@ -220,17 +365,41 @@ class MappingEngine:
     def _attrs_to_hcl(
         self, gcp_type: str, name: str, attrs: dict
     ) -> str:
-        """GCP Terraform 리소스 속성을 HCL 문자열로 변환한다."""
-        import json
+        """auto 리소스(룰 기반) 전용"""
+
+        MAP_TYPE_KEYS = {"labels", "annotations", "limits", "requests", "metadata"}
 
         def dict_to_hcl(d: dict, indent: int = 2) -> str:
             lines = []
             pad   = " " * indent
             for k, v in d.items():
+                if "." in k or "/" in k:
+                    lines.append(f'{pad}# annotation: "{k}" = "{v}"')
+                    continue
                 if isinstance(v, dict):
-                    lines.append(f"{pad}{k} {{")
-                    lines.append(dict_to_hcl(v, indent + 2))
-                    lines.append(f"{pad}}}")
+                    if k in MAP_TYPE_KEYS:
+                        lines.append(f'{pad}{k} = {{')
+                        for mk, mv in v.items():
+                            if isinstance(mv, bool):
+                                lines.append(f'{pad}  {mk} = {str(mv).lower()}')
+                            elif isinstance(mv, (int, float)):
+                                lines.append(f'{pad}  {mk} = {mv}')
+                            else:
+                                lines.append(f'{pad}  {mk} = "{mv}"')
+                        lines.append(f'{pad}}}')
+                    else:
+                        lines.append(f"{pad}{k} {{")
+                        lines.append(dict_to_hcl(v, indent + 2))
+                        lines.append(f"{pad}}}")
+                elif isinstance(v, list):
+                    if v and isinstance(v[0], dict):
+                        for item in v:
+                            lines.append(f"{pad}{k} {{")
+                            lines.append(dict_to_hcl(item, indent + 2))
+                            lines.append(f"{pad}}}")
+                    else:
+                        formatted = json.dumps(v)
+                        lines.append(f'{pad}{k} = {formatted}')
                 elif isinstance(v, bool):
                     lines.append(f'{pad}{k} = {str(v).lower()}')
                 elif isinstance(v, (int, float)):
@@ -239,6 +408,7 @@ class MappingEngine:
                     lines.append(f'{pad}{k} = "{v}"')
             return "\n".join(lines)
 
-        resource_name = name.replace("-", "_")
+        # [수정] TF 리소스 이름도 일관성을 위해 소문자화 (GCP 권장 컨벤션)
+        resource_name = name.lower().replace("-", "_")
         body = dict_to_hcl(attrs)
         return f'resource "{gcp_type}" "{resource_name}" {{\n{body}\n}}'


### PR DESCRIPTION
1. bedrock_client.py: 모델 ID 변경 / 반환 방식 전면 변경: terraform_attributes(HCL 속성) → mapping_info(의미 정보) / 리소스 타입별 전용 프롬프트 적용
2. detector.py: ExternalId 파라미터 추가 / Name 태그 기반 필터링 / top_tags 추출 / ResourceDeleted 필터링 / resource_id·resource_name 중복 방지 / if top_tags: 조건 제거 (tags list→dict 보장)
3. dr_packager.py: 복잡한 ECS 동적 조회를 제거
4. failover.py: 삭제
5. mapper.py: _get_name_tag() 헬퍼 함수 추가 / RULE_BASED_MAP VPC·Subnet·RouteTable Name 태그 기반 네이밍 / NatGateway에 필수 필드 router, region 추가 / review 리소스: Bedrock mapping_info 기반 Python 템플릿 HCL 생성 / config_json list 정규화
