### PR TITLE
feat: destroy flow + landing/login redesign + dashboard toast + wizar…

### DIFF
--- a/backend/app/api/craft.py
+++ b/backend/app/api/craft.py
@@ -573,9 +573,16 @@ def deployment_complete_callback(
             print(f"[경고] EventBridge 발행 실패: {e}")
 
     elif body.status == "destroyed" and project:
-        # destroy 완료 → project status "destroy_completed" 전환
-        project.status = "destroy_completed"
-        db.commit()
+        # destroy 완료 →
+        # delete_project_records로 DB 전체 삭제 (AWS 리소스 삭제 체크 후 삭제 요청한 경우)
+        # projects.py의 _delete_project_records 재사용
+        try:
+            from app.api.projects import _delete_project_records
+            _delete_project_records(body.project_id, project, db)
+        except Exception:
+            # 혹시 이미 삭제된 경우 등 — project status만 destroy_completed로 마킹
+            project.status = "destroy_completed"
+            db.commit()
 
     elif body.status == "destroy_failed" and project:
         # destroy 실패 → destroying → destroy_failed, project는 유지

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from typing import Optional
 from app.core.auth import get_current_user
+from app.core.config import settings
 from app.core.database import get_db
 from app.models.project import Project
 from app.models.aws_account import AWSAccount
@@ -16,31 +17,24 @@ class CreateProjectRequest(BaseModel):
     name: str
     account_id: str
     region: str
-    prefix: str          # 네이밍 규칙 {prefix}-{env}-{resource}의 prefix
-    environment: str     # prod / staging / dev
+    prefix: str
+    environment: str
 
 
 @router.get("")
 def list_projects(
-    status: Optional[str] = Query(None, description="completed/deploying/failed"),
-    environment: Optional[str] = Query(None, description="prod/staging/dev"),
+    status: Optional[str] = Query(None),
+    environment: Optional[str] = Query(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """프로젝트 목록을 반환한다. status, environment 필터 지원."""
     query = db.query(Project).filter(Project.user_id == current_user.user_id)
-
     if status:
         query = query.filter(Project.status == status)
     if environment:
         query = query.filter(Project.environment == environment)
-
     projects = query.order_by(Project.created_at.desc()).all()
-
-    return {
-        "success": True,
-        "data": [_project_to_dict(p) for p in projects],
-    }
+    return {"success": True, "data": [_project_to_dict(p) for p in projects]}
 
 
 @router.post("", status_code=201)
@@ -49,19 +43,12 @@ def create_project(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    새 프로젝트를 생성한다.
-    prefix + environment 필드는 필수다. (ERD NOT NULL 제약)
-    네이밍 규칙 미리보기: {prefix}-{env}-{resource} (예: DD-prod-vpc)
-    """
-    # environment 유효성 검사
     if request.environment not in ("prod", "staging", "dev"):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"code": "VALIDATION_ERROR", "message": "environment는 prod, staging, dev 중 하나여야 합니다."},
         )
 
-    # 연동된 AWS 계정 소유 확인
     account = db.query(AWSAccount).filter(
         AWSAccount.account_id == request.account_id,
         AWSAccount.user_id == current_user.user_id,
@@ -87,11 +74,8 @@ def create_project(
     db.add(project)
     db.commit()
     db.refresh(project)
+    return {"success": True, "data": _project_to_dict(project)}
 
-    return {
-        "success": True,
-        "data": _project_to_dict(project),
-    }
 
 @router.get("/{project_id}")
 def get_project(
@@ -99,10 +83,8 @@ def get_project(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """프로젝트 상세 정보를 반환한다. aws_resources, dr_package 정보 포함."""
     project = _get_project_or_404(project_id, current_user.user_id, db)
 
-    # 최신 DR Package 조회
     from app.models.sync_history import DRPackage
     latest_package = db.query(DRPackage).filter(
         DRPackage.project_id == project_id,
@@ -133,19 +115,87 @@ def delete_project(
 ):
     project = db.query(Project).filter(
         Project.project_id == project_id,
-        Project.user_id == current_user.user_id
+        Project.user_id == current_user.user_id,
     ).first()
 
     if not project:
         raise HTTPException(status_code=404, detail="프로젝트를 찾을 수 없습니다.")
 
+    # ── destroy_aws_resources=True: AWS 리소스 먼저 destroy ──────────
+    if request.destroy_aws_resources and project.status in (
+        "completed", "partial_failed", "failed", "destroy_failed"
+    ):
+        from app.models.deployment import Deployment
+        from app.services.craftops.runner import TerraformRunnerService
+
+        # 최신 deployment 조회
+        latest_deployment = (
+            db.query(Deployment)
+            .filter(Deployment.project_id == project_id)
+            .order_by(Deployment.created_at.desc())
+            .first()
+        )
+
+        if latest_deployment:
+            account = db.query(AWSAccount).filter(
+                AWSAccount.account_id == project.account_id,
+            ).first()
+
+            if not account:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail={"code": "NOT_FOUND", "message": "AWS 계정 정보를 찾을 수 없습니다."},
+                )
+
+            # destroying 상태로 전환 — 콜백에서 destroyed 오면 DB 삭제 진행
+            project.status = "destroying"
+            latest_deployment.status = "destroying"
+            latest_deployment.error_message = None
+            db.commit()
+
+            runner = TerraformRunnerService()
+            try:
+                runner.spawn_destroy_task(
+                    project_id=project_id,
+                    deployment_id=latest_deployment.deployment_id,
+                    role_arn=account.role_arn,
+                    region=project.region,
+                    user_id=project.user_id,
+                    subnet_ids=settings.platform_subnet_ids.split(","),
+                    security_group_ids=settings.platform_sg_ids.split(","),
+                )
+            except Exception as e:
+                # ECS spawn 실패 시 상태 원복
+                project.status = "destroy_failed"
+                latest_deployment.status = "destroy_failed"
+                latest_deployment.error_message = f"ECS Task 실행 실패: {str(e)}"
+                db.commit()
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail={"code": "SPAWN_FAILED", "message": f"ECS Task 실행에 실패했습니다: {str(e)}"},
+                )
+
+            return {
+                "success": True,
+                "message": "AWS 리소스 삭제가 시작되었습니다. 삭제 완료 후 프로젝트가 자동으로 제거됩니다.",
+                "status": "destroying",
+            }
+
+    # ── destroy_aws_resources=False 또는 배포 없는 경우: DB만 삭제 ──
+    _delete_project_records(project_id, project, db)
+
+    return {"success": True, "message": "프로젝트가 삭제되었습니다."}
+
+
+def _delete_project_records(project_id: str, project: Project, db: Session) -> None:
+    """프로젝트 관련 DB 레코드 전체 삭제 (CASCADE 수동 처리)"""
     from app.models.deployment import Deployment, DeploymentResource
     from app.models.aws_resource import AWSResource
     from app.models.gcp_mapping import GCPMapping
     from app.models.sync_history import SyncHistory, DRPackage
     from app.models.failover_history import FailoverHistory
 
-    # [FIX] failover_history 먼저 삭제 (NOT NULL FK 제약)
+    # failover_history 먼저 (NOT NULL FK)
     db.query(FailoverHistory).filter(
         FailoverHistory.project_id == project_id
     ).delete(synchronize_session=False)
@@ -185,10 +235,8 @@ def delete_project(
     db.delete(project)
     db.commit()
 
-    return {"success": True, "message": "프로젝트가 삭제되었습니다."}
 
-
-# ── 헬퍼 함수 ──────────────────────────────────────────────────────
+# ── 헬퍼 ──────────────────────────────────────────────────────────
 def _get_project_or_404(project_id: str, user_id: str, db: Session) -> Project:
     project = db.query(Project).filter(
         Project.project_id == project_id,
@@ -204,14 +252,14 @@ def _get_project_or_404(project_id: str, user_id: str, db: Session) -> Project:
 
 def _project_to_dict(project: Project) -> dict:
     return {
-        "project_id": project.project_id,
-        "name": project.name,
-        "prefix": project.prefix,
-        "environment": project.environment,
-        "region": project.region,
-        "status": project.status,
-        "dr_status": project.dr_status,
+        "project_id":     project.project_id,
+        "name":           project.name,
+        "prefix":         project.prefix,
+        "environment":    project.environment,
+        "region":         project.region,
+        "status":         project.status,
+        "dr_status":      project.dr_status,
         "last_deployed_at": project.last_deployed_at.isoformat() if project.last_deployed_at else None,
-        "last_synced_at": project.last_synced_at.isoformat() if project.last_synced_at else None,
-        "created_at": project.created_at.isoformat(),
+        "last_synced_at":   project.last_synced_at.isoformat() if project.last_synced_at else None,
+        "created_at":       project.created_at.isoformat(),
     }

--- a/fortune-app/Dockerfile
+++ b/fortune-app/Dockerfile
@@ -8,8 +8,8 @@ COPY index.html /usr/share/nginx/html/index.html
 
 # Health check (ALB Target Group 헬스체크용)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -qO- http://localhost:80/health || exit 1
+  CMD wget -qO- http://localhost:8080/health || exit 1
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/fortune-app/nginx.conf
+++ b/fortune-app/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
 
     root /usr/share/nginx/html;

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -8,10 +8,6 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { apiClient } from '@/lib/api'
 import { useAuthStore } from '@/store/authStore'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Alert, AlertDescription } from '@/components/ui/alert'
 
 const loginSchema = z.object({
   email: z.string().email('올바른 이메일을 입력하세요.'),
@@ -23,6 +19,7 @@ export default function LoginPage() {
   const router = useRouter()
   const { setAuth } = useAuthStore()
   const [error, setError] = useState<string>('')
+  const [showPw, setShowPw] = useState(false)
 
   const {
     register,
@@ -54,75 +51,526 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <div className="text-3xl font-bold text-teal-600">⚡ AutoOps</div>
-          <CardTitle className="text-sm text-gray-500 font-normal mt-1">
-            멀티클라우드 인프라 자동화 플랫폼
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            <div>
-              <label className="text-sm font-medium">이메일</label>
-              <Input
-                {...register('email')}
-                type="email"
-                placeholder="user@example.com"
-                className="mt-1"
-              />
-              {errors.email && (
-                <p className="text-red-500 text-xs mt-1">{errors.email.message}</p>
-              )}
+    <>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+        :root {
+          --bg: #07090f;
+          --ink: #e7ebf3;
+          --ink-dim: #8b93a7;
+          --ink-mute: #4b5267;
+          --line: rgba(255,255,255,0.06);
+          --line-2: rgba(255,255,255,0.10);
+          --line-3: rgba(255,255,255,0.16);
+          --orange: #ffa53d;
+          --blue: #5aa3ff;
+          --danger: #ff7676;
+          --display: 'Plus Jakarta Sans', -apple-system, sans-serif;
+          --mono: 'JetBrains Mono', ui-monospace, monospace;
+        }
+        body { background: var(--bg); color: var(--ink); overflow: hidden; }
+
+        .ao-stage {
+          position: relative; min-height: 100vh;
+          display: grid; place-items: center;
+          padding: 24px;
+          overflow: hidden; isolation: isolate;
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        }
+        .ao-grid {
+          position: absolute; inset: 0; z-index: 0;
+          background-image:
+            linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+          background-size: 56px 56px;
+          mask-image: radial-gradient(ellipse 80% 70% at 50% 50%, #000 30%, transparent 75%);
+          -webkit-mask-image: radial-gradient(ellipse 80% 70% at 50% 50%, #000 30%, transparent 75%);
+          opacity: 0.5;
+        }
+        .ao-orbit {
+          position: absolute; top: 50%; left: 50%;
+          width: min(720px, 80vw); aspect-ratio: 1;
+          transform: translate(-50%, -50%);
+          border-radius: 50%; border: 1px dashed rgba(255,255,255,0.06);
+          z-index: 1; animation: ao-spin 90s linear infinite;
+        }
+        .ao-orbit::before, .ao-orbit::after {
+          content: ""; position: absolute; border-radius: 50%;
+          border: 1px dashed rgba(255,255,255,0.04);
+        }
+        .ao-orbit::before { inset: -60px; }
+        .ao-orbit::after  { inset: -140px; border-color: rgba(255,255,255,0.025); }
+        @keyframes ao-spin { to { transform: translate(-50%, -50%) rotate(360deg); } }
+
+        .ao-vignette {
+          position: absolute; inset: 0; z-index: 1; pointer-events: none;
+          background: radial-gradient(ellipse 60% 55% at 50% 50%, transparent 0%, rgba(7,9,15,0.55) 70%, rgba(7,9,15,0.95) 100%);
+        }
+        .ao-streams { position: absolute; inset: 0; z-index: 2; pointer-events: none; width: 100%; height: 100%; }
+        .ao-stream {
+          fill: none; stroke-linecap: round; filter: url(#aoGlow);
+          stroke-dasharray: 1400; stroke-dashoffset: 1400;
+          animation: ao-draw 2.6s 0.2s cubic-bezier(.22,.8,.18,1) forwards, ao-flow 9s 3s linear infinite;
+        }
+        .ao-stream-o { stroke: var(--orange); stroke-width: 2.2; }
+        .ao-stream-o-thin { stroke: var(--orange); stroke-width: 1; opacity: 0.5; }
+        .ao-stream-b { stroke: var(--blue); stroke-width: 2.2; animation-delay: 0.5s, 3.3s; }
+        .ao-stream-b-thin { stroke: var(--blue); stroke-width: 1; opacity: 0.5; animation-delay: 0.5s, 3.3s; }
+        @keyframes ao-draw { to { stroke-dashoffset: 0; } }
+        @keyframes ao-flow {
+          0%   { stroke-dasharray: 12 28; stroke-dashoffset: 0; }
+          100% { stroke-dasharray: 12 28; stroke-dashoffset: -160; }
+        }
+
+        .ao-topbar {
+          position: fixed; top: 0; left: 0; right: 0; z-index: 50;
+          display: flex; align-items: center; justify-content: space-between;
+          padding: 20px 28px;
+        }
+        .ao-brand {
+          display: inline-flex; align-items: center; gap: 10px;
+          font-family: var(--display);
+          font-weight: 800; font-size: 16px; letter-spacing: -0.02em;
+          color: var(--ink); text-decoration: none;
+          background: none; border: none; cursor: pointer; padding: 0;
+        }
+        .ao-mark {
+          width: 24px; height: 24px;
+          display: grid; place-items: center;
+          border-radius: 6px;
+          background:
+            radial-gradient(80% 80% at 30% 25%, rgba(255,165,61,0.7), transparent 60%),
+            radial-gradient(80% 80% at 70% 80%, rgba(90,163,255,0.7), transparent 60%),
+            #11151f;
+          border: 1px solid rgba(255,255,255,0.08);
+          box-shadow: 0 4px 24px rgba(90,163,255,0.18), inset 0 0 12px rgba(255,255,255,0.06);
+          position: relative;
+        }
+        .ao-mark::after {
+          content: ""; position: absolute; top: 50%; left: 50%;
+          transform: translate(-50%, -50%);
+          width: 8px; height: 8px; border-radius: 2px;
+          background: #fff; box-shadow: 0 0 12px rgba(255,255,255,0.8);
+        }
+        .ao-back {
+          font-family: var(--mono);
+          font-size: 12px; color: var(--ink-dim);
+          background: rgba(255,255,255,0.03);
+          display: inline-flex; align-items: center; gap: 8px;
+          padding: 8px 14px; border-radius: 8px;
+          border: 1px solid var(--line-2);
+          cursor: pointer;
+          transition: color 160ms, border-color 160ms, background 160ms;
+        }
+        .ao-back:hover { color: var(--ink); border-color: var(--line-3); background: rgba(255,255,255,0.06); }
+
+        .ao-corner {
+          position: absolute; z-index: 4;
+          font-family: var(--mono); font-size: 11.5px; font-weight: 500;
+          display: inline-flex; align-items: center; gap: 10px;
+          opacity: 0; animation: ao-rise 900ms 1200ms cubic-bezier(.22,.8,.18,1) forwards;
+        }
+        .ao-corner .pip {
+          width: 7px; height: 7px; border-radius: 50%;
+          box-shadow: 0 0 10px currentColor;
+        }
+        .ao-corner-bl { bottom: 24px; left: 28px; color: var(--orange); }
+        .ao-corner-br { bottom: 24px; right: 28px; color: var(--ink-mute); font-weight: 400; letter-spacing: 0.1em; }
+        @keyframes ao-rise {
+          0%   { opacity: 0; transform: translateY(12px); }
+          100% { opacity: 1; transform: translateY(0); }
+        }
+
+        .ao-panel {
+          position: relative; z-index: 10;
+          width: 100%; max-width: 440px;
+          padding: 44px 40px 36px;
+          border-radius: 18px;
+          border: 1px solid var(--line-2);
+          background:
+            radial-gradient(ellipse 100% 60% at 50% 0%, rgba(90,163,255,0.06), transparent 70%),
+            linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.005));
+          backdrop-filter: blur(12px);
+          -webkit-backdrop-filter: blur(12px);
+          box-shadow:
+            0 20px 60px -20px rgba(0,0,0,0.6),
+            0 0 80px -30px rgba(90,163,255,0.25),
+            inset 0 1px 0 rgba(255,255,255,0.05);
+          opacity: 0;
+          animation: ao-panelIn 900ms 200ms cubic-bezier(.22,.8,.18,1) forwards;
+        }
+        .ao-panel::before {
+          content: ""; position: absolute; top: -1px; left: 30px; right: 30px; height: 1px;
+          background: linear-gradient(90deg, transparent, rgba(255,255,255,0.45), transparent);
+        }
+        @keyframes ao-panelIn {
+          0%   { opacity: 0; transform: translateY(20px) scale(0.985); filter: blur(8px); }
+          100% { opacity: 1; transform: translateY(0) scale(1); filter: blur(0); }
+        }
+
+        .ao-head { text-align: center; margin-bottom: 32px; }
+        .ao-head-mark {
+          width: 44px; height: 44px;
+          margin: 0 auto 18px;
+          border-radius: 12px;
+          background:
+            radial-gradient(80% 80% at 30% 25%, rgba(255,165,61,0.8), transparent 60%),
+            radial-gradient(80% 80% at 70% 80%, rgba(90,163,255,0.8), transparent 60%),
+            #11151f;
+          border: 1px solid rgba(255,255,255,0.10);
+          box-shadow: 0 6px 30px rgba(90,163,255,0.25), inset 0 0 16px rgba(255,255,255,0.08);
+          position: relative;
+        }
+        .ao-head-mark::after {
+          content: ""; position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%);
+          width: 14px; height: 14px; border-radius: 3px;
+          background: #fff; box-shadow: 0 0 14px rgba(255,255,255,0.9);
+        }
+        .ao-eyebrow {
+          font-family: var(--mono); font-size: 10.5px; font-weight: 500;
+          letter-spacing: 0.22em; text-transform: uppercase;
+          color: var(--ink-mute); margin-bottom: 12px;
+        }
+        .ao-title {
+          font-family: var(--display);
+          font-size: 28px; font-weight: 700;
+          letter-spacing: -0.025em; line-height: 1.15;
+          color: var(--ink); margin: 0 0 8px;
+        }
+        .ao-sub { font-size: 13.5px; color: var(--ink-dim); margin: 0; line-height: 1.5; }
+
+        .ao-form { display: flex; flex-direction: column; gap: 18px; }
+        .ao-field { display: flex; flex-direction: column; gap: 8px; }
+        .ao-field-label {
+          display: flex; align-items: center; justify-content: space-between;
+          font-family: var(--mono);
+          font-size: 10.5px; font-weight: 500;
+          letter-spacing: 0.16em; text-transform: uppercase;
+          color: var(--ink-dim);
+        }
+        .ao-field-label .ao-hint {
+          font-size: 11px; letter-spacing: 0; text-transform: none;
+          color: var(--ink-mute); font-family: inherit; font-weight: 500;
+        }
+        .ao-field-label .ao-hint a {
+          color: var(--blue); text-decoration: none;
+          background: none; border: none; cursor: pointer; font: inherit; padding: 0;
+        }
+        .ao-field-label .ao-hint a:hover { text-decoration: underline; }
+
+        .ao-input-wrap {
+          position: relative;
+          display: flex; align-items: center;
+          border: 1px solid var(--line-2);
+          border-radius: 10px;
+          background: rgba(255,255,255,0.025);
+          transition: border-color 200ms, background 200ms, box-shadow 200ms;
+        }
+        .ao-input-wrap:hover { border-color: var(--line-3); }
+        .ao-input-wrap:focus-within {
+          border-color: rgba(90,163,255,0.55);
+          background: rgba(255,255,255,0.04);
+          box-shadow: 0 0 0 4px rgba(90,163,255,0.10);
+        }
+        .ao-input-wrap.ao-error {
+          border-color: rgba(255,118,118,0.55);
+          box-shadow: 0 0 0 4px rgba(255,118,118,0.10);
+        }
+        .ao-input-icon {
+          padding: 0 12px 0 14px;
+          color: var(--ink-mute);
+          display: grid; place-items: center;
+          flex-shrink: 0;
+        }
+        .ao-input-wrap:focus-within .ao-input-icon { color: var(--blue); }
+        .ao-input {
+          flex: 1; min-width: 0;
+          background: transparent; border: none; outline: none;
+          color: var(--ink);
+          font-family: inherit;
+          font-size: 14.5px;
+          padding: 14px 14px 14px 0;
+          letter-spacing: -0.005em;
+        }
+        .ao-input::placeholder { color: var(--ink-mute); font-family: var(--mono); font-size: 13px; letter-spacing: 0.02em; }
+        .ao-toggle {
+          padding: 0 14px;
+          background: transparent; border: none; cursor: pointer;
+          color: var(--ink-mute);
+          font-family: var(--mono); font-size: 11px;
+          letter-spacing: 0.1em; text-transform: uppercase;
+          transition: color 160ms;
+        }
+        .ao-toggle:hover { color: var(--ink-dim); }
+
+        .ao-field-error {
+          font-family: var(--mono);
+          font-size: 11px; color: var(--danger);
+          letter-spacing: 0.02em;
+          display: flex; align-items: center; gap: 6px;
+          margin-top: 2px;
+        }
+        .ao-field-error::before {
+          content: "!"; display: grid; place-items: center;
+          width: 14px; height: 14px; border-radius: 50%;
+          background: rgba(255,118,118,0.15);
+          font-size: 9px; font-weight: 700;
+        }
+
+        .ao-alert {
+          display: flex; gap: 10px;
+          padding: 12px 14px;
+          border-radius: 10px;
+          border: 1px solid rgba(255,118,118,0.3);
+          background: rgba(255,118,118,0.06);
+          color: var(--danger);
+          font-size: 13px; line-height: 1.5;
+        }
+        .ao-alert .ico {
+          flex-shrink: 0; width: 18px; height: 18px;
+          border-radius: 50%; background: rgba(255,118,118,0.18);
+          display: grid; place-items: center;
+          font-family: var(--mono); font-weight: 700; font-size: 11px;
+        }
+
+        .ao-submit {
+          margin-top: 6px;
+          width: 100%;
+          display: inline-flex; align-items: center; justify-content: center; gap: 10px;
+          padding: 14px 18px;
+          font-family: var(--display);
+          font-size: 14px; font-weight: 600;
+          letter-spacing: -0.005em;
+          border-radius: 10px;
+          border: 1px solid #f3f4f8;
+          background: linear-gradient(180deg, #ffffff, #e8eaf0);
+          color: #0a0d14;
+          cursor: pointer;
+          transition: transform 180ms, box-shadow 180ms, filter 180ms;
+        }
+        .ao-submit:hover:not(:disabled) {
+          transform: translateY(-1px);
+          box-shadow: 0 8px 30px -8px rgba(255,255,255,0.35), 0 0 30px -10px rgba(90,163,255,0.5);
+        }
+        .ao-submit:disabled { opacity: 0.65; cursor: not-allowed; filter: saturate(0.6); }
+        .ao-submit .arrow { transition: transform 200ms; }
+        .ao-submit:hover:not(:disabled) .arrow { transform: translateX(3px); }
+        .ao-spinner {
+          width: 14px; height: 14px; border-radius: 50%;
+          border: 2px solid rgba(10,13,20,0.2);
+          border-top-color: rgba(10,13,20,0.9);
+          animation: ao-spin2 700ms linear infinite;
+        }
+        @keyframes ao-spin2 { to { transform: rotate(360deg); } }
+
+        .ao-divider {
+          display: flex; align-items: center; gap: 12px;
+          margin: 26px 0 18px;
+          font-family: var(--mono);
+          font-size: 10.5px; letter-spacing: 0.18em; text-transform: uppercase;
+          color: var(--ink-mute);
+        }
+        .ao-divider::before, .ao-divider::after {
+          content: ""; flex: 1; height: 1px; background: var(--line-2);
+        }
+        .ao-signup-row { text-align: center; font-size: 13px; color: var(--ink-dim); }
+        .ao-link {
+          color: var(--ink);
+          text-decoration: none;
+          font-weight: 600;
+          border-bottom: 1px solid var(--line-3);
+          padding: 0 0 1px;
+          transition: color 160ms, border-color 160ms;
+          background: none; border-left: none; border-right: none; border-top: none;
+          font-family: inherit; font-size: inherit; cursor: pointer;
+        }
+        .ao-link:hover { color: var(--orange); border-bottom-color: var(--orange); }
+
+        .ao-meta {
+          position: relative; z-index: 10;
+          margin-top: 22px;
+          display: flex; align-items: center; justify-content: center; gap: 18px;
+          font-family: var(--mono);
+          font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase;
+          color: var(--ink-mute);
+          opacity: 0;
+          animation: ao-rise 900ms 500ms cubic-bezier(.22,.8,.18,1) forwards;
+        }
+        .ao-meta a {
+          color: inherit; text-decoration: none; transition: color 160ms;
+          background: none; border: none; cursor: pointer; font: inherit; padding: 0;
+        }
+        .ao-meta a:hover { color: var(--ink-dim); }
+        .ao-meta .ao-sep { width: 3px; height: 3px; border-radius: 50%; background: var(--ink-mute); opacity: 0.5; }
+
+        @media (max-width: 600px) {
+          .ao-panel { padding: 36px 26px 30px; }
+          .ao-topbar { padding: 16px 18px; }
+          .ao-corner-bl, .ao-corner-br { font-size: 10px; bottom: 14px; }
+          .ao-corner-bl { left: 16px; }
+          .ao-corner-br { right: 16px; }
+        }
+      `}</style>
+
+      <div className="ao-stage">
+
+        {/* Background atmosphere */}
+        <div className="ao-grid"></div>
+        <div className="ao-orbit"></div>
+
+        <svg className="ao-streams" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <filter id="aoGlow" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur stdDeviation="6" result="blur" />
+              <feMerge>
+                <feMergeNode in="blur" />
+                <feMergeNode in="blur" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+          </defs>
+          <path className="ao-stream ao-stream-o" d="M -50 760 C 220 700, 380 640, 620 540 S 1050 380, 1300 360" />
+          <path className="ao-stream ao-stream-o-thin" d="M -80 820 C 260 780, 480 720, 700 600 S 1100 460, 1380 440" />
+          <path className="ao-stream ao-stream-b" d="M 1650 140 C 1380 200, 1220 260, 980 360 S 550 520, 300 540" />
+          <path className="ao-stream ao-stream-b-thin" d="M 1680 80 C 1340 120, 1120 180, 900 300 S 500 440, 220 460" />
+        </svg>
+
+        <div className="ao-vignette"></div>
+
+        {/* Top bar */}
+        <div className="ao-topbar">
+          <button className="ao-brand" onClick={() => router.push('/')}>
+            <span className="ao-mark"></span>
+            AutoOps
+          </button>
+          <button className="ao-back" onClick={() => router.push('/')}>← 홈으로</button>
+        </div>
+
+        {/* Corner labels */}
+        <div className="ao-corner ao-corner-bl">
+          <span className="pip" style={{ background: 'var(--orange)', width: 7, height: 7, borderRadius: '50%', boxShadow: '0 0 10px currentColor' }}></span>
+          Secure Session · TLS 1.3
+        </div>
+        {/* Login Panel */}
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}>
+          <div className="ao-panel">
+            <div className="ao-head">
+              <div className="ao-head-mark"></div>
+              <div className="ao-eyebrow">Sign in</div>
+              <h1 className="ao-title">다시 만나서 반갑습니다</h1>
+              <p className="ao-sub">계정으로 로그인하고 인프라를 이어서 만드세요.</p>
             </div>
-            <div>
-              <label className="text-sm font-medium">비밀번호</label>
-              <Input
-                {...register('password')}
-                type="password"
-                placeholder="••••••••"
-                className="mt-1"
-              />
-              {errors.password && (
-                <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>
+
+            <form className="ao-form" onSubmit={handleSubmit(onSubmit)} noValidate>
+
+              {/* Email */}
+              <div className="ao-field">
+                <label className="ao-field-label" htmlFor="email">
+                  <span>이메일</span>
+                </label>
+                <div className={`ao-input-wrap ${errors.email ? 'ao-error' : ''}`}>
+                  <span className="ao-input-icon">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                      <rect x="3" y="5" width="18" height="14" rx="2" />
+                      <path d="M3 7l9 7 9-7" />
+                    </svg>
+                  </span>
+                  <input
+                    id="email"
+                    className="ao-input"
+                    type="email"
+                    placeholder="user@example.com"
+                    autoComplete="email"
+                    {...register('email')}
+                  />
+                </div>
+                {errors.email && (
+                  <div className="ao-field-error">{errors.email.message}</div>
+                )}
+              </div>
+
+              {/* Password */}
+              <div className="ao-field">
+                <label className="ao-field-label" htmlFor="password">
+                  <span>비밀번호</span>
+                  <span className="ao-hint">
+                    <button type="button" onClick={() => router.push('/forgot-password')}>
+                      비밀번호 찾기
+                    </button>
+                  </span>
+                </label>
+                <div className={`ao-input-wrap ${errors.password ? 'ao-error' : ''}`}>
+                  <span className="ao-input-icon">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                      <rect x="4" y="11" width="16" height="10" rx="2" />
+                      <path d="M8 11V7a4 4 0 1 1 8 0v4" />
+                    </svg>
+                  </span>
+                  <input
+                    id="password"
+                    className="ao-input"
+                    type={showPw ? 'text' : 'password'}
+                    placeholder="••••••••"
+                    autoComplete="current-password"
+                    {...register('password')}
+                  />
+                  <button
+                    type="button"
+                    className="ao-toggle"
+                    onClick={() => setShowPw((v) => !v)}
+                    aria-label="비밀번호 표시 토글"
+                  >
+                    {showPw ? 'Hide' : 'Show'}
+                  </button>
+                </div>
+                {errors.password && (
+                  <div className="ao-field-error">{errors.password.message}</div>
+                )}
+              </div>
+
+              {/* Form-level error */}
+              {error && (
+                <div className="ao-alert" role="alert">
+                  <span className="ico">!</span>
+                  <span>{error}</span>
+                </div>
               )}
+
+              {/* Submit */}
+              <button type="submit" className="ao-submit" disabled={isSubmitting}>
+                {isSubmitting ? (
+                  <>
+                    <span className="ao-spinner"></span>
+                    <span>로그인 중...</span>
+                  </>
+                ) : (
+                  <>
+                    <span>로그인</span>
+                    <span className="arrow">→</span>
+                  </>
+                )}
+              </button>
+            </form>
+
+            <div className="ao-divider">New here</div>
+            <div className="ao-signup-row">
+              계정이 없으신가요?{' '}
+              <button type="button" className="ao-link" onClick={() => router.push('/signup')}>
+                회원가입
+              </button>
             </div>
+          </div>
 
-            {error && (
-              <Alert variant="destructive">
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
-
-            <Button
-              type="submit"
-              className="w-full bg-teal-600 hover:bg-teal-700"
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? (
-                <span className="flex items-center gap-2">
-                  <span className="animate-spin">⏳</span> 로그인 중...
-                </span>
-              ) : (
-                '로그인'
-              )}
-            </Button>
-          </form>
-
-          <p className="text-center text-sm text-gray-500 mt-4">
-            계정이 없으신가요?{' '}
-            <button
-              type="button"
-              className="text-teal-600 hover:underline"
-              onClick={() => router.push('/signup')}
-            >
-              회원가입
-            </button>
-          </p>
-
-        </CardContent>
-      </Card>
-    </div>
+          <div className="ao-meta">
+            <span>v0.4.2</span>
+            <span className="ao-sep"></span>
+            <button type="button" onClick={() => router.push('/privacy')}>개인정보처리방침</button>
+            <span className="ao-sep"></span>
+            <button type="button" onClick={() => router.push('/terms')}>이용약관</button>
+          </div>
+        </div>
+      </div>
+    </>
   )
 }

--- a/frontend/app/(auth)/signup/page.tsx
+++ b/frontend/app/(auth)/signup/page.tsx
@@ -7,10 +7,6 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { apiClient } from '@/lib/api'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Alert, AlertDescription } from '@/components/ui/alert'
 
 const signupSchema = z.object({
   name: z.string().min(2, '이름은 2자 이상이어야 합니다.'),
@@ -21,24 +17,52 @@ const signupSchema = z.object({
     .regex(/[A-Z]/, '대문자를 포함해야 합니다.')
     .regex(/[0-9]/, '숫자를 포함해야 합니다.')
     .regex(/[^A-Za-z0-9]/, '특수문자를 포함해야 합니다.'),
+  agree: z
+    .boolean()
+    .refine((v) => v === true, { message: '약관에 동의해주세요.' }),
 })
 type SignupForm = z.infer<typeof signupSchema>
+
+const STRENGTH_TONES = [
+  { bg: '#ff7676', text: 'Weak' },
+  { bg: '#ff9747', text: 'Fair' },
+  { bg: '#ffa53d', text: 'Good' },
+  { bg: '#9bd1ff', text: 'Strong' },
+  { bg: '#6ee7a0', text: 'Excellent' },
+] as const
 
 export default function SignupPage() {
   const router = useRouter()
   const [error, setError] = useState('')
+  const [showPw, setShowPw] = useState(false)
+  const [pwValue, setPwValue] = useState('')
 
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
-  } = useForm<SignupForm>({ resolver: zodResolver(signupSchema) })
+  } = useForm<SignupForm>({
+    resolver: zodResolver(signupSchema),
+    defaultValues: { agree: false },
+  })
+
+  const pwReqs = {
+    len: pwValue.length >= 8,
+    upper: /[A-Z]/.test(pwValue),
+    num: /[0-9]/.test(pwValue),
+    sym: /[^A-Za-z0-9]/.test(pwValue),
+  }
+  const met = Object.values(pwReqs).filter(Boolean).length
+  const tone = STRENGTH_TONES[met]
+  const pwValid = met === 4
 
   const onSubmit = async (data: SignupForm) => {
     setError('')
     try {
-      await apiClient.post('/api/auth/signup', data)
-      router.push(`/login`)
+      const { agree: _agree, ...payload } = data
+      void _agree
+      await apiClient.post('/api/auth/signup', payload)
+      router.push('/login')
     } catch (err: unknown) {
       const msg =
         (err as { response?: { data?: { error?: { message?: string } } } })
@@ -48,89 +72,659 @@ export default function SignupPage() {
     }
   }
 
+  // Bind onChange for password so we can drive the strength meter alongside RHF
+  const passwordReg = register('password')
+
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <div className="text-3xl font-bold text-teal-600">⚡ AutoOps</div>
-          <CardTitle className="text-sm text-gray-500 font-normal mt-1">
-            회원가입
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            <div>
-              <label className="text-sm font-medium">이름</label>
-              <Input
-                {...register('name')}
-                placeholder="홍길동"
-                className="mt-1"
-              />
-              {errors.name && (
-                <p className="text-red-500 text-xs mt-1">{errors.name.message}</p>
-              )}
-            </div>
-            <div>
-              <label className="text-sm font-medium">이메일</label>
-              <Input
-                {...register('email')}
-                type="email"
-                placeholder="user@example.com"
-                className="mt-1"
-              />
-              {errors.email && (
-                <p className="text-red-500 text-xs mt-1">{errors.email.message}</p>
-              )}
-            </div>
-            <div>
-              <label className="text-sm font-medium">비밀번호</label>
-              <Input
-                {...register('password')}
-                type="password"
-                placeholder="••••••••"
-                className="mt-1"
-              />
-              {errors.password && (
-                <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>
-              )}
-              <p className="text-xs text-gray-400 mt-1">
-                8자 이상, 대문자·숫자·특수문자 포함
+    <>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+        :root {
+          --bg: #07090f;
+          --ink: #e7ebf3;
+          --ink-dim: #8b93a7;
+          --ink-mute: #4b5267;
+          --line: rgba(255,255,255,0.06);
+          --line-2: rgba(255,255,255,0.10);
+          --line-3: rgba(255,255,255,0.16);
+          --orange: #ffa53d;
+          --blue: #5aa3ff;
+          --green: #6ee7a0;
+          --danger: #ff7676;
+          --display: 'Plus Jakarta Sans', -apple-system, sans-serif;
+          --mono: 'JetBrains Mono', ui-monospace, monospace;
+        }
+        body { background: var(--bg); color: var(--ink); }
+
+        .au-stage {
+          position: relative; min-height: 100vh;
+          display: grid; grid-template-columns: 1fr 1fr;
+          isolation: isolate;
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        }
+
+        /* Left rail */
+        .au-rail {
+          position: relative;
+          padding: 64px 56px;
+          display: flex; flex-direction: column;
+          border-right: 1px solid var(--line-2);
+          overflow: hidden;
+        }
+        .au-rail-bg {
+          position: absolute; inset: 0; z-index: 0;
+          background-image:
+            linear-gradient(rgba(255,255,255,0.035) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(255,255,255,0.035) 1px, transparent 1px);
+          background-size: 48px 48px;
+          mask-image: radial-gradient(ellipse 90% 80% at 30% 40%, #000 30%, transparent 80%);
+          -webkit-mask-image: radial-gradient(ellipse 90% 80% at 30% 40%, #000 30%, transparent 80%);
+          opacity: 0.6;
+        }
+        .au-rail-glow-o {
+          position: absolute; z-index: 1; pointer-events: none;
+          top: -160px; left: -160px;
+          width: 540px; height: 540px;
+          border-radius: 50%;
+          background: radial-gradient(circle, rgba(255,165,61,0.18), transparent 60%);
+          filter: blur(20px);
+        }
+        .au-rail-glow-b {
+          position: absolute; z-index: 1; pointer-events: none;
+          bottom: -200px; right: -120px;
+          width: 580px; height: 580px;
+          border-radius: 50%;
+          background: radial-gradient(circle, rgba(90,163,255,0.16), transparent 60%);
+          filter: blur(20px);
+        }
+        .au-rail-streams { position: absolute; inset: 0; z-index: 1; pointer-events: none; width: 100%; height: 100%; }
+        .au-rail-stream { fill: none; stroke-linecap: round; stroke-dasharray: 10 22; opacity: 0.4; }
+        .au-rail-stream-o { stroke: var(--orange); stroke-width: 1.4; }
+        .au-rail-stream-b { stroke: var(--blue); stroke-width: 1.4; }
+
+        .au-rail-content { position: relative; z-index: 5; display: flex; flex-direction: column; height: 100%; }
+        .au-rail-brand {
+          display: inline-flex; align-items: center; gap: 10px;
+          font-family: var(--display);
+          font-weight: 800; font-size: 16px; letter-spacing: -0.02em;
+          color: var(--ink); text-decoration: none;
+          width: fit-content;
+          background: none; border: none; padding: 0; cursor: pointer;
+        }
+        .au-mark {
+          width: 24px; height: 24px;
+          display: grid; place-items: center;
+          border-radius: 6px;
+          background:
+            radial-gradient(80% 80% at 30% 25%, rgba(255,165,61,0.7), transparent 60%),
+            radial-gradient(80% 80% at 70% 80%, rgba(90,163,255,0.7), transparent 60%),
+            #11151f;
+          border: 1px solid rgba(255,255,255,0.08);
+          box-shadow: 0 4px 24px rgba(90,163,255,0.18), inset 0 0 12px rgba(255,255,255,0.06);
+          position: relative;
+        }
+        .au-mark::after {
+          content: ""; position: absolute; top: 50%; left: 50%;
+          transform: translate(-50%, -50%);
+          width: 8px; height: 8px; border-radius: 2px;
+          background: #fff; box-shadow: 0 0 12px rgba(255,255,255,0.8);
+        }
+
+        .au-rail-headline { margin-top: auto; margin-bottom: 40px; }
+        .au-rail-eyebrow {
+          display: inline-flex; align-items: center; gap: 10px;
+          font-family: var(--mono);
+          font-size: 11px; font-weight: 500;
+          letter-spacing: 0.2em; text-transform: uppercase;
+          color: var(--ink-mute);
+          margin-bottom: 24px;
+        }
+        .au-rail-eyebrow::before { content: ""; width: 24px; height: 1px; background: currentColor; }
+        .au-rail-title {
+          font-family: var(--display);
+          font-weight: 700;
+          font-size: clamp(32px, 3.4vw, 44px);
+          line-height: 1.12;
+          letter-spacing: -0.03em;
+          color: var(--ink);
+          margin: 0 0 18px;
+          max-width: 460px;
+        }
+        .au-rail-title em { font-style: normal; color: var(--ink-dim); }
+        .au-rail-sub { color: var(--ink-dim); font-size: 15px; line-height: 1.65; max-width: 420px; margin: 0; }
+
+        .au-rail-features { margin-top: 40px; display: flex; flex-direction: column; gap: 14px; max-width: 420px; }
+        .au-rail-feature { display: flex; gap: 14px; align-items: flex-start; }
+        .au-rail-feature .au-fico {
+          flex-shrink: 0; width: 30px; height: 30px;
+          border-radius: 8px;
+          background: rgba(255,255,255,0.03);
+          border: 1px solid var(--line-2);
+          display: grid; place-items: center;
+          color: var(--ink-dim);
+        }
+        .au-rail-feature[data-tone="orange"] .au-fico { color: var(--orange); border-color: rgba(255,165,61,0.25); background: rgba(255,165,61,0.06); }
+        .au-rail-feature[data-tone="blue"]   .au-fico { color: var(--blue);   border-color: rgba(90,163,255,0.25);  background: rgba(90,163,255,0.06); }
+        .au-rail-feature .au-flabel { font-family: var(--display); font-weight: 600; font-size: 14px; color: var(--ink); letter-spacing: -0.01em; margin-bottom: 3px; }
+        .au-rail-feature .au-fdesc { font-size: 13px; color: var(--ink-dim); line-height: 1.5; }
+
+        .au-rail-foot {
+          margin-top: auto; padding-top: 40px;
+          display: flex; align-items: center; gap: 12px;
+          font-family: var(--mono);
+          font-size: 11px; color: var(--ink-mute);
+          letter-spacing: 0.1em; text-transform: uppercase;
+        }
+        .au-rail-foot .pip {
+          width: 6px; height: 6px; border-radius: 50%;
+          background: var(--green); box-shadow: 0 0 8px var(--green);
+        }
+
+        /* Right form column */
+        .au-form-col {
+          position: relative;
+          padding: 64px 56px;
+          display: flex; flex-direction: column;
+          justify-content: center;
+          min-height: 100vh;
+        }
+        .au-form-top {
+          position: absolute; top: 24px; right: 28px;
+          display: flex; align-items: center; gap: 14px;
+          font-size: 13px; color: var(--ink-dim);
+        }
+        .au-link {
+          background: none; border: none; cursor: pointer;
+          font: inherit; padding: 0;
+          color: var(--ink); font-weight: 600;
+          border-bottom: 1px solid var(--line-3);
+          padding-bottom: 1px;
+          transition: color 160ms, border-color 160ms;
+        }
+        .au-link:hover { color: var(--orange); border-bottom-color: var(--orange); }
+
+        .au-form-inner { width: 100%; max-width: 440px; margin: 0 auto; }
+        .au-form-head { margin-bottom: 36px; }
+        .au-form-eyebrow {
+          font-family: var(--mono);
+          font-size: 10.5px; font-weight: 500;
+          letter-spacing: 0.22em; text-transform: uppercase;
+          color: var(--ink-mute);
+          margin-bottom: 14px;
+          display: inline-flex; align-items: center; gap: 10px;
+        }
+        .au-form-eyebrow .step {
+          padding: 3px 8px;
+          border: 1px solid var(--line-2);
+          border-radius: 100px;
+          background: rgba(255,255,255,0.02);
+          color: var(--ink-dim);
+          letter-spacing: 0.15em;
+        }
+        .au-form-title {
+          font-family: var(--display);
+          font-size: 32px; font-weight: 700;
+          letter-spacing: -0.025em; line-height: 1.15;
+          color: var(--ink); margin: 0 0 10px;
+        }
+        .au-form-sub { font-size: 14px; color: var(--ink-dim); line-height: 1.55; margin: 0; }
+
+        .au-form { display: flex; flex-direction: column; gap: 18px; }
+        .au-field { display: flex; flex-direction: column; gap: 8px; }
+        .au-field-label {
+          display: flex; align-items: center; justify-content: space-between;
+          font-family: var(--mono);
+          font-size: 10.5px; font-weight: 500;
+          letter-spacing: 0.16em; text-transform: uppercase;
+          color: var(--ink-dim);
+        }
+
+        .au-input-wrap {
+          position: relative;
+          display: flex; align-items: center;
+          border: 1px solid var(--line-2);
+          border-radius: 10px;
+          background: rgba(255,255,255,0.025);
+          transition: border-color 200ms, background 200ms, box-shadow 200ms;
+        }
+        .au-input-wrap:hover { border-color: var(--line-3); }
+        .au-input-wrap:focus-within {
+          border-color: rgba(90,163,255,0.55);
+          background: rgba(255,255,255,0.04);
+          box-shadow: 0 0 0 4px rgba(90,163,255,0.10);
+        }
+        .au-input-wrap.au-error {
+          border-color: rgba(255,118,118,0.55);
+          box-shadow: 0 0 0 4px rgba(255,118,118,0.10);
+        }
+        .au-input-wrap.au-valid:not(:focus-within) {
+          border-color: rgba(110,231,160,0.35);
+        }
+        .au-input-icon { padding: 0 12px 0 14px; color: var(--ink-mute); display: grid; place-items: center; flex-shrink: 0; }
+        .au-input-wrap:focus-within .au-input-icon { color: var(--blue); }
+        .au-input-wrap.au-valid:not(:focus-within) .au-input-icon { color: var(--green); }
+        .au-input {
+          flex: 1; min-width: 0;
+          background: transparent; border: none; outline: none;
+          color: var(--ink);
+          font-family: inherit;
+          font-size: 14.5px;
+          padding: 14px 14px 14px 0;
+          letter-spacing: -0.005em;
+        }
+        .au-input::placeholder { color: var(--ink-mute); font-family: var(--mono); font-size: 13px; letter-spacing: 0.02em; }
+        .au-toggle {
+          padding: 0 14px;
+          background: transparent; border: none; cursor: pointer;
+          color: var(--ink-mute);
+          font-family: var(--mono); font-size: 11px;
+          letter-spacing: 0.1em; text-transform: uppercase;
+          transition: color 160ms;
+        }
+        .au-toggle:hover { color: var(--ink-dim); }
+
+        .au-field-error {
+          font-family: var(--mono);
+          font-size: 11px; color: var(--danger);
+          letter-spacing: 0.02em;
+          display: flex; align-items: center; gap: 6px;
+        }
+        .au-field-error::before {
+          content: "!"; display: grid; place-items: center;
+          width: 14px; height: 14px; border-radius: 50%;
+          background: rgba(255,118,118,0.15);
+          font-size: 9px; font-weight: 700;
+        }
+
+        /* PW reqs */
+        .au-pw-reqs {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 6px 14px;
+          margin-top: 2px;
+          padding: 12px 14px;
+          border-radius: 8px;
+          border: 1px dashed var(--line-2);
+          background: rgba(255,255,255,0.015);
+        }
+        .au-pw-req {
+          display: flex; align-items: center; gap: 8px;
+          font-size: 12px;
+          color: var(--ink-mute);
+          transition: color 200ms;
+          font-family: var(--mono);
+          letter-spacing: 0.01em;
+        }
+        .au-pw-req .dot {
+          width: 6px; height: 6px; border-radius: 50%;
+          background: var(--ink-mute);
+          transition: background 200ms, box-shadow 200ms;
+          flex-shrink: 0;
+        }
+        .au-pw-req.met { color: var(--green); }
+        .au-pw-req.met .dot {
+          background: var(--green);
+          box-shadow: 0 0 8px rgba(110,231,160,0.5);
+        }
+
+        .au-pw-strength { margin-top: 4px; display: flex; align-items: center; gap: 10px; }
+        .au-pw-strength .bar { flex: 1; height: 3px; background: rgba(255,255,255,0.06); border-radius: 2px; overflow: hidden; position: relative; }
+        .au-pw-strength .fill { height: 100%; width: 0%; transition: width 300ms, background 300ms; border-radius: 2px; }
+        .au-pw-strength .label { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; min-width: 56px; text-align: right; }
+
+        .au-terms {
+          display: flex; align-items: flex-start; gap: 11px;
+          margin-top: 4px;
+          cursor: pointer;
+          user-select: none;
+        }
+        .au-terms input { display: none; }
+        .au-terms .box {
+          flex-shrink: 0;
+          width: 18px; height: 18px;
+          border-radius: 5px;
+          border: 1px solid var(--line-3);
+          background: rgba(255,255,255,0.03);
+          display: grid; place-items: center;
+          transition: background 200ms, border-color 200ms;
+          margin-top: 1px;
+        }
+        .au-terms .box svg { opacity: 0; transition: opacity 160ms; color: #0a0d14; }
+        .au-terms input:checked + .box { background: #fff; border-color: #fff; }
+        .au-terms input:checked + .box svg { opacity: 1; }
+        .au-terms .text { font-size: 13px; color: var(--ink-dim); line-height: 1.5; }
+        .au-terms .text a { color: var(--ink); text-decoration: none; border-bottom: 1px solid var(--line-3); transition: color 160ms, border-color 160ms; }
+        .au-terms .text a:hover { color: var(--blue); border-bottom-color: var(--blue); }
+
+        .au-alert {
+          display: flex; gap: 10px;
+          padding: 12px 14px;
+          border-radius: 10px;
+          border: 1px solid rgba(255,118,118,0.3);
+          background: rgba(255,118,118,0.06);
+          color: var(--danger);
+          font-size: 13px; line-height: 1.5;
+        }
+        .au-alert .ico {
+          flex-shrink: 0; width: 18px; height: 18px;
+          border-radius: 50%; background: rgba(255,118,118,0.18);
+          display: grid; place-items: center;
+          font-family: var(--mono); font-weight: 700; font-size: 11px;
+        }
+
+        .au-submit {
+          margin-top: 8px;
+          width: 100%;
+          display: inline-flex; align-items: center; justify-content: center; gap: 10px;
+          padding: 14px 18px;
+          font-family: var(--display);
+          font-size: 14px; font-weight: 600;
+          letter-spacing: -0.005em;
+          border-radius: 10px;
+          border: 1px solid #f3f4f8;
+          background: linear-gradient(180deg, #ffffff, #e8eaf0);
+          color: #0a0d14;
+          cursor: pointer;
+          transition: transform 180ms, box-shadow 180ms, filter 180ms;
+        }
+        .au-submit:hover:not(:disabled) {
+          transform: translateY(-1px);
+          box-shadow: 0 8px 30px -8px rgba(255,255,255,0.35), 0 0 30px -10px rgba(90,163,255,0.5);
+        }
+        .au-submit:disabled { opacity: 0.65; cursor: not-allowed; filter: saturate(0.6); }
+        .au-submit .arrow { transition: transform 200ms; }
+        .au-submit:hover:not(:disabled) .arrow { transform: translateX(3px); }
+        .au-spinner {
+          width: 14px; height: 14px; border-radius: 50%;
+          border: 2px solid rgba(10,13,20,0.2);
+          border-top-color: rgba(10,13,20,0.9);
+          animation: au-spin 700ms linear infinite;
+        }
+        @keyframes au-spin { to { transform: rotate(360deg); } }
+
+        .au-form-foot {
+          margin-top: 20px;
+          text-align: center;
+          font-size: 13px;
+          color: var(--ink-dim);
+        }
+
+        @media (max-width: 960px) {
+          .au-stage { grid-template-columns: 1fr; }
+          .au-rail {
+            padding: 32px 28px;
+            min-height: auto;
+            border-right: none;
+            border-bottom: 1px solid var(--line-2);
+          }
+          .au-rail-headline { margin-top: 32px; margin-bottom: 24px; }
+          .au-rail-features { display: none; }
+          .au-rail-foot { padding-top: 24px; }
+          .au-form-col { padding: 40px 28px 56px; min-height: auto; }
+          .au-form-top { position: static; justify-content: flex-end; margin-bottom: 24px; }
+        }
+        @media (max-width: 520px) {
+          .au-rail { padding: 28px 22px; }
+          .au-form-col { padding: 32px 22px 48px; }
+          .au-form-title { font-size: 26px; }
+          .au-pw-reqs { grid-template-columns: 1fr; }
+        }
+      `}</style>
+
+      <div className="au-stage">
+
+        {/* ============== Left rail ============== */}
+        <aside className="au-rail">
+          <div className="au-rail-bg"></div>
+          <div className="au-rail-glow-o"></div>
+          <div className="au-rail-glow-b"></div>
+
+          <svg className="au-rail-streams" viewBox="0 0 800 1200" preserveAspectRatio="xMidYMid slice">
+            <path className="au-rail-stream au-rail-stream-o" d="M -40 980 C 180 920, 320 860, 480 720 S 720 540, 900 500" />
+            <path className="au-rail-stream au-rail-stream-b" d="M 820 140 C 620 220, 480 320, 360 460 S 140 660, -40 700" />
+          </svg>
+
+          <div className="au-rail-content">
+            <button className="au-rail-brand" onClick={() => router.push('/')}>
+              <span className="au-mark"></span>
+              AutoOps
+            </button>
+
+            <div className="au-rail-headline">
+              <div className="au-rail-eyebrow">Join AutoOps</div>
+              <h1 className="au-rail-title">
+                한 줄로 시작해서<br/>
+                <em>두 클라우드를 다룹니다.</em>
+              </h1>
+              <p className="au-rail-sub">
+                가입과 동시에 AWS Primary와 GCP Standby를 동시에 운영하는 인프라 자동화 워크플로우를 시작할 수 있습니다.
               </p>
             </div>
 
-            {error && (
-              <Alert variant="destructive">
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
+            <div className="au-rail-features">
+              <div className="au-rail-feature" data-tone="orange">
+                <div className="au-fico">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                    <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
+                  </svg>
+                </div>
+                <div>
+                  <div className="au-flabel">자연어 프롬프트로 인프라 생성</div>
+                  <div className="au-fdesc">&ldquo;Postgres 붙은 FastAPI 서버&rdquo; 같은 한 문장이 Terraform이 됩니다.</div>
+                </div>
+              </div>
 
-            <Button
-              type="submit"
-              className="w-full bg-teal-600 hover:bg-teal-700"
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? (
-                <span className="flex items-center gap-2">
-                  <span className="animate-spin">⏳</span> 가입 중...
+              <div className="au-rail-feature" data-tone="blue">
+                <div className="au-fico">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                    <path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/>
+                    <path d="M3 12h18M12 3v18"/>
+                  </svg>
+                </div>
+                <div>
+                  <div className="au-flabel">GCP DR 자동 미러링</div>
+                  <div className="au-fdesc">AWS에 배포하는 순간 GCP Standby가 같이 만들어집니다.</div>
+                </div>
+              </div>
+
+              <div className="au-rail-feature">
+                <div className="au-fico">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                    <path d="M9 12l2 2 4-4"/>
+                    <path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/>
+                  </svg>
+                </div>
+                <div>
+                  <div className="au-flabel">4단계 자동 검증</div>
+                  <div className="au-fdesc">validate → tfsec → checkov → infracost. 배포 전에 다 잡습니다.</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="au-rail-foot">
+              <span className="pip"></span>
+              AutoOps · v0.4.2
+            </div>
+          </div>
+        </aside>
+
+        {/* ============== Right form column ============== */}
+        <section className="au-form-col">
+
+          <div className="au-form-top">
+            <span>이미 계정이 있으신가요?</span>
+            <button type="button" className="au-link" onClick={() => router.push('/login')}>
+              로그인
+            </button>
+          </div>
+
+          <div className="au-form-inner">
+            <div className="au-form-head">
+              <div className="au-form-eyebrow">
+                <span className="step">Step 01 / 02</span>
+                계정 만들기
+              </div>
+              <h2 className="au-form-title">계정을 만들어 시작하세요</h2>
+              <p className="au-form-sub">가입 후 AWS · GCP 연결로 넘어갑니다. 1분이면 충분합니다.</p>
+            </div>
+
+            <form className="au-form" onSubmit={handleSubmit(onSubmit)} noValidate>
+
+              {/* Name */}
+              <div className="au-field">
+                <label className="au-field-label" htmlFor="name"><span>이름</span></label>
+                <div className={`au-input-wrap ${errors.name ? 'au-error' : ''}`}>
+                  <span className="au-input-icon">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+                      <circle cx="12" cy="7" r="4"/>
+                    </svg>
+                  </span>
+                  <input
+                    id="name"
+                    className="au-input"
+                    type="text"
+                    placeholder="홍길동"
+                    autoComplete="name"
+                    {...register('name')}
+                  />
+                </div>
+                {errors.name && <div className="au-field-error">{errors.name.message}</div>}
+              </div>
+
+              {/* Email */}
+              <div className="au-field">
+                <label className="au-field-label" htmlFor="email"><span>이메일</span></label>
+                <div className={`au-input-wrap ${errors.email ? 'au-error' : ''}`}>
+                  <span className="au-input-icon">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                      <rect x="3" y="5" width="18" height="14" rx="2"/>
+                      <path d="M3 7l9 7 9-7"/>
+                    </svg>
+                  </span>
+                  <input
+                    id="email"
+                    className="au-input"
+                    type="email"
+                    placeholder="user@example.com"
+                    autoComplete="email"
+                    {...register('email')}
+                  />
+                </div>
+                {errors.email && <div className="au-field-error">{errors.email.message}</div>}
+              </div>
+
+              {/* Password */}
+              <div className="au-field">
+                <label className="au-field-label" htmlFor="password">
+                  <span>비밀번호</span>
+                </label>
+                <div
+                  className={`au-input-wrap ${
+                    errors.password ? 'au-error' : pwValid ? 'au-valid' : ''
+                  }`}
+                >
+                  <span className="au-input-icon">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                      <rect x="4" y="11" width="16" height="10" rx="2"/>
+                      <path d="M8 11V7a4 4 0 1 1 8 0v4"/>
+                    </svg>
+                  </span>
+                  <input
+                    id="password"
+                    className="au-input"
+                    type={showPw ? 'text' : 'password'}
+                    placeholder="••••••••"
+                    autoComplete="new-password"
+                    {...passwordReg}
+                    onChange={(e) => {
+                      passwordReg.onChange(e)
+                      setPwValue(e.target.value)
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="au-toggle"
+                    onClick={() => setShowPw((v) => !v)}
+                    aria-label="비밀번호 표시 토글"
+                  >
+                    {showPw ? 'Hide' : 'Show'}
+                  </button>
+                </div>
+
+                <div className="au-pw-strength">
+                  <div className="bar">
+                    <div
+                      className="fill"
+                      style={{
+                        width: `${(met / 4) * 100}%`,
+                        background: tone.bg,
+                      }}
+                    />
+                  </div>
+                  <div className="label" style={{ color: tone.bg }}>
+                    {tone.text}
+                  </div>
+                </div>
+
+                <div className="au-pw-reqs">
+                  <div className={`au-pw-req ${pwReqs.len ? 'met' : ''}`}><span className="dot"></span>8자 이상</div>
+                  <div className={`au-pw-req ${pwReqs.upper ? 'met' : ''}`}><span className="dot"></span>대문자 포함</div>
+                  <div className={`au-pw-req ${pwReqs.num ? 'met' : ''}`}><span className="dot"></span>숫자 포함</div>
+                  <div className={`au-pw-req ${pwReqs.sym ? 'met' : ''}`}><span className="dot"></span>특수문자 포함</div>
+                </div>
+
+                {errors.password && <div className="au-field-error">{errors.password.message}</div>}
+              </div>
+
+              {/* Terms */}
+              <label className="au-terms">
+                <input type="checkbox" {...register('agree')} />
+                <span className="box">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12"/>
+                  </svg>
                 </span>
-              ) : (
-                '회원가입'
-              )}
-            </Button>
+                <span className="text">
+                  <a href="/terms" onClick={(e) => { e.preventDefault(); router.push('/terms') }}>이용약관</a>
+                  {' '}및{' '}
+                  <a href="/privacy" onClick={(e) => { e.preventDefault(); router.push('/privacy') }}>개인정보처리방침</a>
+                  에 동의합니다.
+                </span>
+              </label>
+              {errors.agree && <div className="au-field-error">{errors.agree.message}</div>}
 
-            <p className="text-center text-sm text-gray-500">
-              이미 계정이 있으신가요?{' '}
-              <button
-                type="button"
-                className="text-teal-600 hover:underline"
-                onClick={() => router.push('/login')}
-              >
-                로그인
+              {/* Form-level error */}
+              {error && (
+                <div className="au-alert" role="alert">
+                  <span className="ico">!</span>
+                  <span>{error}</span>
+                </div>
+              )}
+
+              {/* Submit */}
+              <button type="submit" className="au-submit" disabled={isSubmitting}>
+                {isSubmitting ? (
+                  <>
+                    <span className="au-spinner"></span>
+                    <span>가입 중...</span>
+                  </>
+                ) : (
+                  <>
+                    <span>계정 만들기</span>
+                    <span className="arrow">→</span>
+                  </>
+                )}
               </button>
-            </p>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+            </form>
+
+            <div className="au-form-foot">
+              Step 02에서는 AWS · GCP 계정 연결을 진행합니다.
+            </div>
+          </div>
+        </section>
+      </div>
+    </>
   )
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,25 +1,69 @@
 // frontend/app/dashboard/page.tsx
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { apiClient } from '@/lib/api'
 import { Project } from '@/types'
 
-const STATUS_CONFIG: Record<string, { text: string; color: string }> = {
-  completed:      { text: '✅ 완료',      color: 'text-emerald-400' },
-  deploying:      { text: '⏳ 배포 중',   color: 'text-blue-400' },
-  failed:         { text: '❌ 실패',      color: 'text-red-400' },
-  partial_failed: { text: '⚠️ 부분 실패', color: 'text-yellow-400' },
-  created:        { text: '🔧 준비 중',   color: 'text-[#9ca3af]' },
+// ─── Status → visual tone mapping ─────────────────────────────
+type Tone = 'green' | 'blue' | 'red' | 'yellow' | 'orange' | 'mute'
+interface StatusConf { text: string; tone: Tone }
+
+const STATUS_CONFIG: Record<string, StatusConf> = {
+  completed:         { text: '완료',       tone: 'green' },
+  deploying:         { text: '배포 중',    tone: 'blue' },
+  failed:            { text: '실패',       tone: 'red' },
+  partial_failed:    { text: '부분 실패',  tone: 'yellow' },
+  created:           { text: '준비 중',    tone: 'mute' },
+  destroying:        { text: '삭제 중',    tone: 'orange' },
+  destroy_completed: { text: '삭제 완료',  tone: 'mute' },
+  destroy_failed:    { text: '삭제 실패',  tone: 'red' },
 }
 
-const DR_STATUS_CONFIG: Record<string, { text: string; color: string }> = {
-  ready:     { text: '✅ 준비 완료',    color: 'text-emerald-400' },
-  syncing:   { text: '🔄 동기화 중',    color: 'text-blue-400' },
-  not_ready: { text: '⚠️ 동기화 필요', color: 'text-[#9ca3af]' },
+const DR_STATUS_CONFIG: Record<string, StatusConf> = {
+  ready:     { text: '준비 완료',    tone: 'green' },
+  syncing:   { text: '동기화 중',    tone: 'blue' },
+  not_ready: { text: '동기화 필요',  tone: 'mute' },
 }
 
+// AWS / GCP per-project resource counts (from §spec)
+const AWS_RES_PER_PROJECT = 16
+const GCP_DR_RES_PER_PROJECT = 11
+
+// Filter chips
+type FilterKey = 'all' | 'active' | 'deploying' | 'failed'
+
+// ─── Toast ────────────────────────────────────────────────────
+interface ToastData {
+  projectName: string
+  message: string
+}
+
+function DeployToast({ data, onClose }: { data: ToastData; onClose: () => void }) {
+  useEffect(() => {
+    const t = setTimeout(onClose, 4000)
+    return () => clearTimeout(t)
+  }, [onClose])
+
+  return (
+    <div className="dx-toast" role="status">
+      <div className="dx-toast-ico">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12"/>
+        </svg>
+      </div>
+      <div className="dx-toast-body">
+        <p className="dx-toast-title">{data.projectName}</p>
+        <p className="dx-toast-msg">{data.message}</p>
+      </div>
+      <button className="dx-toast-x" onClick={onClose} aria-label="닫기">✕</button>
+      <div className="dx-toast-bar" />
+    </div>
+  )
+}
+
+// ─── Main ─────────────────────────────────────────────────────
 export default function DashboardPage() {
   const router = useRouter()
   const [projects, setProjects]     = useState<Project[]>([])
@@ -27,14 +71,29 @@ export default function DashboardPage() {
   const [error, setError]           = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [destroyAws, setDestroyAws] = useState(false)
+  const [toast, setToast]           = useState<ToastData | null>(null)
+  const [filter, setFilter]         = useState<FilterKey>('all')
 
+  // localStorage toast (deploy success carry-over)
   useEffect(() => {
+    const raw = localStorage.getItem('deploy_toast')
+    if (raw) {
+      try { setToast(JSON.parse(raw)) } catch {}
+      localStorage.removeItem('deploy_toast')
+    }
+  }, [])
+
+  // Fetch projects
+  const fetchProjects = useCallback(() => {
+    setIsLoading(true)
     apiClient
       .get('/api/projects')
       .then((res) => setProjects(res.data.data))
       .catch(() => setError('프로젝트 목록을 불러오지 못했습니다.'))
       .finally(() => setIsLoading(false))
   }, [])
+
+  useEffect(() => { fetchProjects() }, [fetchProjects])
 
   const handleDelete = async (projectId: string) => {
     try {
@@ -55,213 +114,610 @@ export default function DashboardPage() {
     }
   }
 
-  const totalResources = projects.length * 16
-  const drReadyCount   = projects.filter((p) => p.dr_status === 'ready').length
-  const drReadyRate    = projects.length > 0
+  const closeToast = useCallback(() => setToast(null), [])
+
+  // ─── Derived values ─────────────────────────────────────────
+  const drReadyCount = projects.filter((p) => p.dr_status === 'ready').length
+  const drReadyRate  = projects.length > 0
     ? Math.round((drReadyCount / projects.length) * 100)
     : 0
+  const activeCount  = projects.filter((p) => p.status === 'completed').length
+  const totalAws     = projects.length * AWS_RES_PER_PROJECT
+  const totalDrAvail = projects.length * GCP_DR_RES_PER_PROJECT
+  const totalDrLive  = drReadyCount * GCP_DR_RES_PER_PROJECT
+
+  // unique regions string
+  const regionsText = useMemo(() => {
+    const set = new Set(projects.map((p) => p.region))
+    if (set.size === 0) return '—'
+    return Array.from(set).slice(0, 3).join(' · ')
+  }, [projects])
+
+  // filtered projects
+  const filtered = useMemo(() => {
+    if (filter === 'all') return projects
+    if (filter === 'active')    return projects.filter((p) => p.status === 'completed')
+    if (filter === 'deploying') return projects.filter((p) => p.status === 'deploying' || p.status === 'destroying')
+    if (filter === 'failed')    return projects.filter((p) => p.status === 'failed' || p.status === 'partial_failed' || p.status === 'destroy_failed')
+    return projects
+  }, [projects, filter])
+
+  // formatted "now"
+  const nowText = useMemo(() => {
+    const d = new Date()
+    const fmt = new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).format(d)
+    return `${fmt} KST`
+  }, [])
 
   return (
-    <div className="px-6 py-8 md:px-12 md:py-12 max-w-5xl">
+    <>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
-      {/* 헤더 */}
-      <div className="mb-8 flex justify-between items-start">
-        <div>
-          <h1 className="text-3xl font-extrabold tracking-tight">⚙️ AutoOps</h1>
-          <p className="text-[#9ca3af] text-sm mt-1">대시보드</p>
-        </div>
-        <button
-          onClick={() => router.push('/projects/new')}
-          className="px-4 py-2 bg-white text-black text-sm font-semibold rounded-xl hover:bg-white/90 transition-colors"
-        >
-          + 새 프로젝트
-        </button>
-      </div>
+        :root {
+          --dx-bg: #0b0e17;
+          --dx-ink: #edf0f6;
+          --dx-ink-dim: #aeb4c5;
+          --dx-ink-mute: #7a8298;
+          --dx-line: rgba(255,255,255,0.08);
+          --dx-line-2: rgba(255,255,255,0.13);
+          --dx-line-3: rgba(255,255,255,0.20);
+          --dx-orange: #ffa53d;
+          --dx-blue: #5aa3ff;
+          --dx-green: #6ee7a0;
+          --dx-yellow: #f5d061;
+          --dx-red: #ff7676;
+          --dx-display: 'Plus Jakarta Sans', -apple-system, sans-serif;
+          --dx-mono: 'JetBrains Mono', ui-monospace, monospace;
+        }
 
-      {/* 요약 카드 3개 */}
-      <div className="grid grid-cols-3 gap-4 mb-8">
-        <div className="bg-[#121214] border border-white/8 rounded-3xl p-6 text-center">
-          <p className="text-xs text-[#9ca3af] mb-2">전체 프로젝트</p>
-          <p className="text-3xl font-bold">{projects.length}개</p>
-        </div>
-        <div className="bg-[#121214] border border-white/8 rounded-3xl p-6 text-center">
-          <p className="text-xs text-[#9ca3af] mb-2">AWS 리소스</p>
-          <p className="text-3xl font-bold">{totalResources}개</p>
-        </div>
-        <div className="bg-[#121214] border border-white/8 rounded-3xl p-6 text-center">
-          <p className="text-xs text-[#9ca3af] mb-2">DR 준비율</p>
-          <p className={`text-3xl font-bold ${
-            drReadyRate === 100 ? 'text-emerald-400' :
-            drReadyRate > 0     ? 'text-yellow-400'  : 'text-[#9ca3af]'
-          }`}>
-            {drReadyRate}%
-          </p>
-        </div>
-      </div>
+        .dx-page {
+          position: relative;
+          padding: 40px 48px 80px;
+          max-width: 1280px;
+          margin: 0 auto;
+          isolation: isolate;
+          color: var(--dx-ink);
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        }
+        .dx-page::before {
+          content: "";
+          position: fixed; inset: 0; z-index: -1;
+          background-image:
+            linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+          background-size: 56px 56px;
+          mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 30%, transparent 80%);
+          -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 30%, transparent 80%);
+          opacity: 0.55;
+          pointer-events: none;
+        }
 
-      {/* 에러 */}
-      {error && (
-        <div className="mb-4 bg-red-500/5 border border-red-500/20 rounded-xl p-3 text-sm text-red-400 flex justify-between items-center">
-          <span>{error}</span>
-          <button
-            onClick={() => setError(null)}
-            className="text-red-400/60 hover:text-red-400 ml-4"
-          >
-            ✕
-          </button>
-        </div>
-      )}
+        /* Page head */
+        .dx-head { display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 36px; padding-bottom: 24px; border-bottom: 1px solid var(--dx-line); gap: 16px; flex-wrap: wrap; }
+        .dx-title-row { display: flex; align-items: center; gap: 14px; margin: 0 0 8px; }
+        .dx-mark {
+          width: 32px; height: 32px;
+          display: grid; place-items: center;
+          border-radius: 8px;
+          background:
+            radial-gradient(80% 80% at 30% 25%, rgba(255,165,61,0.7), transparent 60%),
+            radial-gradient(80% 80% at 70% 80%, rgba(90,163,255,0.7), transparent 60%),
+            #11151f;
+          border: 1px solid rgba(255,255,255,0.08);
+          box-shadow: 0 4px 24px rgba(90,163,255,0.18), inset 0 0 12px rgba(255,255,255,0.06);
+          position: relative; flex-shrink: 0;
+        }
+        .dx-mark::after { content: ""; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 10px; height: 10px; border-radius: 2px; background: #fff; box-shadow: 0 0 12px rgba(255,255,255,0.8); }
+        .dx-title-row h1 { font-family: var(--dx-display); font-weight: 700; font-size: 28px; letter-spacing: -0.025em; margin: 0; color: var(--dx-ink); }
+        .dx-meta { display: flex; align-items: center; gap: 14px; font-family: var(--dx-mono); font-size: 11.5px; font-weight: 500; color: var(--dx-ink-dim); letter-spacing: 0.08em; text-transform: uppercase; flex-wrap: wrap; }
+        .dx-meta .pip { width: 6px; height: 6px; border-radius: 50%; background: var(--dx-green); box-shadow: 0 0 8px var(--dx-green); animation: dx-pulse 2s ease-in-out infinite; }
+        .dx-meta .sep { width: 3px; height: 3px; border-radius: 50%; background: var(--dx-ink-mute); opacity: 0.6; }
+        @keyframes dx-pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.5; transform: scale(0.85); } }
 
-      {/* 프로젝트 목록 */}
-      <div className="bg-[#121214] border border-white/8 rounded-3xl overflow-hidden">
-        <div className="px-6 py-4 border-b border-white/8">
-          <p className="text-sm font-semibold">프로젝트 목록</p>
-        </div>
+        .dx-head-actions { display: flex; align-items: center; gap: 10px; }
+        .dx-btn {
+          display: inline-flex; align-items: center; gap: 8px;
+          padding: 10px 16px;
+          font-family: inherit;
+          font-size: 13px; font-weight: 600;
+          border-radius: 10px;
+          border: 1px solid var(--dx-line-2);
+          background: rgba(255,255,255,0.04);
+          color: var(--dx-ink);
+          cursor: pointer;
+          transition: background 160ms, border-color 160ms, transform 160ms;
+        }
+        .dx-btn:hover { background: rgba(255,255,255,0.08); border-color: var(--dx-line-3); }
+        .dx-btn-primary { background: linear-gradient(180deg, #ffffff, #e8eaf0); color: #0a0d14; border-color: #f3f4f8; }
+        .dx-btn-primary:hover { background: #fff; border-color: #fff; transform: translateY(-1px); box-shadow: 0 6px 24px -6px rgba(255,255,255,0.4), 0 0 24px -10px rgba(90,163,255,0.4); }
+        .dx-btn .arrow { transition: transform 200ms; }
+        .dx-btn:hover .arrow { transform: translateX(2px); }
 
-        {isLoading ? (
-          <div className="p-12 text-center text-[#9ca3af] text-sm">
-            로딩 중...
+        /* KPI */
+        .dx-kpi-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 36px; }
+        .dx-kpi {
+          position: relative;
+          padding: 22px 22px 20px;
+          border-radius: 14px;
+          border: 1px solid var(--dx-line-2);
+          background: linear-gradient(180deg, rgba(255,255,255,0.045), rgba(255,255,255,0.015));
+          overflow: hidden;
+          transition: border-color 220ms;
+        }
+        .dx-kpi:hover { border-color: var(--dx-line-3); }
+        .dx-kpi::before {
+          content: ""; position: absolute;
+          top: 0; left: 22px; right: 22px;
+          height: 1px;
+          background: linear-gradient(90deg, transparent, var(--dx-accent, rgba(255,255,255,0.5)), transparent);
+        }
+        .dx-kpi[data-accent="orange"] { --dx-accent: var(--dx-orange); }
+        .dx-kpi[data-accent="blue"]   { --dx-accent: var(--dx-blue); }
+        .dx-kpi[data-accent="green"]  { --dx-accent: var(--dx-green); }
+        .dx-kpi-label { display: flex; align-items: center; gap: 8px; font-family: var(--dx-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; color: var(--dx-ink-dim); margin-bottom: 14px; }
+        .dx-kpi-label .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--dx-accent, var(--dx-ink-mute)); box-shadow: 0 0 8px var(--dx-accent, transparent); }
+        .dx-kpi-value { display: flex; align-items: baseline; gap: 6px; font-family: var(--dx-display); font-weight: 700; font-size: 36px; letter-spacing: -0.025em; line-height: 1; color: var(--dx-ink); }
+        .dx-kpi-value .unit { font-family: inherit; font-size: 14px; color: var(--dx-ink-mute); font-weight: 500; }
+        .dx-kpi-foot { margin-top: 14px; font-family: var(--dx-mono); font-size: 11.5px; color: var(--dx-ink-dim); }
+        .dx-kpi-bar { margin-top: 12px; height: 3px; background: rgba(255,255,255,0.05); border-radius: 2px; overflow: hidden; }
+        .dx-kpi-bar .fill { height: 100%; background: var(--dx-accent, var(--dx-ink-mute)); border-radius: 2px; transition: width 600ms cubic-bezier(.22,.8,.18,1); box-shadow: 0 0 10px var(--dx-accent, transparent); }
+
+        /* Alert */
+        .dx-alert {
+          display: flex; gap: 10px; padding: 12px 14px;
+          border-radius: 10px;
+          border: 1px solid rgba(255,118,118,0.3);
+          background: rgba(255,118,118,0.06);
+          color: var(--dx-red);
+          font-size: 13px; line-height: 1.5;
+          margin-bottom: 24px;
+          align-items: center;
+        }
+        .dx-alert .ico { flex-shrink: 0; width: 18px; height: 18px; border-radius: 50%; background: rgba(255,118,118,0.18); display: grid; place-items: center; font-family: var(--dx-mono); font-weight: 700; font-size: 11px; }
+        .dx-alert .x { margin-left: auto; background: none; border: none; color: var(--dx-red); opacity: 0.6; cursor: pointer; font-family: var(--dx-mono); transition: opacity 160ms; }
+        .dx-alert .x:hover { opacity: 1; }
+
+        /* Table */
+        .dx-table-card { border: 1px solid var(--dx-line-2); border-radius: 16px; background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.008)); overflow: hidden; }
+        .dx-table-head { display: flex; align-items: center; justify-content: space-between; padding: 18px 22px; border-bottom: 1px solid var(--dx-line); background: rgba(255,255,255,0.01); gap: 12px; }
+        .dx-table-head .title { display: flex; align-items: baseline; gap: 12px; }
+        .dx-table-head .title h2 { font-family: var(--dx-display); font-weight: 700; font-size: 15px; margin: 0; letter-spacing: -0.015em; color: var(--dx-ink); }
+        .dx-count { font-family: var(--dx-mono); font-size: 11px; color: var(--dx-ink-dim); letter-spacing: 0.1em; padding: 3px 8px; border-radius: 100px; border: 1px solid var(--dx-line-2); background: rgba(255,255,255,0.04); }
+        .dx-filters { display: flex; gap: 6px; }
+        .dx-chip {
+          padding: 5px 12px;
+          font-family: var(--dx-mono);
+          font-size: 11.5px;
+          font-weight: 500;
+          letter-spacing: 0.05em;
+          color: var(--dx-ink-dim);
+          border: 1px solid var(--dx-line-2);
+          border-radius: 100px;
+          background: transparent;
+          cursor: pointer;
+          transition: color 160ms, background 160ms, border-color 160ms;
+        }
+        .dx-chip:hover { color: var(--dx-ink); border-color: var(--dx-line-3); }
+        .dx-chip.active { color: var(--dx-ink); background: rgba(255,255,255,0.09); border-color: var(--dx-line-3); }
+
+        .dx-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+        .dx-table thead th { text-align: left; padding: 14px 16px; font-family: var(--dx-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; color: var(--dx-ink-dim); background: rgba(255,255,255,0.025); border-bottom: 1px solid var(--dx-line-2); }
+        .dx-table thead th:first-child { padding-left: 22px; }
+        .dx-table thead th:last-child { padding-right: 22px; text-align: right; }
+        .dx-table tbody td { padding: 16px; border-bottom: 1px solid var(--dx-line); vertical-align: middle; }
+        .dx-table tbody td:first-child { padding-left: 22px; }
+        .dx-table tbody td:last-child { padding-right: 22px; }
+        .dx-table tbody tr { transition: background 140ms; cursor: pointer; }
+        .dx-table tbody tr:hover { background: rgba(255,255,255,0.025); }
+        .dx-table tbody tr:last-child td { border-bottom: none; }
+
+        .dx-proj .name { font-family: var(--dx-display); font-weight: 600; font-size: 14px; color: var(--dx-ink); letter-spacing: -0.01em; margin-bottom: 4px; }
+        .dx-proj .meta { font-family: var(--dx-mono); font-size: 11.5px; color: var(--dx-ink-dim); letter-spacing: 0.02em; display: flex; align-items: center; gap: 8px; }
+        .dx-proj .meta .dot-sep { width: 2px; height: 2px; border-radius: 50%; background: var(--dx-ink-mute); opacity: 0.6; }
+
+        .dx-env { display: inline-flex; align-items: center; padding: 4px 10px; font-family: var(--dx-mono); font-size: 10.5px; font-weight: 500; letter-spacing: 0.08em; text-transform: uppercase; border-radius: 100px; border: 1px solid var(--dx-line-2); background: rgba(255,255,255,0.02); color: var(--dx-ink-dim); }
+        .dx-env[data-env="prod"]       { color: var(--dx-orange); border-color: rgba(255,165,61,0.25);  background: rgba(255,165,61,0.05); }
+        .dx-env[data-env="production"] { color: var(--dx-orange); border-color: rgba(255,165,61,0.25);  background: rgba(255,165,61,0.05); }
+        .dx-env[data-env="stage"]      { color: var(--dx-yellow); border-color: rgba(245,208,97,0.25);  background: rgba(245,208,97,0.05); }
+        .dx-env[data-env="staging"]    { color: var(--dx-yellow); border-color: rgba(245,208,97,0.25);  background: rgba(245,208,97,0.05); }
+        .dx-env[data-env="dev"]        { color: var(--dx-blue);   border-color: rgba(90,163,255,0.25);  background: rgba(90,163,255,0.05); }
+        .dx-env[data-env="development"]{ color: var(--dx-blue);   border-color: rgba(90,163,255,0.25);  background: rgba(90,163,255,0.05); }
+
+        .dx-status { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 500; color: var(--dx-ink-dim); }
+        .dx-status .pip { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+        .dx-status[data-tone="green"]  { color: var(--dx-green); }
+        .dx-status[data-tone="green"] .pip  { background: var(--dx-green);  box-shadow: 0 0 8px var(--dx-green); }
+        .dx-status[data-tone="blue"]   { color: var(--dx-blue); }
+        .dx-status[data-tone="blue"] .pip   { background: var(--dx-blue);   box-shadow: 0 0 8px var(--dx-blue);   animation: dx-pulse 1.6s ease-in-out infinite; }
+        .dx-status[data-tone="red"]    { color: var(--dx-red); }
+        .dx-status[data-tone="red"] .pip    { background: var(--dx-red);    box-shadow: 0 0 8px var(--dx-red); }
+        .dx-status[data-tone="yellow"] { color: var(--dx-yellow); }
+        .dx-status[data-tone="yellow"] .pip { background: var(--dx-yellow); box-shadow: 0 0 8px var(--dx-yellow); }
+        .dx-status[data-tone="orange"] { color: var(--dx-orange); }
+        .dx-status[data-tone="orange"] .pip { background: var(--dx-orange); box-shadow: 0 0 8px var(--dx-orange); animation: dx-pulse 1.6s ease-in-out infinite; }
+        .dx-status[data-tone="mute"] .pip { background: var(--dx-ink-mute); }
+
+        .dx-ts { font-family: var(--dx-mono); font-size: 11.5px; color: var(--dx-ink-dim); letter-spacing: 0.01em; }
+        .dx-ts .dim { color: var(--dx-ink-mute); }
+
+        .dx-actions { display: flex; gap: 6px; justify-content: flex-end; align-items: center; }
+        .dx-ibtn {
+          width: 30px; height: 30px;
+          display: grid; place-items: center;
+          border-radius: 8px;
+          border: 1px solid var(--dx-line-2);
+          background: rgba(255,255,255,0.02);
+          color: var(--dx-ink-dim);
+          cursor: pointer;
+          transition: all 160ms;
+          padding: 0;
+        }
+        .dx-ibtn:hover { color: var(--dx-ink); border-color: var(--dx-line-3); background: rgba(255,255,255,0.05); }
+        .dx-ibtn[data-variant="blue"]:hover { color: var(--dx-blue); border-color: rgba(90,163,255,0.4); background: rgba(90,163,255,0.08); }
+        .dx-ibtn[data-variant="red"]:hover { color: var(--dx-red); border-color: rgba(255,118,118,0.4); background: rgba(255,118,118,0.08); }
+        .dx-ibtn[data-variant="orange"] { color: var(--dx-orange); border-color: rgba(255,165,61,0.3); background: rgba(255,165,61,0.06); }
+        .dx-ibtn[data-variant="orange"]:hover { background: rgba(255,165,61,0.15); border-color: rgba(255,165,61,0.5); }
+        .dx-ibtn:disabled { opacity: 0.35; cursor: not-allowed; }
+        .dx-ibtn:disabled:hover { color: var(--dx-ink-mute); border-color: var(--dx-line-2); background: rgba(255,255,255,0.02); }
+
+        .dx-confirm { display: flex; flex-direction: column; gap: 8px; align-items: flex-end; padding: 10px 12px; border-radius: 10px; border: 1px solid rgba(255,118,118,0.3); background: rgba(255,118,118,0.05); }
+        .dx-confirm-check { display: flex; align-items: center; gap: 8px; font-family: var(--dx-mono); font-size: 11px; color: var(--dx-ink-dim); cursor: pointer; user-select: none; letter-spacing: 0.02em; }
+        .dx-confirm-check input { display: none; }
+        .dx-confirm-check .cb { width: 14px; height: 14px; border-radius: 3px; border: 1px solid var(--dx-line-3); background: rgba(255,255,255,0.03); display: grid; place-items: center; transition: all 200ms; }
+        .dx-confirm-check .cb svg { opacity: 0; color: #fff; }
+        .dx-confirm-check input:checked + .cb { background: var(--dx-red); border-color: var(--dx-red); }
+        .dx-confirm-check input:checked + .cb svg { opacity: 1; }
+        .dx-confirm-btns { display: flex; gap: 6px; }
+        .dx-btn-danger { padding: 6px 12px; font-family: var(--dx-display); font-size: 11.5px; font-weight: 600; border-radius: 8px; border: 1px solid var(--dx-red); background: var(--dx-red); color: #fff; cursor: pointer; transition: filter 160ms; }
+        .dx-btn-danger:hover { filter: brightness(1.1); }
+        .dx-btn-ghost { padding: 6px 12px; font-family: inherit; font-size: 11.5px; font-weight: 500; border-radius: 8px; border: 1px solid var(--dx-line-2); background: transparent; color: var(--dx-ink-dim); cursor: pointer; transition: all 160ms; }
+        .dx-btn-ghost:hover { color: var(--dx-ink); background: rgba(255,255,255,0.05); }
+
+        .dx-empty { padding: 80px 24px; text-align: center; }
+        .dx-empty-mark { width: 56px; height: 56px; margin: 0 auto 18px; border-radius: 14px; border: 1px dashed var(--dx-line-3); display: grid; place-items: center; color: var(--dx-ink-mute); }
+        .dx-empty-title { font-family: var(--dx-display); font-weight: 600; font-size: 16px; color: var(--dx-ink); margin: 0 0 6px; letter-spacing: -0.01em; }
+        .dx-empty-sub { font-size: 13px; color: var(--dx-ink-dim); margin: 0 0 22px; }
+
+        .dx-loading { padding: 80px 24px; text-align: center; font-family: var(--dx-mono); font-size: 12px; letter-spacing: 0.15em; text-transform: uppercase; color: var(--dx-ink-mute); display: flex; align-items: center; justify-content: center; gap: 12px; }
+        .dx-loading .spinner { width: 14px; height: 14px; border-radius: 50%; border: 2px solid rgba(255,255,255,0.1); border-top-color: var(--dx-blue); animation: dx-spin 700ms linear infinite; }
+        @keyframes dx-spin { to { transform: rotate(360deg); } }
+
+        /* Toast */
+        .dx-toast {
+          position: fixed; bottom: 24px; right: 24px; z-index: 100;
+          min-width: 320px; max-width: 400px;
+          padding: 16px 18px;
+          border-radius: 14px;
+          border: 1px solid rgba(110,231,160,0.3);
+          background: linear-gradient(135deg, rgba(15,45,31,0.95), rgba(13,31,23,0.95));
+          backdrop-filter: blur(12px);
+          -webkit-backdrop-filter: blur(12px);
+          box-shadow: 0 20px 60px -20px rgba(0,0,0,0.6), 0 0 40px -10px rgba(110,231,160,0.2);
+          display: flex; gap: 12px;
+          overflow: hidden;
+          animation: dx-slideUp 300ms cubic-bezier(.22,.8,.18,1);
+        }
+        .dx-toast-ico { flex-shrink: 0; width: 32px; height: 32px; border-radius: 8px; background: rgba(110,231,160,0.15); border: 1px solid rgba(110,231,160,0.3); display: grid; place-items: center; color: var(--dx-green); }
+        .dx-toast-body { flex: 1; min-width: 0; }
+        .dx-toast-title { font-family: var(--dx-display); font-weight: 600; font-size: 14px; color: var(--dx-ink); margin: 0 0 4px; letter-spacing: -0.01em; }
+        .dx-toast-msg { font-size: 12.5px; color: var(--dx-green); margin: 0; line-height: 1.4; }
+        .dx-toast-x { background: none; border: none; color: var(--dx-ink-mute); cursor: pointer; font-family: var(--dx-mono); transition: color 160ms; flex-shrink: 0; }
+        .dx-toast-x:hover { color: var(--dx-ink); }
+        .dx-toast-bar { position: absolute; bottom: 0; left: 0; height: 2px; background: var(--dx-green); box-shadow: 0 0 8px var(--dx-green); animation: dx-shrink 4s linear forwards; }
+        @keyframes dx-slideUp { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+        @keyframes dx-shrink { from { width: 100%; } to { width: 0%; } }
+
+        @media (max-width: 1024px) {
+          .dx-kpi-grid { grid-template-columns: repeat(2, 1fr); }
+        }
+        @media (max-width: 720px) {
+          .dx-page { padding: 28px 20px 60px; }
+          .dx-head { flex-direction: column; align-items: stretch; gap: 16px; }
+          .dx-kpi-grid { grid-template-columns: 1fr 1fr; gap: 10px; }
+          .dx-kpi-value { font-size: 28px; }
+          .dx-table { font-size: 12px; }
+          .dx-table thead th, .dx-table tbody td { padding: 12px 10px; }
+          .dx-filters { display: none; }
+        }
+      `}</style>
+
+      <div className="dx-page">
+
+        {/* Page header */}
+        <div className="dx-head">
+          <div>
+            <div className="dx-title-row">
+              <span className="dx-mark"></span>
+              <h1>Dashboard</h1>
+            </div>
+            <div className="dx-meta">
+              <span className="pip"></span>
+              <span>All systems operational</span>
+              <span className="sep"></span>
+              <span>{nowText}</span>
+            </div>
           </div>
-        ) : projects.length === 0 ? (
-          <div className="p-12 text-center space-y-3">
-            <p className="text-[#9ca3af]">프로젝트가 없습니다.</p>
-            <button
-              onClick={() => router.push('/projects/new')}
-              className="px-4 py-2 bg-white/5 hover:bg-white/10 text-sm rounded-xl transition-colors"
-            >
-              + 새 프로젝트 만들기
+          <div className="dx-head-actions">
+            <button className="dx-btn" onClick={fetchProjects} disabled={isLoading}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/>
+              </svg>
+              새로고침
+            </button>
+            <button className="dx-btn dx-btn-primary" onClick={() => router.push('/projects/new')}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+                <path d="M12 5v14M5 12h14"/>
+              </svg>
+              새 프로젝트
+              <span className="arrow">→</span>
             </button>
           </div>
-        ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-white/8">
-                <th className="text-left px-6 py-3 text-xs text-[#9ca3af] font-semibold">프로젝트</th>
-                <th className="text-left px-4 py-3 text-xs text-[#9ca3af] font-semibold">환경</th>
-                <th className="text-left px-4 py-3 text-xs text-[#9ca3af] font-semibold">배포 상태</th>
-                <th className="text-left px-4 py-3 text-xs text-[#9ca3af] font-semibold">DR 상태</th>
-                <th className="text-left px-4 py-3 text-xs text-[#9ca3af] font-semibold">마지막 배포</th>
-                <th className="text-left px-4 py-3 text-xs text-[#9ca3af] font-semibold">바로가기</th>
-              </tr>
-            </thead>
-            <tbody>
-              {projects.map((p) => {
-                const deployConf         = STATUS_CONFIG[p.status]       ?? { text: p.status,    color: 'text-[#9ca3af]' }
-                const drConf             = DR_STATUS_CONFIG[p.dr_status] ?? { text: p.dr_status, color: 'text-[#9ca3af]' }
-                const isConfirmingDelete = deletingId === p.project_id
+        </div>
 
-                return (
-                  <tr
-                    key={p.project_id}
-                    className="border-b border-white/8 hover:bg-white/[0.04] cursor-pointer transition-colors"
-                    onClick={() => {
-                      if (isConfirmingDelete) return
-                      router.push(`/projects/${p.project_id}`)
-                    }}
-                  >
-                    <td className="px-6 py-4">
-                      <p className="font-medium">{p.name}</p>
-                      <p className="text-xs text-[#9ca3af] mt-0.5">
-                        {p.prefix}-{p.environment} · {p.region}
-                      </p>
-                    </td>
-                    <td className="px-4 py-4">
-                      <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-white/5 text-[#9ca3af]">
-                        {p.environment}
-                      </span>
-                    </td>
-                    <td className="px-4 py-4">
-                      <span className={`text-sm font-medium ${deployConf.color}`}>
-                        {deployConf.text}
-                      </span>
-                    </td>
-                    <td className="px-4 py-4">
-                      <span className={`text-sm font-medium ${drConf.color}`}>
-                        {drConf.text}
-                      </span>
-                    </td>
-                    <td className="px-4 py-4 text-[#9ca3af] text-xs">
-                      {p.last_deployed_at
-                        ? new Date(p.last_deployed_at).toLocaleString('ko-KR')
-                        : '-'}
-                    </td>
+        {/* KPI grid */}
+        <div className="dx-kpi-grid">
+          <div className="dx-kpi">
+            <div className="dx-kpi-label">
+              <span className="dot" style={{ background: 'rgba(255,255,255,0.5)', boxShadow: '0 0 8px rgba(255,255,255,0.3)' }}></span>
+              Projects
+            </div>
+            <div className="dx-kpi-value">
+              {projects.length}<span className="unit">개</span>
+            </div>
+            <div className="dx-kpi-foot">
+              {activeCount} active · {projects.length - activeCount} other
+            </div>
+          </div>
 
-                    {/* 바로가기 + 삭제 */}
-                    <td className="px-4 py-4">
-                      <div
-                        className="flex gap-2 items-center"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {!isConfirmingDelete && (
-                          <>
-                            <button
-                              onClick={() => router.push(`/projects/${p.project_id}/mirror`)}
-                              className="px-2.5 py-1 rounded-lg text-xs bg-white/5 hover:bg-white/10 text-[#9ca3af] hover:text-white transition-colors"
-                              title="MirrorOps DR 대시보드"
-                            >
-                              🪞 DR
-                            </button>
-                            <button
-                              onClick={() => router.push(`/projects/${p.project_id}/failover`)}
-                              className={`px-2.5 py-1 rounded-lg text-xs transition-colors ${
-                                p.dr_status === 'ready'
-                                  ? 'bg-red-600/20 hover:bg-red-600/40 text-red-400'
-                                  : 'bg-white/5 hover:bg-white/10 text-[#9ca3af]'
-                              }`}
-                              title="페일오버 콘솔"
-                            >
-                              🔴
-                            </button>
-                            <button
-                              onClick={() => setDeletingId(p.project_id)}
-                              className="px-2.5 py-1 rounded-lg text-xs bg-white/5 hover:bg-red-500/20 text-[#9ca3af] hover:text-red-400 transition-colors"
-                              title="프로젝트 삭제"
-                            >
-                              🗑️
-                            </button>
-                          </>
-                        )}
+          <div className="dx-kpi" data-accent="orange">
+            <div className="dx-kpi-label">
+              <span className="dot"></span>
+              AWS Resources · CraftOps
+            </div>
+            <div className="dx-kpi-value">
+              {totalAws}<span className="unit">개</span>
+            </div>
+            <div className="dx-kpi-foot">{regionsText}</div>
+          </div>
 
-                        {/* 삭제 확인 단계 */}
-                        {isConfirmingDelete && (
-                          <div className="flex flex-col gap-1.5">
-                            <label className="flex items-center gap-1.5 text-xs text-[#9ca3af] cursor-pointer">
-                              <input
-                                type="checkbox"
-                                checked={destroyAws}
-                                onChange={(e) => setDestroyAws(e.target.checked)}
-                                className="accent-red-500"
-                              />
-                              AWS 리소스도 삭제
-                            </label>
-                            <div className="flex gap-1">
-                              <button
-                                onClick={() => handleDelete(p.project_id)}
-                                className="px-2.5 py-1 rounded-lg text-xs bg-red-600 hover:bg-red-700 text-white transition-colors"
-                              >
-                                삭제
-                              </button>
-                              <button
-                                onClick={() => {
-                                  setDeletingId(null)
-                                  setDestroyAws(false)
-                                }}
-                                className="px-2.5 py-1 rounded-lg text-xs bg-white/5 hover:bg-white/10 text-[#9ca3af] transition-colors"
-                              >
-                                취소
-                              </button>
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+          <div className="dx-kpi" data-accent="blue">
+            <div className="dx-kpi-label">
+              <span className="dot"></span>
+              GCP DR · MirrorOps
+            </div>
+            <div className="dx-kpi-value">
+              {totalDrLive}<span className="unit">/ {totalDrAvail}</span>
+            </div>
+            <div className="dx-kpi-foot">{drReadyCount} of {projects.length} mirrored</div>
+          </div>
+
+          <div className="dx-kpi" data-accent="green">
+            <div className="dx-kpi-label">
+              <span className="dot"></span>
+              DR Ready Rate
+            </div>
+            <div className="dx-kpi-value">
+              {drReadyRate}<span className="unit">%</span>
+            </div>
+            <div className="dx-kpi-bar">
+              <div className="fill" style={{ width: `${drReadyRate}%` }} />
+            </div>
+          </div>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="dx-alert" role="alert">
+            <span className="ico">!</span>
+            <span>{error}</span>
+            <button className="x" onClick={() => setError(null)} aria-label="닫기">✕</button>
+          </div>
         )}
+
+        {/* Projects table */}
+        <div className="dx-table-card">
+          <div className="dx-table-head">
+            <div className="title">
+              <h2>프로젝트 목록</h2>
+              <span className="dx-count">{filtered.length} {filter === 'all' ? 'total' : filter}</span>
+            </div>
+            <div className="dx-filters">
+              {(['all', 'active', 'deploying', 'failed'] as FilterKey[]).map((k) => (
+                <button
+                  key={k}
+                  className={`dx-chip ${filter === k ? 'active' : ''}`}
+                  onClick={() => setFilter(k)}
+                >
+                  {k === 'all' ? 'All' : k === 'active' ? 'Active' : k === 'deploying' ? 'Deploying' : 'Failed'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {isLoading ? (
+            <div className="dx-loading">
+              <span className="spinner"></span>
+              <span>loading projects</span>
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="dx-empty">
+              <div className="dx-empty-mark">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                  <rect x="3" y="3" width="7" height="7" rx="1"/>
+                  <rect x="14" y="3" width="7" height="7" rx="1"/>
+                  <rect x="3" y="14" width="7" height="7" rx="1"/>
+                  <rect x="14" y="14" width="7" height="7" rx="1"/>
+                </svg>
+              </div>
+              <h3 className="dx-empty-title">
+                {projects.length === 0 ? '아직 프로젝트가 없습니다' : `이 조건에 맞는 프로젝트가 없습니다`}
+              </h3>
+              <p className="dx-empty-sub">
+                {projects.length === 0
+                  ? '첫 프로젝트를 만들고 AWS·GCP 듀얼 환경을 시작해보세요.'
+                  : '다른 필터를 선택해보세요.'}
+              </p>
+              {projects.length === 0 && (
+                <button className="dx-btn dx-btn-primary" onClick={() => router.push('/projects/new')}>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+                    <path d="M12 5v14M5 12h14"/>
+                  </svg>
+                  새 프로젝트 만들기
+                </button>
+              )}
+            </div>
+          ) : (
+            <table className="dx-table">
+              <thead>
+                <tr>
+                  <th>프로젝트</th>
+                  <th>환경</th>
+                  <th>배포 상태</th>
+                  <th>DR 상태</th>
+                  <th>마지막 배포</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((p) => {
+                  const deployConf = STATUS_CONFIG[p.status]       ?? { text: p.status,    tone: 'mute' as Tone }
+                  const drConf     = DR_STATUS_CONFIG[p.dr_status] ?? { text: p.dr_status, tone: 'mute' as Tone }
+                  const isConfirmingDelete = deletingId === p.project_id
+                  const drReady = p.dr_status === 'ready'
+
+                  // format last_deployed_at as: YYYY-MM-DD HH:MM
+                  let dateStr = '—'
+                  let timeStr = ''
+                  if (p.last_deployed_at) {
+                    const d = new Date(p.last_deployed_at)
+                    const pad = (n: number) => String(n).padStart(2, '0')
+                    dateStr = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+                    timeStr = `${pad(d.getHours())}:${pad(d.getMinutes())}`
+                  }
+
+                  return (
+                    <tr
+                      key={p.project_id}
+                      onClick={() => {
+                        if (isConfirmingDelete) return
+                        router.push(`/projects/${p.project_id}`)
+                      }}
+                    >
+                      <td>
+                        <div className="dx-proj">
+                          <div className="name">{p.name}</div>
+                          <div className="meta">
+                            <span>{p.prefix}-{p.environment}</span>
+                            <span className="dot-sep"></span>
+                            <span>{p.region}</span>
+                          </div>
+                        </div>
+                      </td>
+                      <td>
+                        <span className="dx-env" data-env={p.environment}>{p.environment}</span>
+                      </td>
+                      <td>
+                        <span className="dx-status" data-tone={deployConf.tone}>
+                          <span className="pip"></span>
+                          {deployConf.text}
+                        </span>
+                      </td>
+                      <td>
+                        <span className="dx-status" data-tone={drConf.tone}>
+                          <span className="pip"></span>
+                          {drConf.text}
+                        </span>
+                      </td>
+                      <td>
+                        <span className="dx-ts">
+                          {dateStr}{timeStr && <> <span className="dim">{timeStr}</span></>}
+                        </span>
+                      </td>
+                      <td>
+                        <div className="dx-actions" onClick={(e) => e.stopPropagation()}>
+                          {!isConfirmingDelete ? (
+                            <>
+                              <button
+                                className="dx-ibtn"
+                                data-variant="blue"
+                                title="MirrorOps DR 대시보드"
+                                onClick={() => router.push(`/projects/${p.project_id}/mirror`)}
+                              >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                                  <rect x="3" y="3" width="18" height="18" rx="2"/>
+                                  <path d="M12 3v18"/>
+                                </svg>
+                              </button>
+                              <button
+                                className="dx-ibtn"
+                                data-variant="orange"
+                                disabled={!drReady}
+                                title={drReady ? '페일오버 콘솔' : 'DR이 준비되어야 페일오버 가능'}
+                                onClick={() => router.push(`/projects/${p.project_id}/failover`)}
+                              >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                                  <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
+                                </svg>
+                              </button>
+                              <button
+                                className="dx-ibtn"
+                                data-variant="red"
+                                title="프로젝트 삭제"
+                                onClick={() => setDeletingId(p.project_id)}
+                              >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                                  <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/>
+                                </svg>
+                              </button>
+                            </>
+                          ) : (
+                            <div className="dx-confirm">
+                              <label className="dx-confirm-check">
+                                <input
+                                  type="checkbox"
+                                  checked={destroyAws}
+                                  onChange={(e) => setDestroyAws(e.target.checked)}
+                                />
+                                <span className="cb">
+                                  <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                                    <polyline points="20 6 9 17 4 12"/>
+                                  </svg>
+                                </span>
+                                AWS 리소스도 삭제
+                              </label>
+                              <div className="dx-confirm-btns">
+                                <button
+                                  className="dx-btn-ghost"
+                                  onClick={() => { setDeletingId(null); setDestroyAws(false) }}
+                                >
+                                  취소
+                                </button>
+                                <button
+                                  className="dx-btn-danger"
+                                  onClick={() => handleDelete(p.project_id)}
+                                >
+                                  영구 삭제
+                                </button>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
       </div>
-    </div>
+
+      {/* Toast */}
+      {toast && <DeployToast data={toast} onClose={closeToast} />}
+    </>
   )
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,65 +1,713 @@
-import Image from "next/image";
+// frontend/app/page.tsx
+'use client'
 
-export default function Home() {
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function LandingPage() {
+  const router = useRouter()
+
+  // 파티클 생성
+  useEffect(() => {
+    const container = document.getElementById('particles')
+    if (!container) return
+    const n = 28
+    for (let i = 0; i < n; i++) {
+      const s = document.createElement('span')
+      s.style.cssText = `
+        position:absolute;
+        width:2px;height:2px;border-radius:50%;
+        left:${Math.random() * 100}%;
+        top:${Math.random() * 100}%;
+        animation-delay:${Math.random() * 9}s;
+        animation-duration:${7 + Math.random() * 5}s;
+        opacity:${0.3 + Math.random() * 0.5};
+        animation-name:drift;
+        animation-timing-function:linear;
+        animation-iteration-count:infinite;
+      `
+      const isBlue = Math.random() > 0.6
+      if (isBlue) {
+        s.style.background = '#5aa3ff'
+        s.style.boxShadow = '0 0 8px rgba(90,163,255,0.8)'
+      } else if (Math.random() > 0.6) {
+        s.style.background = '#ffa53d'
+        s.style.boxShadow = '0 0 8px rgba(255,165,61,0.8)'
+      } else {
+        s.style.background = 'rgba(255,255,255,0.55)'
+        s.style.boxShadow = '0 0 8px rgba(255,255,255,0.7)'
+      }
+      container.appendChild(s)
+    }
+    return () => { if (container) container.innerHTML = '' }
+  }, [])
+
+  // 스무스 스크롤
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id)
+    if (!el) return
+    window.scrollTo({ top: el.getBoundingClientRect().top + window.scrollY - 60, behavior: 'smooth' })
+  }
+
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+    <>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+        :root {
+          --bg: #07090f;
+          --bg-2: #0b0e16;
+          --ink: #e7ebf3;
+          --ink-dim: #8b93a7;
+          --ink-mute: #4b5267;
+          --line: rgba(255,255,255,0.06);
+          --line-2: rgba(255,255,255,0.10);
+          --orange: #ffa53d;
+          --orange-deep: #f5871f;
+          --blue: #5aa3ff;
+          --blue-deep: #3d7eea;
+          --display: 'Plus Jakarta Sans', -apple-system, sans-serif;
+          --mono: 'JetBrains Mono', ui-monospace, monospace;
+        }
+        * { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; }
+        body {
+          background: var(--bg);
+          color: var(--ink);
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+          -webkit-font-smoothing: antialiased;
+          overflow-x: hidden;
+        }
+        a { color: inherit; text-decoration: none; }
+        button { font-family: inherit; cursor: pointer; }
+
+        /* NAV */
+        .nav {
+          position: fixed; inset: 0 0 auto 0;
+          z-index: 60;
+          display: flex; align-items: center; justify-content: space-between;
+          padding: 18px 36px;
+          backdrop-filter: blur(14px) saturate(140%);
+          background: linear-gradient(180deg, rgba(7,9,15,0.75) 0%, rgba(7,9,15,0.35) 80%, rgba(7,9,15,0));
+        }
+        .brand {
+          display: flex; align-items: center; gap: 10px;
+          font-family: var(--display);
+          font-weight: 800; font-size: 17px; letter-spacing: -0.02em;
+        }
+        .brand-mark {
+          width: 26px; height: 26px;
+          display: grid; place-items: center;
+          border-radius: 7px;
+          background:
+            radial-gradient(80% 80% at 30% 25%, rgba(255,165,61,0.7), transparent 60%),
+            radial-gradient(80% 80% at 70% 80%, rgba(90,163,255,0.7), transparent 60%),
+            #11151f;
+          border: 1px solid rgba(255,255,255,0.08);
+          box-shadow: 0 4px 24px rgba(90,163,255,0.18), inset 0 0 12px rgba(255,255,255,0.06);
+        }
+        .brand-mark::after {
+          content: ""; width: 9px; height: 9px;
+          border-radius: 2px; background: #fff;
+          box-shadow: 0 0 12px rgba(255,255,255,0.8);
+        }
+        .nav-links {
+          display: flex; align-items: center; gap: 28px;
+          font-size: 13px; color: var(--ink-dim); font-weight: 500;
+        }
+        .nav-links a { transition: color 160ms; }
+        .nav-links a:hover { color: var(--ink); }
+        .nav-cta { display: flex; gap: 10px; align-items: center; }
+        .btn {
+          display: inline-flex; align-items: center; gap: 8px;
+          padding: 9px 16px; font-size: 13px; font-weight: 600;
+          border-radius: 8px; border: 1px solid var(--line-2);
+          background: rgba(255,255,255,0.04); color: var(--ink);
+          transition: background 160ms, border-color 160ms, transform 160ms;
+          cursor: pointer;
+        }
+        .btn:hover { background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.18); }
+        .btn-primary { background: #f3f4f8; color: #0a0d14; border-color: #f3f4f8; }
+        .btn-primary:hover { background: #fff; border-color: #fff; transform: translateY(-1px); }
+        .btn .arrow { transition: transform 200ms; display: inline-block; }
+        .btn:hover .arrow { transform: translateX(3px); }
+
+        /* HERO */
+        .hero {
+          position: relative; height: 100vh; min-height: 720px;
+          display: grid; place-items: center;
+          overflow: hidden; isolation: isolate;
+        }
+        .grid-bg {
+          position: absolute; inset: 0;
+          background-image:
+            linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+          background-size: 56px 56px;
+          mask-image: radial-gradient(ellipse 90% 70% at 50% 50%, #000 35%, transparent 75%);
+          -webkit-mask-image: radial-gradient(ellipse 90% 70% at 50% 50%, #000 35%, transparent 75%);
+          opacity: 0.55; z-index: 0;
+        }
+        .vignette {
+          position: absolute; inset: 0;
+          background: radial-gradient(ellipse 70% 60% at 50% 50%, transparent 0%, rgba(7,9,15,0.6) 70%, rgba(7,9,15,0.95) 100%);
+          z-index: 1; pointer-events: none;
+        }
+        .orbit {
+          position: absolute; top: 50%; left: 50%;
+          width: min(640px, 60vw); aspect-ratio: 1;
+          transform: translate(-50%, -50%);
+          border-radius: 50%; border: 1px dashed rgba(255,255,255,0.08);
+          z-index: 1; animation: spin 60s linear infinite;
+        }
+        .orbit::before, .orbit::after {
+          content: ""; position: absolute;
+          border-radius: 50%; border: 1px dashed rgba(255,255,255,0.06);
+        }
+        .orbit::before { inset: -50px; }
+        .orbit::after  { inset: -110px; border-color: rgba(255,255,255,0.04); }
+        @keyframes spin { to { transform: translate(-50%, -50%) rotate(360deg); } }
+
+        .particles { position: absolute; inset: 0; z-index: 1; pointer-events: none; }
+        @keyframes drift {
+          0%   { transform: translate(0, 20px); opacity: 0; }
+          15%  { opacity: 1; }
+          85%  { opacity: 1; }
+          100% { transform: translate(0, -120px); opacity: 0; }
+        }
+
+        .streams { position: absolute; inset: 0; width: 100%; height: 100%; z-index: 2; pointer-events: none; }
+        .stream-path {
+          fill: none; stroke-linecap: round; filter: url(#glow);
+          stroke-dasharray: 1400; stroke-dashoffset: 1400;
+          animation: draw 2.4s 0.3s cubic-bezier(.22,.8,.18,1) forwards, flow 8s 3s linear infinite;
+        }
+        .stream-orange { stroke: var(--orange); stroke-width: 2.2; }
+        .stream-orange-thin { stroke: var(--orange); stroke-width: 1; opacity: 0.55; }
+        .stream-blue { stroke: var(--blue); stroke-width: 2.2; animation-delay: 0.5s, 3.2s; }
+        .stream-blue-thin { stroke: var(--blue); stroke-width: 1; opacity: 0.55; animation-delay: 0.5s, 3.2s; }
+        @keyframes draw { to { stroke-dashoffset: 0; } }
+        @keyframes flow {
+          0%   { stroke-dasharray: 12 28; stroke-dashoffset: 0; }
+          100% { stroke-dasharray: 12 28; stroke-dashoffset: -160; }
+        }
+
+        .hero-inner { position: relative; z-index: 5; text-align: center; padding: 0 24px; }
+        .eyebrow {
+          display: inline-flex; align-items: center; gap: 10px;
+          font-family: var(--mono); font-size: 11.5px; font-weight: 500;
+          letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-dim);
+          padding: 7px 14px; border: 1px solid var(--line-2); border-radius: 100px;
+          background: rgba(255,255,255,0.03); margin-bottom: 36px;
+          opacity: 0; animation: rise 800ms 100ms cubic-bezier(.22,.8,.18,1) forwards;
+        }
+        .eyebrow .dot {
+          width: 6px; height: 6px; border-radius: 50%;
+          background: #6ee7a0; box-shadow: 0 0 8px #6ee7a0;
+          animation: pulse 2s ease-in-out infinite;
+        }
+        @keyframes pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.5; transform: scale(0.85); } }
+
+        .wordmark {
+          font-family: var(--display); font-weight: 800;
+          font-size: clamp(72px, 14vw, 200px);
+          line-height: 0.95; letter-spacing: -0.045em;
+          margin: 0; color: #fff;
+          text-shadow: 0 0 30px rgba(255,255,255,0.35), 0 0 80px rgba(255,255,255,0.22), 0 0 160px rgba(90,163,255,0.18);
+          opacity: 0; animation: glowIn 1400ms 300ms cubic-bezier(.22,.8,.18,1) forwards;
+        }
+        @keyframes glowIn {
+          0%   { opacity: 0; letter-spacing: 0.04em; filter: blur(20px); }
+          60%  { opacity: 1; }
+          100% { opacity: 1; letter-spacing: -0.045em; filter: blur(0); }
+        }
+
+        .tagline {
+          margin: 28px auto 0;
+          font-size: clamp(15px, 1.4vw, 19px); color: var(--ink-dim);
+          font-weight: 500; letter-spacing: -0.01em; line-height: 1.6;
+          max-width: 560px;
+          opacity: 0; animation: rise 800ms 900ms cubic-bezier(.22,.8,.18,1) forwards;
+        }
+        .tagline strong { color: var(--ink); font-weight: 600; }
+
+        .hero-cta {
+          display: flex; gap: 12px; justify-content: center; margin-top: 40px;
+          opacity: 0; animation: rise 800ms 1100ms cubic-bezier(.22,.8,.18,1) forwards;
+        }
+        .hero-cta .btn { padding: 12px 20px; font-size: 14px; }
+
+        @keyframes rise {
+          0%   { opacity: 0; transform: translateY(14px); }
+          100% { opacity: 1; transform: translateY(0); }
+        }
+
+        .corner {
+          position: absolute; z-index: 5;
+          font-family: var(--mono); font-size: 12px; font-weight: 500;
+          letter-spacing: 0.02em; display: flex; align-items: center; gap: 10px;
+          opacity: 0; animation: rise 900ms 1500ms cubic-bezier(.22,.8,.18,1) forwards;
+        }
+        .corner .pip { width: 7px; height: 7px; border-radius: 50%; box-shadow: 0 0 10px currentColor; }
+        .corner-tr { top: 90px; right: 36px; color: var(--blue); }
+        .corner-bl { bottom: 32px; left: 36px; color: var(--orange); }
+        .corner-br { bottom: 32px; right: 36px; color: var(--ink-mute); font-weight: 400; letter-spacing: 0.1em; }
+
+        .scroll-hint {
+          position: absolute; bottom: 28px; left: 50%; transform: translateX(-50%);
+          z-index: 5; font-family: var(--mono); font-size: 10.5px;
+          letter-spacing: 0.2em; text-transform: uppercase; color: var(--ink-mute);
+          display: flex; flex-direction: column; align-items: center; gap: 8px;
+          opacity: 0; animation: rise 900ms 1800ms cubic-bezier(.22,.8,.18,1) forwards;
+        }
+        .scroll-hint .line {
+          width: 1px; height: 28px;
+          background: linear-gradient(180deg, rgba(255,255,255,0.4), transparent);
+          animation: drop 2s ease-in-out infinite;
+        }
+        @keyframes drop {
+          0%, 100% { transform: scaleY(1); transform-origin: top; opacity: 0.4; }
+          50% { transform: scaleY(1.4); opacity: 1; }
+        }
+
+        /* SECTION */
+        .section { position: relative; padding: 140px 36px; max-width: 1200px; margin: 0 auto; }
+        .section-head { margin-bottom: 64px; max-width: 720px; }
+        .section-tag {
+          font-family: var(--mono); font-size: 11.5px; font-weight: 500;
+          letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute);
+          display: inline-flex; align-items: center; gap: 10px; margin-bottom: 18px;
+        }
+        .section-tag::before { content: ""; width: 18px; height: 1px; background: currentColor; }
+        .section-title {
+          font-family: var(--display); font-size: clamp(32px, 4vw, 52px);
+          font-weight: 700; line-height: 1.1; letter-spacing: -0.03em;
+          margin: 0 0 18px; color: var(--ink);
+        }
+        .section-sub { font-size: 16px; color: var(--ink-dim); line-height: 1.65; max-width: 560px; margin: 0; }
+
+        /* CAP GRID */
+        .cap-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+        .cap {
+          position: relative; padding: 32px; border-radius: 16px;
+          border: 1px solid var(--line);
+          background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.01));
+          transition: border-color 220ms, transform 220ms;
+          overflow: hidden; min-height: 320px;
+          display: flex; flex-direction: column;
+        }
+        .cap:hover { border-color: var(--line-2); transform: translateY(-2px); }
+        .cap::before {
+          content: ""; position: absolute; top: 0; left: 0; right: 0; height: 1px;
+          background: linear-gradient(90deg, transparent, var(--accent, #fff), transparent);
+          opacity: 0.5;
+        }
+        .cap[data-accent="orange"] { --accent: var(--orange); }
+        .cap[data-accent="blue"]   { --accent: var(--blue); }
+        .cap[data-accent="white"]  { --accent: rgba(255,255,255,0.4); }
+        .cap-icon {
+          width: 40px; height: 40px; border-radius: 10px;
+          background: rgba(255,255,255,0.03); border: 1px solid var(--line-2);
+          display: grid; place-items: center; margin-bottom: 22px;
+          color: var(--accent); font-family: var(--mono); font-size: 16px; font-weight: 600;
+        }
+        .cap-label { font-family: var(--mono); font-size: 11px; font-weight: 500; letter-spacing: 0.15em; text-transform: uppercase; color: var(--accent); margin-bottom: 8px; }
+        .cap-name { font-family: var(--display); font-size: 24px; font-weight: 700; letter-spacing: -0.02em; color: var(--ink); margin: 0 0 12px; }
+        .cap-desc { font-size: 14px; color: var(--ink-dim); line-height: 1.65; margin: 0 0 22px; }
+        .cap-meta {
+          margin-top: auto; display: flex; flex-direction: column; gap: 6px;
+          padding-top: 18px; border-top: 1px dashed var(--line);
+          font-family: var(--mono); font-size: 11.5px; color: var(--ink-mute);
+        }
+        .cap-meta div { display: flex; justify-content: space-between; }
+        .cap-meta span:last-child { color: var(--ink-dim); }
+
+        /* FLOW */
+        .flow-section { background: linear-gradient(180deg, transparent, rgba(255,255,255,0.015), transparent); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+        .flow { display: grid; grid-template-columns: repeat(6, 1fr); gap: 0; position: relative; margin-top: 32px; }
+        .flow-step {
+          position: relative; padding: 28px 18px; border-right: 1px dashed var(--line);
+          text-align: center; transition: background 200ms;
+        }
+        .flow-step:last-child { border-right: none; }
+        .flow-step:hover { background: rgba(255,255,255,0.02); }
+        .flow-num { font-family: var(--mono); font-size: 10.5px; color: var(--ink-mute); letter-spacing: 0.18em; margin-bottom: 10px; }
+        .flow-glyph {
+          width: 44px; height: 44px; margin: 0 auto 16px; border-radius: 12px;
+          background: rgba(255,255,255,0.03); border: 1px solid var(--line-2);
+          display: grid; place-items: center; color: var(--ink);
+        }
+        .flow-step[data-tone="orange"] .flow-glyph { color: var(--orange); border-color: rgba(255,165,61,0.25); background: rgba(255,165,61,0.05); }
+        .flow-step[data-tone="blue"]   .flow-glyph { color: var(--blue);   border-color: rgba(90,163,255,0.25);  background: rgba(90,163,255,0.06); }
+        .flow-name { font-family: var(--display); font-weight: 700; font-size: 14px; letter-spacing: -0.01em; color: var(--ink); margin-bottom: 4px; }
+        .flow-sub  { font-family: var(--mono); font-size: 10.5px; color: var(--ink-mute); letter-spacing: 0.05em; }
+
+        /* SPLIT */
+        .split { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }
+        .cloud {
+          position: relative; padding: 40px 32px; border-radius: 18px;
+          border: 1px solid var(--line);
+          background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
+          overflow: hidden; min-height: 360px;
+        }
+        .cloud-orange {
+          background: radial-gradient(ellipse 60% 50% at 100% 0%, rgba(255,165,61,0.10), transparent 60%), linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
+          border-color: rgba(255,165,61,0.18);
+        }
+        .cloud-blue {
+          background: radial-gradient(ellipse 60% 50% at 0% 0%, rgba(90,163,255,0.10), transparent 60%), linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
+          border-color: rgba(90,163,255,0.18);
+        }
+        .cloud-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 28px; }
+        .cloud-badge { font-family: var(--mono); font-size: 11px; font-weight: 500; letter-spacing: 0.16em; text-transform: uppercase; padding: 6px 12px; border-radius: 100px; border: 1px solid; }
+        .cloud-orange .cloud-badge { color: var(--orange); border-color: rgba(255,165,61,0.3); background: rgba(255,165,61,0.06); }
+        .cloud-blue   .cloud-badge { color: var(--blue);   border-color: rgba(90,163,255,0.3);  background: rgba(90,163,255,0.06); }
+        .cloud-status { font-family: var(--mono); font-size: 11.5px; color: var(--ink-dim); display: flex; align-items: center; gap: 8px; }
+        .cloud-status .pip { width: 7px; height: 7px; border-radius: 50%; background: #6ee7a0; box-shadow: 0 0 10px #6ee7a0; animation: pulse 2s ease-in-out infinite; }
+        .cloud-status.standby .pip { background: var(--blue); box-shadow: 0 0 10px var(--blue); }
+        .cloud-title { font-family: var(--display); font-size: 28px; font-weight: 700; letter-spacing: -0.02em; margin: 0 0 8px; }
+        .cloud-desc { color: var(--ink-dim); font-size: 14px; line-height: 1.65; margin: 0 0 28px; max-width: 380px; }
+        .cloud-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; padding-top: 24px; border-top: 1px dashed var(--line); }
+        .cloud-stat .label { font-family: var(--mono); font-size: 10.5px; color: var(--ink-mute); letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 6px; }
+        .cloud-stat .value { font-family: var(--display); font-size: 22px; font-weight: 700; color: var(--ink); letter-spacing: -0.02em; }
+        .cloud-stat .value small { font-size: 12px; color: var(--ink-mute); font-weight: 500; margin-left: 3px; }
+
+        /* TERMINAL */
+        .showcase { margin-top: 56px; border: 1px solid var(--line); border-radius: 16px; background: linear-gradient(180deg, #0a0d14, #07090f); overflow: hidden; }
+        .term-bar { display: flex; align-items: center; gap: 8px; padding: 12px 16px; border-bottom: 1px solid var(--line); background: rgba(255,255,255,0.015); }
+        .term-bar .dots { display: flex; gap: 6px; }
+        .term-bar .dots span { width: 11px; height: 11px; border-radius: 50%; background: rgba(255,255,255,0.1); }
+        .term-bar .title { font-family: var(--mono); font-size: 12px; color: var(--ink-mute); margin-left: 8px; }
+        .term-bar .status { margin-left: auto; font-family: var(--mono); font-size: 11px; color: var(--ink-mute); display: flex; align-items: center; gap: 8px; }
+        .term-bar .status .pip { width: 6px; height: 6px; border-radius: 50%; background: #6ee7a0; box-shadow: 0 0 8px #6ee7a0; animation: pulse 2s ease-in-out infinite; }
+        .term-body { padding: 28px 28px 32px; font-family: var(--mono); font-size: 13.5px; line-height: 1.85; color: var(--ink); }
+        .term-line { display: flex; gap: 12px; }
+        .term-line .prompt { color: var(--orange); flex-shrink: 0; }
+        .term-line.user .text { color: var(--ink); }
+        .term-line.sys .prompt { color: var(--ink-mute); }
+        .term-line.sys .text { color: var(--ink-dim); }
+        .term-line.ok .prompt  { color: #6ee7a0; }
+        .term-line.ok .text    { color: var(--ink-dim); }
+        .term-line.blue .prompt { color: var(--blue); }
+        .term-line.blue .text   { color: var(--ink-dim); }
+        .caret { display: inline-block; width: 7px; height: 1em; background: var(--ink); vertical-align: -2px; margin-left: 4px; animation: blink 1s steps(2) infinite; }
+        @keyframes blink { 50% { opacity: 0; } }
+
+        /* CTA */
+        .cta-strip { position: relative; padding: 120px 36px; text-align: center; overflow: hidden; }
+        .cta-strip::before {
+          content: ""; position: absolute; inset: 0;
+          background: radial-gradient(ellipse 50% 70% at 20% 50%, rgba(255,165,61,0.10), transparent 60%), radial-gradient(ellipse 50% 70% at 80% 50%, rgba(90,163,255,0.10), transparent 60%);
+          pointer-events: none;
+        }
+        .cta-strip h2 { font-family: var(--display); font-size: clamp(34px, 5vw, 64px); font-weight: 800; line-height: 1.05; letter-spacing: -0.035em; margin: 0 auto 20px; max-width: 820px; color: #fff; position: relative; }
+        .cta-strip p { color: var(--ink-dim); font-size: 16px; line-height: 1.6; max-width: 520px; margin: 0 auto 36px; position: relative; }
+        .cta-strip .btns { display: flex; gap: 12px; justify-content: center; position: relative; }
+        .cta-strip .btn { padding: 13px 22px; font-size: 14px; }
+
+        /* FOOTER */
+        footer { padding: 48px 36px 56px; border-top: 1px solid var(--line); display: flex; justify-content: space-between; align-items: flex-start; gap: 32px; flex-wrap: wrap; max-width: 1200px; margin: 0 auto; }
+        .foot-brand { display: flex; flex-direction: column; gap: 12px; }
+        .foot-brand .brand { font-size: 16px; }
+        .foot-brand .copy { font-family: var(--mono); font-size: 11.5px; color: var(--ink-mute); letter-spacing: 0.04em; }
+        .foot-cols { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 48px; }
+        .foot-col h4 { font-family: var(--mono); font-size: 10.5px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute); margin: 0 0 14px; }
+        .foot-col ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+        .foot-col a { font-size: 13px; color: var(--ink-dim); transition: color 160ms; }
+        .foot-col a:hover { color: var(--ink); }
+
+        @media (max-width: 980px) {
+          .nav-links { display: none; }
+          .cap-grid { grid-template-columns: 1fr; }
+          .flow { grid-template-columns: repeat(2, 1fr); }
+          .flow-step { border-right: 1px dashed var(--line); border-bottom: 1px dashed var(--line); }
+          .flow-step:nth-child(2n) { border-right: none; }
+          .split { grid-template-columns: 1fr; }
+          .foot-cols { grid-template-columns: 1fr 1fr; gap: 28px; }
+          .corner-bl, .corner-tr { font-size: 10.5px; }
+          .corner-tr { top: 80px; right: 18px; }
+          .corner-bl { bottom: 18px; left: 18px; }
+          .corner-br { display: none; }
+          .section { padding: 90px 24px; }
+        }
+      `}</style>
+
+      {/* NAV */}
+      <nav className="nav">
+        <a className="brand" href="#top">
+          <span className="brand-mark"></span>
+          AutoOps
+        </a>
+        <div className="nav-links">
+          <a href="#platform" onClick={(e) => { e.preventDefault(); scrollTo('platform') }}>플랫폼</a>
+          <a href="#flow" onClick={(e) => { e.preventDefault(); scrollTo('flow') }}>동작 방식</a>
+          <a href="#cloud" onClick={(e) => { e.preventDefault(); scrollTo('cloud') }}>듀얼 클라우드</a>
+        </div>
+        <div className="nav-cta">
+          <button className="btn" onClick={() => router.push('/login')}>로그인</button>
+          <button className="btn btn-primary" onClick={() => router.push('/signup')}>
+            시작하기 <span className="arrow">→</span>
+          </button>
+        </div>
+      </nav>
+
+      {/* HERO */}
+      <section className="hero" id="top">
+        <div className="grid-bg"></div>
+        <div className="orbit"></div>
+        <div className="particles" id="particles"></div>
+
+        <svg className="streams" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur stdDeviation="6" result="blur" />
+              <feMerge>
+                <feMergeNode in="blur" />
+                <feMergeNode in="blur" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+          </defs>
+          <path className="stream-path stream-orange" d="M -50 760 C 220 700, 380 640, 620 540 S 1050 380, 1300 360" />
+          <path className="stream-path stream-orange-thin" d="M -80 820 C 260 780, 480 720, 700 600 S 1100 460, 1380 440" />
+          <path className="stream-path stream-blue" d="M 1650 140 C 1380 200, 1220 260, 980 360 S 550 520, 300 540" />
+          <path className="stream-path stream-blue-thin" d="M 1680 80 C 1340 120, 1120 180, 900 300 S 500 440, 220 460" />
+        </svg>
+
+        <div className="vignette"></div>
+
+        <div className="corner corner-br">Made By 뚝딱</div>
+
+        <div className="hero-inner">
+          <div className="eyebrow">
+            <span className="dot"></span>
+            Automated · Intelligent · Resilient
+          </div>
+          <h1 className="wordmark">AutoOps</h1>
+          <p className="tagline">
+            인프라를 만드는 순간,<br />
+            <strong>재해 대비도 함께 시작된다.</strong>
+          </p>
+          <div className="hero-cta">
+            <button className="btn btn-primary" onClick={() => router.push('/signup')}>
+              무료로 시작하기 <span className="arrow">→</span>
+            </button>
+            <button className="btn" onClick={() => scrollTo('flow')}>
+              동작 방식 보기
+            </button>
+          </div>
+        </div>
+
+        <div className="scroll-hint">
+          <span>Scroll</span>
+          <span className="line"></span>
+        </div>
+      </section>
+
+      {/* CAPABILITIES */}
+      <section className="section" id="platform">
+        <div className="section-head">
+          <div className="section-tag">Platform</div>
+          <h2 className="section-title">
+            자연어 한 줄로<br />
+            <em style={{ fontStyle: 'normal', color: 'var(--ink-dim)' }}>멀티 클라우드 인프라를 짜는 방법.</em>
+          </h2>
+          <p className="section-sub">
+            AutoOps는 프롬프트 입력 → AWS 자동 배포 → GCP DR 미러링까지를 하나의 파이프라인으로 묶었습니다. 세 개의 코어 엔진이 그 위에서 동작합니다.
           </p>
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
+
+        <div className="cap-grid">
+          <div className="cap" data-accent="orange">
+            <div className="cap-icon">◇</div>
+            <div className="cap-label">CraftOps</div>
+            <h3 className="cap-name">AI Provisioning Engine</h3>
+            <p className="cap-desc">
+              자연어 프롬프트를 Terraform 코드로 변환하고, AWS 환경에 즉시 배포합니다. VPC · ECS · RDS · ALB 까지 한 번에.
+            </p>
+            <div className="cap-meta">
+              <div><span>Target</span><span>AWS</span></div>
+              <div><span>Output</span><span>Terraform 1.7+</span></div>
+              <div><span>AI</span><span>Gemini API</span></div>
+            </div>
+          </div>
+
+          <div className="cap" data-accent="blue">
+            <div className="cap-icon">◈</div>
+            <div className="cap-label">MirrorOps</div>
+            <h3 className="cap-name">DR Mirroring Engine</h3>
+            <p className="cap-desc">
+              배포 직후 동일 구성을 GCP Standby로 코드화합니다. Warm Standby 전략으로 비용은 최소화, RTO는 15분 이내.
+            </p>
+            <div className="cap-meta">
+              <div><span>Target</span><span>GCP</span></div>
+              <div><span>Mode</span><span>Warm Standby</span></div>
+              <div><span>RTO / RPO</span><span>15min / 3min</span></div>
+            </div>
+          </div>
+
+          <div className="cap" data-accent="white">
+            <div className="cap-icon">◉</div>
+            <div className="cap-label">Validation Loop</div>
+            <h3 className="cap-name">4-Stage Verifier</h3>
+            <p className="cap-desc">
+              validate → 보안 스캔 → 비용 예측 → plan 4단계 검증을 자동 수행합니다. Self-Correction으로 오류를 자동 수정.
+            </p>
+            <div className="cap-meta">
+              <div><span>Stages</span><span>4</span></div>
+              <div><span>Security</span><span>tfsec + checkov</span></div>
+              <div><span>Cost</span><span>Infracost</span></div>
+            </div>
+          </div>
         </div>
-      </main>
-    </div>
-  );
+      </section>
+
+      {/* FLOW */}
+      <section className="flow-section" id="flow">
+        <div className="section">
+          <div className="section-head">
+            <div className="section-tag">End-to-End Flow</div>
+            <h2 className="section-title">한 줄 입력에서 DR 패키지까지.</h2>
+            <p className="section-sub">
+              프롬프트 입력부터 GCP 스탠바이 환경 미러링까지 6단계. 모두 백그라운드에서 자동으로 일어납니다.
+            </p>
+          </div>
+
+          <div className="flow">
+            {[
+              { n: '01', tone: '', name: '프롬프트 입력', sub: 'Natural language', icon: <path d="M3 12h18M3 6h18M3 18h12" strokeWidth="1.6" stroke="currentColor" fill="none" strokeLinecap="round"/> },
+              { n: '02', tone: 'orange', name: '인프라 설계', sub: 'CraftOps · IaC', icon: <><rect x="3" y="3" width="7" height="7" rx="1" strokeWidth="1.6" stroke="currentColor" fill="none"/><rect x="14" y="3" width="7" height="7" rx="1" strokeWidth="1.6" stroke="currentColor" fill="none"/><rect x="3" y="14" width="7" height="7" rx="1" strokeWidth="1.6" stroke="currentColor" fill="none"/><rect x="14" y="14" width="7" height="7" rx="1" strokeWidth="1.6" stroke="currentColor" fill="none"/></> },
+              { n: '03', tone: '', name: 'Validation', sub: '4-stage check', icon: <><path d="M9 11l3 3 7-7" strokeWidth="1.6" stroke="currentColor" fill="none" strokeLinecap="round"/><path d="M20 12v6a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h9" strokeWidth="1.6" stroke="currentColor" fill="none"/></> },
+              { n: '04', tone: 'orange', name: 'AWS 배포', sub: 'terraform apply', icon: <path d="M12 2l3 7h7l-5.5 4.5L18 21l-6-4-6 4 1.5-7.5L2 9h7z" strokeWidth="1.6" stroke="currentColor" fill="none" strokeLinejoin="round"/> },
+              { n: '05', tone: 'blue', name: 'GCP 미러링', sub: 'MirrorOps', icon: <><path d="M3 12a9 9 0 1 0 18 0M3 12a9 9 0 1 1 18 0" strokeWidth="1.6" stroke="currentColor" fill="none"/><path d="M3 12h18M12 3v18" strokeWidth="1.6" stroke="currentColor" fill="none"/></> },
+              { n: '06', tone: 'blue', name: 'DR Package', sub: 'Standby ready', icon: <><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" strokeWidth="1.6" stroke="currentColor" fill="none"/><path d="M3.27 6.96L12 12.01l8.73-5.05M12 22.08V12" strokeWidth="1.6" stroke="currentColor" fill="none"/></> },
+            ].map((step) => (
+              <div key={step.n} className="flow-step" data-tone={step.tone || undefined}>
+                <div className="flow-num">{step.n}</div>
+                <div className="flow-glyph">
+                  <svg width="20" height="20" viewBox="0 0 24 24">{step.icon}</svg>
+                </div>
+                <div className="flow-name">{step.name}</div>
+                <div className="flow-sub">{step.sub}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* DUAL CLOUD */}
+      <section className="section" id="cloud">
+        <div className="section-head">
+          <div className="section-tag">Dual Cloud</div>
+          <h2 className="section-title">하나의 코드, 두 개의 클라우드.</h2>
+          <p className="section-sub">
+            AWS에 인프라를 만드는 그 순간, GCP에는 같은 형태의 스탠바이 환경이 IaC로 동기화됩니다. 장애 발생 시 단일 명령으로 트래픽이 넘어갑니다.
+          </p>
+        </div>
+
+        <div className="split">
+          <div className="cloud cloud-orange">
+            <div className="cloud-head">
+              <span className="cloud-badge">CraftOps · AWS</span>
+              <span className="cloud-status">
+                <span className="pip"></span> Active · us-west-2
+              </span>
+            </div>
+            <h3 className="cloud-title">Primary Production</h3>
+            <p className="cloud-desc">
+              실제 트래픽이 흐르는 메인 환경. CraftOps 엔진이 자연어에서 Terraform을 만들고 그대로 배포합니다. 16개 리소스 3-Tier 망분리 아키텍처 기본 제공.
+            </p>
+            <div className="cloud-stats">
+              <div className="cloud-stat"><div className="label">Resources</div><div className="value">16</div></div>
+              <div className="cloud-stat"><div className="label">Arch</div><div className="value" style={{ fontSize: 16 }}>3-Tier</div></div>
+              <div className="cloud-stat"><div className="label">IaC</div><div className="value" style={{ fontSize: 16 }}>TF<small>1.7</small></div></div>
+            </div>
+          </div>
+
+          <div className="cloud cloud-blue">
+            <div className="cloud-head">
+              <span className="cloud-badge">MirrorOps · GCP</span>
+              <span className="cloud-status standby">
+                <span className="pip"></span> Standby · us-west1
+              </span>
+            </div>
+            <h3 className="cloud-title">Disaster Recovery</h3>
+            <p className="cloud-desc">
+              AWS 배포 직후 자동 생성되는 미러 환경. 코드로만 살아있다가 장애 시 즉시 구동. AWS Control Plane 전역 장애에도 독립적으로 작동합니다.
+            </p>
+            <div className="cloud-stats">
+              <div className="cloud-stat"><div className="label">Resources</div><div className="value">11</div></div>
+              <div className="cloud-stat"><div className="label">RTO</div><div className="value">15<small>min</small></div></div>
+              <div className="cloud-stat"><div className="label">RPO</div><div className="value">3<small>min</small></div></div>
+            </div>
+          </div>
+        </div>
+
+        {/* TERMINAL */}
+        <div className="showcase">
+          <div className="term-bar">
+            <div className="dots"><span></span><span></span><span></span></div>
+            <span className="title">autoops · prompt session</span>
+            <span className="status"><span className="pip"></span> live</span>
+          </div>
+          <div className="term-body">
+            <div className="term-line user"><span className="prompt">›</span><span className="text">프로덕션용 FastAPI 서버 + PostgreSQL 15, 금융보안 3-Tier 망분리, 오레곤 리전, 오토스케일링 포함해줘.</span></div>
+            <div className="term-line sys"><span className="prompt">·</span><span className="text">parsing intent · matched template: web-api-stack · 16 resources</span></div>
+            <div className="term-line sys"><span className="prompt">·</span><span className="text">drafting terraform — VPC · ECS Fargate · RDS PostgreSQL · ALB</span></div>
+            <div className="term-line ok"><span className="prompt">✓</span><span className="text">validation passed — terraform validate · tfsec · checkov · infracost</span></div>
+            <div className="term-line ok"><span className="prompt">✓</span><span className="text">aws apply complete — us-west-2 · 16 resources created</span></div>
+            <div className="term-line blue"><span className="prompt">↻</span><span className="text">mirroring to gcp standby — EventBridge triggered · MirrorOps running</span></div>
+            <div className="term-line blue"><span className="prompt">✓</span><span className="text">dr package sealed — 11 resources · warm standby · RTO 15min<span className="caret"></span></span></div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="cta-strip" id="start">
+        <h2>인프라부터 DR까지,<br />하나의 줄로 끝.</h2>
+        <p>가입하고 첫 프롬프트를 입력하면 AWS · GCP 듀얼 환경이 자동으로 준비됩니다.</p>
+        <div className="btns">
+          <button className="btn btn-primary" onClick={() => router.push('/signup')}>
+            무료로 시작하기 <span className="arrow">→</span>
+          </button>
+          <button className="btn" onClick={() => router.push('/login')}>로그인</button>
+        </div>
+      </section>
+
+      {/* FOOTER */}
+      <footer>
+        <div className="foot-brand">
+          <div className="brand">
+            <span className="brand-mark"></span>
+            AutoOps
+          </div>
+          <div className="copy">© 2026 AutoOps · Made By 뚝딱</div>
+        </div>
+        <div className="foot-cols">
+          <div className="foot-col">
+            <h4>Platform</h4>
+            <ul>
+              <li><a href="#platform" onClick={(e) => { e.preventDefault(); scrollTo('platform') }}>CraftOps</a></li>
+              <li><a href="#platform" onClick={(e) => { e.preventDefault(); scrollTo('platform') }}>MirrorOps</a></li>
+              <li><a href="#platform" onClick={(e) => { e.preventDefault(); scrollTo('platform') }}>Validation Loop</a></li>
+            </ul>
+          </div>
+          <div className="foot-col">
+            <h4>Flow</h4>
+            <ul>
+              <li><a href="#flow" onClick={(e) => { e.preventDefault(); scrollTo('flow') }}>동작 방식</a></li>
+              <li><a href="#cloud" onClick={(e) => { e.preventDefault(); scrollTo('cloud') }}>듀얼 클라우드</a></li>
+            </ul>
+          </div>
+          <div className="foot-col">
+            <h4>Account</h4>
+            <ul>
+              <li><a href="#" onClick={(e) => { e.preventDefault(); router.push('/login') }}>로그인</a></li>
+              <li><a href="#" onClick={(e) => { e.preventDefault(); router.push('/signup') }}>회원가입</a></li>
+            </ul>
+          </div>
+        </div>
+      </footer>
+    </>
+  )
 }

--- a/frontend/app/projects/[id]/deploy/page.tsx
+++ b/frontend/app/projects/[id]/deploy/page.tsx
@@ -21,12 +21,21 @@ export default function DeployPage() {
 
   const [deploymentId, setDeploymentId] = useState<string | null>(null)
   const [isDeploying, setIsDeploying] = useState(false)
+  const [projectName, setProjectName] = useState<string>('')        // ← 추가
   const [deployStatus, setDeployStatus] = useState<
     'idle' | 'deploying' | 'completed' | 'failed'
   >('idle')
   const [logs, setLogs] = useState<LogEntry[]>([])
 
   const { events, isConnected } = useWebSocket(projectId, deploymentId)
+
+  // 프로젝트 이름 미리 조회 (토스트용)                              // ← 추가
+  useEffect(() => {
+    if (!projectId) return
+    apiClient.get(`/api/projects/${projectId}`)
+      .then((res) => setProjectName(res.data.data?.name ?? ''))
+      .catch(() => {})
+  }, [projectId])
 
   // WebSocket 이벤트 처리 — §7-7
   useEffect(() => {
@@ -45,8 +54,12 @@ export default function DeployPage() {
 
     if (latest.event_type === 'deploy_completed') {
       setDeployStatus('completed')
-      // §12-9: 배포 완료 → SCR-B-01 DR 대시보드 이동
-      setTimeout(() => router.push(`/projects/${projectId}/mirror`), 2000)
+      // 대시보드 토스트 데이터 저장 후 이동                          // ← 수정
+      localStorage.setItem('deploy_toast', JSON.stringify({
+        projectName: projectName || projectId,
+        message: '배포가 완료되었습니다.',
+      }))
+      setTimeout(() => router.push('/dashboard'), 2000)
     }
 
     if (latest.event_type === 'deploy_failed') {
@@ -57,7 +70,7 @@ export default function DeployPage() {
         1000
       )
     }
-  }, [events, projectId, router])
+  }, [events, projectId, projectName, router])
 
   const handleDeploy = async () => {
     setIsDeploying(true)
@@ -134,10 +147,17 @@ export default function DeployPage() {
         <Card className="border-green-500 bg-green-50">
           <CardContent className="p-4">
             <p className="text-green-700 font-medium">
-              ✅ 배포 완료. MirrorOps가 자동으로 시작됩니다.
+              ✅ 배포 완료. 대시보드로 이동 중...
             </p>
-            <p className="text-sm text-green-600 mt-1">
-              DR 대시보드로 이동 중...
+          </CardContent>
+        </Card>
+      )}
+
+      {deployStatus === 'failed' && (
+        <Card className="border-red-500 bg-red-50">
+          <CardContent className="p-4">
+            <p className="text-red-700 font-medium">
+              ❌ 배포 실패. Partial Failure 페이지로 이동 중...
             </p>
           </CardContent>
         </Card>

--- a/frontend/app/projects/[id]/page.tsx
+++ b/frontend/app/projects/[id]/page.tsx
@@ -7,11 +7,14 @@ import { apiClient } from '@/lib/api'
 import { Project } from '@/types'
 
 const STATUS_CONFIG: Record<string, { text: string; color: string }> = {
-  completed:      { text: '✅ 배포 완료',  color: 'text-emerald-400' },
-  deploying:      { text: '⏳ 배포 중',    color: 'text-blue-400' },
-  failed:         { text: '❌ 배포 실패',  color: 'text-red-400' },
-  partial_failed: { text: '⚠️ 부분 실패', color: 'text-yellow-400' },
-  created:        { text: '🔧 준비 중',    color: 'text-[#9ca3af]' },
+  completed:         { text: '✅ 배포 완료',  color: 'text-emerald-400' },
+  deploying:         { text: '⏳ 배포 중',    color: 'text-blue-400' },
+  failed:            { text: '❌ 배포 실패',  color: 'text-red-400' },
+  partial_failed:    { text: '⚠️ 부분 실패', color: 'text-yellow-400' },
+  created:           { text: '🔧 준비 중',    color: 'text-[#9ca3af]' },
+  destroying:        { text: '🗑️ 삭제 중',   color: 'text-orange-400' },
+  destroy_completed: { text: '🗑️ 삭제 완료', color: 'text-[#9ca3af]' },
+  destroy_failed:    { text: '⚠️ 삭제 실패', color: 'text-red-400' },
 }
 
 const DR_STATUS_CONFIG: Record<string, { text: string; color: string }> = {
@@ -62,6 +65,9 @@ export default function ProjectDetailPage() {
   const deployConf = STATUS_CONFIG[project.status]       ?? { text: project.status,    color: 'text-[#9ca3af]' }
   const drConf     = DR_STATUS_CONFIG[project.dr_status] ?? { text: project.dr_status, color: 'text-[#9ca3af]' }
 
+  // destroy 진행 중 여부
+  const isDestroying = project.status === 'destroying'
+
   return (
     <div className="px-6 py-8 md:px-12 md:py-12 max-w-5xl">
 
@@ -86,6 +92,14 @@ export default function ProjectDetailPage() {
         </div>
       </div>
 
+      {/* destroying 중 배너 */}
+      {isDestroying && (
+        <div className="mb-6 bg-orange-500/5 border border-orange-500/20 rounded-2xl px-4 py-3 text-sm text-orange-400 flex items-center gap-2">
+          <span className="animate-spin">⏳</span>
+          AWS 리소스 삭제가 진행 중입니다. 잠시 후 새로고침해주세요.
+        </div>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
 
         {/* ── CraftOps 섹션 ── */}
@@ -95,13 +109,10 @@ export default function ProjectDetailPage() {
             <p className="text-sm text-[#9ca3af]">인프라 설계 · 배포</p>
           </div>
 
-          {/* 배포 상태 */}
           <div className="space-y-2">
             <div className="flex justify-between items-center text-sm">
               <span className="text-[#9ca3af]">배포 상태</span>
-              <span className={`font-medium ${deployConf.color}`}>
-                {deployConf.text}
-              </span>
+              <span className={`font-medium ${deployConf.color}`}>{deployConf.text}</span>
             </div>
             <div className="flex justify-between items-center text-sm">
               <span className="text-[#9ca3af]">마지막 배포</span>
@@ -113,20 +124,18 @@ export default function ProjectDetailPage() {
             </div>
           </div>
 
-          {/* CraftOps 액션 */}
           <div className="space-y-2 pt-2 border-t border-white/8">
-
-            {/* created → 첫 배포 시작 */}
+            {/* created → 위저드로 */}
             {project.status === 'created' && (
               <button
-                onClick={() => router.push(`/projects/${projectId}/validate`)}
+                onClick={() => router.push(`/projects/new?project_id=${projectId}`)}
                 className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-white/5 hover:bg-white/10 transition-colors"
               >
                 🚀 배포 시작
               </button>
             )}
 
-            {/* deploying → 배포 로그 보기 */}
+            {/* deploying → 배포 로그 */}
             {project.status === 'deploying' && (
               <button
                 onClick={() => router.push(`/projects/${projectId}/deploy`)}
@@ -136,8 +145,20 @@ export default function ProjectDetailPage() {
               </button>
             )}
 
-            {/* completed / failed → 재배포 */}
-            {(project.status === 'completed' || project.status === 'failed') && (
+            {/* completed → 재배포 or 리소스 삭제 */}
+            {project.status === 'completed' && (
+              <>
+                <button
+                  onClick={() => router.push(`/projects/${projectId}/validate`)}
+                  className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-white/5 hover:bg-white/10 transition-colors"
+                >
+                  🔄 재배포
+                </button>
+              </>
+            )}
+
+            {/* failed → 재배포 */}
+            {project.status === 'failed' && (
               <button
                 onClick={() => router.push(`/projects/${projectId}/validate`)}
                 className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-white/5 hover:bg-white/10 transition-colors"
@@ -155,6 +176,21 @@ export default function ProjectDetailPage() {
                 ⚠️ Partial Failure 대응
               </button>
             )}
+
+            {/* destroying → 진행 중 표시만 */}
+            {project.status === 'destroying' && (
+              <div className="w-full px-4 py-3 rounded-2xl text-sm font-medium bg-orange-500/10 text-orange-400">
+                🗑️ 리소스 삭제 진행 중...
+              </div>
+            )}
+
+            {/* destroy_failed → 재시도 안내 */}
+            {project.status === 'destroy_failed' && (
+              <div className="w-full px-4 py-3 rounded-2xl text-sm bg-red-500/10 text-red-400 space-y-1">
+                <p className="font-medium">⚠️ 삭제 실패</p>
+                <p className="text-xs text-red-400/70">대시보드에서 다시 삭제를 시도하세요.</p>
+              </div>
+            )}
           </div>
         </div>
 
@@ -165,13 +201,10 @@ export default function ProjectDetailPage() {
             <p className="text-sm text-[#9ca3af]">재해복구 · DR 모니터링</p>
           </div>
 
-          {/* DR 상태 */}
           <div className="space-y-2">
             <div className="flex justify-between items-center text-sm">
               <span className="text-[#9ca3af]">DR 상태</span>
-              <span className={`font-medium ${drConf.color}`}>
-                {drConf.text}
-              </span>
+              <span className={`font-medium ${drConf.color}`}>{drConf.text}</span>
             </div>
             <div className="flex justify-between items-center text-sm">
               <span className="text-[#9ca3af]">마지막 동기화</span>
@@ -183,7 +216,6 @@ export default function ProjectDetailPage() {
             </div>
           </div>
 
-          {/* MirrorOps 액션 */}
           <div className="space-y-2 pt-2 border-t border-white/8">
             <button
               onClick={() => router.push(`/projects/${projectId}/mirror`)}
@@ -203,8 +235,6 @@ export default function ProjectDetailPage() {
             >
               📦 DR Package
             </button>
-
-            {/* 페일오버 — DR ready 여부에 따라 강조 */}
             <button
               onClick={() => router.push(`/projects/${projectId}/failover`)}
               className={`w-full text-left px-4 py-3 rounded-2xl text-sm font-bold transition-colors ${

--- a/frontend/app/projects/new/NewProjectPageContent.tsx
+++ b/frontend/app/projects/new/NewProjectPageContent.tsx
@@ -6,8 +6,6 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { apiClient } from '@/lib/api'
 import { WizardLayout } from '@/components/craftops/WizardLayout'
 import { IntentAnalysis } from '@/components/craftops/IntentAnalysis'
-import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
 
 type WizardPhase = 'project-create' | 'step1' | '2-1' | '2-2' | '2-3' | '2-4' | '2-5' | '2-6' | 'summary' | 'validate'
 
@@ -88,76 +86,214 @@ export default function NewProjectPageContent() {
     }
   }
 
+  const isProd = projectForm.environment === 'prod'
+
+  // shared top bar (non-wizard phases use this; wizard phases use WizardLayout's own top bar)
+  const TopBar = ({ stepLabel, onBack, backLabel }: { stepLabel?: string; onBack?: () => void; backLabel?: string }) => (
+    <div className="npc-topbar">
+      <div className="npc-top-left">
+        <span className="npc-brand">
+          <span className="npc-mark"></span>
+          AutoOps
+        </span>
+        {projectForm.name && (
+          <>
+            <span className="npc-crumb-sep" />
+            <div className="npc-crumb-proj">
+              <span className="npc-crumb-eyebrow">
+                <span className="npc-pip" />
+                CraftOps · 인프라 설계
+              </span>
+              <span className="npc-crumb-name">{projectForm.name}</span>
+            </div>
+          </>
+        )}
+      </div>
+      <div className="npc-top-right">
+        {stepLabel && <span className="npc-step-counter">{stepLabel}</span>}
+        {onBack && (
+          <button className="npc-btn-exit" onClick={onBack}>
+            {backLabel || '나가기'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+
+  // ── phase: project-create ──────────────────────────────────────
   if (phase === 'project-create') {
     return (
-      <div className="px-6 py-8 md:px-12 md:py-12 max-w-lg">
-        <button
-          onClick={() => router.push('/dashboard')}
-          className="text-[#9ca3af] hover:text-white text-sm transition-colors mb-6 block"
-        >
-          ← 대시보드
-        </button>
-        <h1 className="text-2xl font-bold mb-1">새 프로젝트 생성</h1>
-        <p className="text-[#9ca3af] text-sm mb-6">
-          프로젝트를 생성한 후 인프라 설계 단계로 이동합니다.
-        </p>
-        <div className="space-y-3">
-          <Input
-            placeholder="프로젝트 이름"
-            value={projectForm.name}
-            onChange={(e) => setProjectForm((f) => ({ ...f, name: e.target.value }))}
-          />
-          <Input
-            placeholder="prefix (예: TS)"
-            value={projectForm.prefix}
-            onChange={(e) => setProjectForm((f) => ({ ...f, prefix: e.target.value }))}
-          />
-          <select
-            className="w-full border rounded px-3 py-2 text-sm bg-black border-white/10 text-white"
-            value={projectForm.environment}
-            onChange={(e) => setProjectForm((f) => ({ ...f, environment: e.target.value }))}
-          >
-            <option value="prod">prod</option>
-            <option value="staging">staging</option>
-            <option value="dev">dev</option>
-          </select>
-          <Button
-            className="w-full bg-teal-600 hover:bg-teal-700"
-            onClick={handleCreateProject}
-            disabled={isSubmitting || !projectForm.name || !projectForm.prefix}
-          >
-            {isSubmitting ? '생성 중...' : '프로젝트 생성 →'}
-          </Button>
+      <>
+        <style>{styles}</style>
+        <TopBar onBack={() => router.push('/dashboard')} backLabel="← 대시보드" />
+
+        <div className="npc-shell">
+          <div className="npc-shell-inner">
+            <div className="npc-step-header">
+              <div className="npc-step-eyebrow">
+                <span className="npc-pip" />
+                Step 00 · 프로젝트 생성
+              </div>
+              <h1 className="npc-step-title">AWS 인프라 구성 시작하기</h1>
+              <p className="npc-step-desc">
+                프로젝트 정보를 입력하면 CraftOps가 16개 AWS 리소스를 자동으로 설계합니다.
+              </p>
+            </div>
+
+            <div className="npc-form-card">
+              {/* 서비스 이름 */}
+              <div className="npc-field">
+                <label className="npc-label">서비스 이름</label>
+                <p className="npc-hint">프로젝트 식별용으로만 쓰입니다. 자유롭게 입력하세요.</p>
+                <div className="npc-input-wrap">
+                  <input
+                    className="npc-input"
+                    placeholder="예) Fortune 송금 서비스"
+                    value={projectForm.name}
+                    onChange={(e) => setProjectForm((f) => ({ ...f, name: e.target.value }))}
+                  />
+                </div>
+              </div>
+
+              {/* prefix */}
+              <div className="npc-field">
+                <label className="npc-label">리소스 식별자 (Prefix)</label>
+                <p className="npc-hint">모든 AWS 리소스 이름에 자동으로 붙습니다.</p>
+                <div className="npc-input-wrap">
+                  <input
+                    className="npc-input npc-mono"
+                    placeholder="예) PAY, GW, FORTUNE"
+                    value={projectForm.prefix}
+                    onChange={(e) => setProjectForm((f) => ({ ...f, prefix: e.target.value }))}
+                  />
+                </div>
+                <p className="npc-hint npc-preview">
+                  예){' '}
+                  <span className="npc-mono-inline">
+                    {(projectForm.prefix || 'PAY')}-prod-vpc, {(projectForm.prefix || 'PAY')}-prod-rds
+                  </span>
+                </p>
+              </div>
+
+              {/* 환경 */}
+              <div className="npc-field">
+                <label className="npc-label">서비스 환경</label>
+                <div className="npc-env-grid">
+                  {([
+                    { v: 'prod',    name: 'prod',    desc: '실서비스 (금융보안 자동 적용)', tone: 'orange' },
+                    { v: 'staging', name: 'staging', desc: '검증/테스트',                  tone: 'yellow' },
+                    { v: 'dev',     name: 'dev',     desc: '개발용 (최소 사양)',            tone: 'blue' },
+                  ] as const).map((opt) => (
+                    <button
+                      key={opt.v}
+                      type="button"
+                      className={`npc-env-card${projectForm.environment === opt.v ? ' npc-active' : ''}`}
+                      data-tone={opt.tone}
+                      onClick={() => setProjectForm((f) => ({ ...f, environment: opt.v }))}
+                    >
+                      <span className="npc-env-name">{opt.name}</span>
+                      <span className="npc-env-desc">{opt.desc}</span>
+                      <span className="npc-env-check">
+                        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                          <polyline points="20 6 9 17 4 12"/>
+                        </svg>
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* 리전 안내 */}
+              <p className="npc-region-note">
+                배포 리전 ·{' '}
+                <span className="npc-mono-inline">{projectForm.region}</span>{' '}
+                (Oregon) · 변경이 필요하면 위저드 완료 후 수정할 수 있습니다.
+              </p>
+            </div>
+
+            <div className="npc-nav-row">
+              <button className="npc-btn-prev" onClick={() => router.push('/dashboard')}>
+                <span className="npc-arrow">←</span>
+                취소
+              </button>
+              <button
+                className="npc-btn-next"
+                onClick={handleCreateProject}
+                disabled={isSubmitting || !projectForm.name || !projectForm.prefix}
+              >
+                {isSubmitting ? (
+                  <>
+                    <span className="npc-spinner" />
+                    <span>생성 중...</span>
+                  </>
+                ) : (
+                  <>
+                    <span>인프라 설계 시작</span>
+                    <span className="npc-arrow">→</span>
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
         </div>
-      </div>
+      </>
     )
   }
 
+  // ── phase: step1 ──────────────────────────────────────────────
   if (phase === 'step1' && projectId) {
     return (
-      <div className="px-6 py-8 md:px-12 md:py-12 max-w-2xl">
-        <button
-          onClick={() => router.push(`/projects/${projectId}`)}
-          className="text-[#9ca3af] hover:text-white text-sm transition-colors mb-6 block"
-        >
-          ← 프로젝트
-        </button>
-        <h1 className="text-2xl font-bold mb-6">Step 1 — 요구사항 분석</h1>
-        <IntentAnalysis
-          projectId={projectId}
-          onComplete={() => setPhase('2-1')}
+      <>
+        <style>{styles}</style>
+        <TopBar
+          stepLabel="Step 01 / 06"
+          onBack={() => router.push(`/projects/${projectId}`)}
+          backLabel="← 프로젝트 정보"
         />
-      </div>
+
+        <div className="npc-shell">
+          <div className="npc-shell-inner">
+            <div className="npc-step-header">
+              <div className="npc-step-eyebrow">
+                <span className="npc-pip" />
+                Step 01 · AI 의도 분석
+              </div>
+              <h1 className="npc-step-title">어떤 서비스를 만드시나요?</h1>
+              <p className="npc-step-desc">
+                서비스를 간단히 설명해주세요. Gemini가 필요한 AWS 리소스 구성을 제안합니다.
+              </p>
+            </div>
+
+            <div className="npc-form-card">
+              <IntentAnalysis
+                projectId={projectId}
+                onComplete={() => setPhase('2-1')}
+              />
+            </div>
+          </div>
+        </div>
+      </>
     )
   }
 
-if (phase === '2-1') {
+  // ── phase: 2-1 기본 설정 ──────────────────────────────────────
+  if (phase === '2-1') {
     return (
-      <div className="p-6">
+      <>
+        <style>{styles}</style>
         <WizardLayout
           currentStep="2-1"
           completedSteps={completedSteps}
-          sidekick="프로덕션 환경이므로 Multi-AZ 구성을 권장합니다."
+          projectName={projectForm.name}
+          region={projectForm.region}
+          onExit={() => projectId && router.push(`/projects/${projectId}`)}
+          title="리소스 네이밍 규칙을 확인해주세요."
+          description="아래 규칙으로 16개 리소스가 자동 네이밍됩니다. Prefix와 환경은 프로젝트 생성 시 입력한 값입니다."
+          sidekick={
+            isProd
+              ? 'prod 환경에는 Multi-AZ + 암호화 + 백업 30일이 자동 적용됩니다. 금융보안원 tfsec 보안 스캔 통과 요건입니다.'
+              : `${projectForm.environment} 환경 기준으로 최소 사양이 적용됩니다. 실서비스 전에 prod로 전환하세요.`
+          }
           onNext={() =>
             handleSaveStep('2-1', {
               prefix:       projectForm.prefix,
@@ -168,46 +304,62 @@ if (phase === '2-1') {
           }
           isSubmitting={isSubmitting}
         >
-          <div className="space-y-3">
-            <div>
-              <label className="text-sm font-medium">리소스 네이밍 규칙</label>
-              <div className="grid grid-cols-2 gap-2 mt-1">
-                <div>
-                  <p className="text-xs text-[#9ca3af]">프리픽스</p>
-                  <Input value={projectForm.prefix} readOnly className="border-white/10 text-white" style={{ backgroundColor: '#121214' }} />
-                </div>
-                <div>
-                  <p className="text-xs text-[#9ca3af]">환경</p>
-                  <Input value={projectForm.environment} readOnly className="border-white/10 text-white" style={{ backgroundColor: '#121214' }} />
-                </div>
+          <div className="npc-grid-2">
+            <div className="npc-field">
+              <label className="npc-label">Prefix</label>
+              <div className="npc-input-wrap npc-readonly">
+                <input className="npc-input npc-mono" value={projectForm.prefix} readOnly />
               </div>
             </div>
-            {namingPreview.length > 0 && (
-              <div className="bg-black/30 border border-white/8 rounded p-3">
-                <p className="text-xs text-[#9ca3af] mb-1">네이밍 미리보기</p>
-                <div className="text-xs space-y-0.5">
-                  {namingPreview.slice(0, 5).map((n) => (
-                    <p key={n} className="font-mono">{n}</p>
-                  ))}
-                  {namingPreview.length > 5 && (
-                    <p className="text-[#9ca3af]">... 외 {namingPreview.length - 5}개</p>
-                  )}
-                </div>
+            <div className="npc-field">
+              <label className="npc-label">Environment</label>
+              <div className="npc-input-wrap npc-readonly">
+                <input className="npc-input npc-mono" value={projectForm.environment} readOnly />
               </div>
-            )}
+            </div>
           </div>
+
+          {namingPreview.length > 0 ? (
+            <div className="npc-preview-block">
+              <div className="npc-preview-label">생성될 리소스 이름 미리보기</div>
+              <ul className="npc-preview-list">
+                {namingPreview.slice(0, 5).map((n) => (
+                  <li key={n}>{n}</li>
+                ))}
+              </ul>
+              {namingPreview.length > 5 && (
+                <div className="npc-preview-more">+ 외 {namingPreview.length - 5}개</div>
+              )}
+            </div>
+          ) : (
+            <p className="npc-helper">
+              다음을 누르면{' '}
+              <span className="npc-mono-inline">
+                {projectForm.prefix || 'PREFIX'}-{projectForm.environment}-*
+              </span>{' '}
+              형식으로 16개 리소스 이름이 확정됩니다.
+            </p>
+          )}
         </WizardLayout>
-      </div>
+      </>
     )
   }
 
+  // ── phase: 2-2 네트워크 ────────────────────────────────────────
   if (phase === '2-2') {
+    const currentCidr = (stepConfigs['2-2']?.vpc_cidr as string) || '10.0.0.0/16'
     return (
-      <div className="p-6">
+      <>
+        <style>{styles}</style>
         <WizardLayout
           currentStep="2-2"
           completedSteps={completedSteps}
-          sidekick="VPC CIDR 입력 시 서브넷 4개(prod) 또는 2개(dev/staging)가 자동 분배됩니다."
+          projectName={projectForm.name}
+          region={projectForm.region}
+          onExit={() => projectId && router.push(`/projects/${projectId}`)}
+          title="VPC 네트워크 대역을 정해주세요."
+          description="CIDR 하나만 입력하면 서브넷 분배, 인터넷 게이트웨이, NAT Gateway, 라우팅 테이블이 모두 자동 생성됩니다."
+          sidekick="CIDR 하나만 입력하면 서브넷 분배, 인터넷 게이트웨이, NAT Gateway, 라우팅 테이블이 모두 자동 생성됩니다. 직접 만들 필요 없습니다."
           onPrev={() => setPhase('2-1')}
           onNext={() => {
             const cidr = (stepConfigs['2-2']?.vpc_cidr as string) || '10.0.0.0/16'
@@ -220,12 +372,15 @@ if (phase === '2-1') {
           }}
           isSubmitting={isSubmitting}
         >
-          <div className="space-y-3">
-            <div>
-              <label className="text-sm font-medium">VPC CIDR</label>
-              <Input
+          <div className="npc-field">
+            <label className="npc-label">VPC CIDR</label>
+            <p className="npc-hint">
+              대부분의 경우 기본값(10.0.0.0/16)을 그대로 사용해도 됩니다. 다른 사내 네트워크와 겹치지 않게 설정해주세요.
+            </p>
+            <div className={`npc-input-wrap${cidrError ? ' npc-error' : ''}`}>
+              <input
+                className="npc-input npc-mono"
                 defaultValue="10.0.0.0/16"
-                className={`mt-1 ${cidrError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                 onChange={(e) => {
                   const val = e.target.value
                   setStepConfigs((prev) => ({
@@ -237,49 +392,106 @@ if (phase === '2-1') {
                   }
                 }}
               />
-              {cidrError ? (
-                <p className="text-red-500 text-xs mt-1">⚠️ {cidrError}</p>
-              ) : (
-                <p className="text-xs text-[#9ca3af] mt-1">
-                  서브넷 자동 분배 (prod: Public 2 + Private 2 / dev·staging: Public 1 + Private 1)
-                </p>
-              )}
             </div>
+            {cidrError ? (
+              <p className="npc-field-error">{cidrError}</p>
+            ) : (
+              <p className="npc-hint">
+                {isProd
+                  ? 'prod → Public 2 + Private 2 (Multi-AZ 고가용성 구성)'
+                  : `${projectForm.environment} → Public 1 + Private 1 (단일 AZ 구성)`}
+              </p>
+            )}
+          </div>
+
+          <div className="npc-preview-block">
+            <div className="npc-preview-label">자동 생성될 서브넷 구성</div>
+            <ul className="npc-preview-list">
+              {isProd ? (
+                <>
+                  <li>{currentCidr.replace(/\.0\/\d+$/, '.1.0/24')} · Public · {projectForm.region}a</li>
+                  <li>{currentCidr.replace(/\.0\/\d+$/, '.2.0/24')} · Public · {projectForm.region}c</li>
+                  <li>{currentCidr.replace(/\.0\/\d+$/, '.11.0/24')} · Private · {projectForm.region}a</li>
+                  <li>{currentCidr.replace(/\.0\/\d+$/, '.12.0/24')} · Private · {projectForm.region}c</li>
+                </>
+              ) : (
+                <>
+                  <li>{currentCidr.replace(/\.0\/\d+$/, '.1.0/24')} · Public · {projectForm.region}a</li>
+                  <li>{currentCidr.replace(/\.0\/\d+$/, '.11.0/24')} · Private · {projectForm.region}a</li>
+                </>
+              )}
+            </ul>
+            <div className="npc-preview-more">+ Internet Gateway · NAT Gateway · Route Table 자동 구성</div>
           </div>
         </WizardLayout>
-      </div>
+      </>
     )
   }
 
+  // ── phase: 2-3 보안 그룹 ──────────────────────────────────────
   if (phase === '2-3') {
     return (
-      <div className="p-6">
+      <>
+        <style>{styles}</style>
         <WizardLayout
           currentStep="2-3"
           completedSteps={completedSteps}
-          sidekick="SG 간 참조 관계를 자동 구성합니다. ALB→App→DB 순서로 허용 규칙이 설정됩니다."
+          projectName={projectForm.name}
+          region={projectForm.region}
+          onExit={() => projectId && router.push(`/projects/${projectId}`)}
+          title="금융보안 3-Tier 망분리가 자동 적용됩니다."
+          description="외부망(ALB)이 탈취되더라도 내부 DB로의 침투를 구조적으로 차단하는 구성입니다. 금융위원회 전자금융업 보안 심사 망분리 요건을 자동 충족합니다."
+          sidekick="이 구성으로 금융위원회 전자금융업 보안 심사의 망분리 요건을 자동 충족합니다. 외부망(ALB)이 탈취되더라도 내부 DB로의 침투를 구조적으로 차단합니다."
           onPrev={() => setPhase('2-2')}
           onNext={() => handleSaveStep('2-3', {})}
           isSubmitting={isSubmitting}
         >
-          <div className="space-y-2 text-sm bg-[#121214] rounded p-3">
-            <p className="font-medium">자동 구성 내용</p>
-            <p>SG-ALB: 443, 80 ← 0.0.0.0/0</p>
-            <p>SG-App: 8080 ← SG-ALB</p>
-            <p>SG-DB: 5432 ← SG-App</p>
+          <div className="npc-sg-block">
+            <div className="npc-sg-title">3-Tier Security Group 자동 구성</div>
+            <div className="npc-sg-rows">
+              <div className="npc-sg-row">
+                <div className="npc-sg-key">SG-ALB</div>
+                <div className="npc-sg-val">
+                  <span className="npc-arrow-glyph">↓</span>
+                  외부 인터넷 → 443, 80 허용 (HTTPS/HTTP)
+                </div>
+              </div>
+              <div className="npc-sg-row">
+                <div className="npc-sg-key">SG-App</div>
+                <div className="npc-sg-val">
+                  <span className="npc-arrow-glyph">↓</span>
+                  ALB에서 오는 트래픽만 앱 서버 8080 허용
+                </div>
+              </div>
+              <div className="npc-sg-row">
+                <div className="npc-sg-key">SG-DB</div>
+                <div className="npc-sg-val">
+                  <span className="npc-arrow-glyph">·</span>
+                  앱 서버에서 오는 트래픽만 DB 5432 허용
+                </div>
+              </div>
+            </div>
           </div>
+          <p className="npc-helper">※ 모든 규칙이 최적값으로 자동 설정됩니다. 수정 없이 다음으로 넘어가세요.</p>
         </WizardLayout>
-      </div>
+      </>
     )
   }
 
+  // ── phase: 2-4 ALB ────────────────────────────────────────────
   if (phase === '2-4') {
     return (
-      <div className="p-6">
+      <>
+        <style>{styles}</style>
         <WizardLayout
           currentStep="2-4"
           completedSteps={completedSteps}
-          sidekick="ALB는 Public Subnet에 자동 배치됩니다."
+          projectName={projectForm.name}
+          region={projectForm.region}
+          onExit={() => projectId && router.push(`/projects/${projectId}`)}
+          title="로드 밸런서가 자동 생성됩니다."
+          description="외부 트래픽을 받아 앱 서버로 분산하는 ALB(Application Load Balancer)입니다. 2개 가용영역(AZ)에 분산 배치되어 특정 데이터센터에 장애가 나도 서비스가 유지됩니다."
+          sidekick="2개 가용영역(AZ)에 분산 배치되어 특정 데이터센터에 장애가 나도 서비스가 유지됩니다."
           onPrev={() => setPhase('2-3')}
           onNext={() =>
             handleSaveStep('2-4', {
@@ -288,35 +500,47 @@ if (phase === '2-1') {
           }
           isSubmitting={isSubmitting}
         >
-          <div className="space-y-3">
-            <div>
-              <label className="text-sm font-medium">ALB 이름</label>
-              <Input
+          <div className="npc-field">
+            <label className="npc-label">로드 밸런서 이름 (자동 생성)</label>
+            <div className="npc-input-wrap npc-readonly">
+              <input
+                className="npc-input npc-mono"
                 value={`${projectForm.prefix}-${projectForm.environment}-alb`}
                 readOnly
-                className="border-white/10 text-white"
-                style={{ backgroundColor: '#121214' }}
               />
             </div>
-            <p className="text-xs text-[#9ca3af]">
-              서브넷: Public 자동 배치 / 보안그룹: SG-ALB 자동 연결 / HTTPS:443 리스너
-            </p>
+          </div>
+
+          <div className="npc-preview-block">
+            <div className="npc-preview-label">자동 구성 항목</div>
+            <ul className="npc-preview-list">
+              <li>Public 서브넷 2개에 자동 배치 (Multi-AZ)</li>
+              <li>SG-ALB 자동 연결</li>
+              <li>HTTPS:443 리스너 + HTTP → HTTPS 자동 리다이렉트</li>
+            </ul>
           </div>
         </WizardLayout>
-      </div>
+      </>
     )
   }
 
+  // ── phase: 2-5 ECS ────────────────────────────────────────────
   if (phase === '2-5') {
     return (
-      <div className="p-6">
+      <>
+        <style>{styles}</style>
         <WizardLayout
           currentStep="2-5"
           completedSteps={completedSteps}
+          projectName={projectForm.name}
+          region={projectForm.region}
+          onExit={() => projectId && router.push(`/projects/${projectId}`)}
+          title="애플리케이션 컨테이너 설정"
+          description="ECS Fargate로 컨테이너를 띄웁니다. vCPU/메모리는 표준값으로 고정되고, 이미지 주소만 지정해주세요."
           sidekick={
-            projectForm.environment === 'prod'
-              ? 'prod 환경: 최소 2개 태스크 + CPU 70% 오토스케일링 자동 적용'
-              : 'dev 환경: 최소 1개 태스크 / 오토스케일링 비활성화'
+            isProd
+              ? '실서비스 환경: 최소 2개 컨테이너 상시 유지 + 트래픽 급증 시 자동 확장. 서비스 중단 없이 운영됩니다.'
+              : `${projectForm.environment} 환경: 최소 1개 컨테이너, 오토스케일링 OFF (비용 최소화).`
           }
           onPrev={() => setPhase('2-4')}
           onNext={() =>
@@ -328,20 +552,30 @@ if (phase === '2-1') {
           }
           isSubmitting={isSubmitting}
         >
-          <div className="space-y-3">
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <label className="text-sm font-medium">vCPU</label>
-                <Input defaultValue="1" readOnly className="border-white/10 text-white" style={{ backgroundColor: '#121214' }} />
-              </div>
-              <div>
-                <label className="text-sm font-medium">메모리 (MB)</label>
-                <Input defaultValue="2048" readOnly className="border-white/10 text-white" style={{ backgroundColor: '#121214' }} />
+          <div className="npc-grid-2">
+            <div className="npc-field">
+              <label className="npc-label">vCPU (고정)</label>
+              <div className="npc-input-wrap npc-readonly">
+                <input className="npc-input npc-mono" defaultValue="1" readOnly />
               </div>
             </div>
-            <div>
-              <label className="text-sm font-medium">컨테이너 이미지 URI</label>
-              <Input
+            <div className="npc-field">
+              <label className="npc-label">메모리 (고정)</label>
+              <div className="npc-input-wrap npc-readonly">
+                <input className="npc-input npc-mono" defaultValue="2048 MB" readOnly />
+              </div>
+            </div>
+          </div>
+
+          <div className="npc-field">
+            <label className="npc-label">배포할 컨테이너 이미지 주소</label>
+            <p className="npc-hint">
+              ECR 형식:{' '}
+              <span className="npc-mono-inline">{'{계정ID}'}.dkr.ecr.{'{리전}'}.amazonaws.com/{'{이미지명}'}:{'{태그}'}</span>
+            </p>
+            <div className="npc-input-wrap">
+              <input
+                className="npc-input npc-mono"
                 defaultValue={DEFAULT_CONTAINER_IMAGE}
                 onChange={(e) =>
                   setStepConfigs((prev) => ({
@@ -351,23 +585,30 @@ if (phase === '2-1') {
                 }
               />
             </div>
+            <p className="npc-hint">아직 이미지가 없다면 기본 샘플 이미지로 먼저 배포 후 교체할 수 있습니다.</p>
           </div>
         </WizardLayout>
-      </div>
+      </>
     )
   }
 
+  // ── phase: 2-6 RDS ────────────────────────────────────────────
   if (phase === '2-6') {
-    const isProd = projectForm.environment === 'prod'
     return (
-      <div className="p-6">
+      <>
+        <style>{styles}</style>
         <WizardLayout
           currentStep="2-6"
           completedSteps={completedSteps}
+          projectName={projectForm.name}
+          region={projectForm.region}
+          onExit={() => projectId && router.push(`/projects/${projectId}`)}
+          title="데이터베이스 자동 구성"
+          description={`규제 요건 기반으로 ${projectForm.environment} 환경에 맞춰 PostgreSQL이 자동 구성됩니다.`}
           sidekick={
             isProd
-              ? 'prod 환경: Multi-AZ ON / 백업 30일 / 암호화 ON 자동 적용'
-              : 'dev 환경: Multi-AZ OFF / 백업 0일 / 암호화 OFF'
+              ? '전자금융감독규정 준수를 위한 최소 보안 요건이 자동 적용됩니다. Multi-AZ + 백업 30일 + 암호화는 tfsec·checkov 필수 통과 조건입니다.'
+              : `${projectForm.environment} 환경 최소 사양이 적용됩니다. 개발팀이 직접 설정할 필요 없습니다.`
           }
           onPrev={() => setPhase('2-5')}
           onNext={async () => {
@@ -376,129 +617,702 @@ if (phase === '2-1') {
           }}
           isSubmitting={isSubmitting}
         >
-          <div className="space-y-2 text-sm bg-[#121214] rounded p-3">
-            <p className="font-medium">자동 적용 설정 ({projectForm.environment})</p>
-            <p>엔진: PostgreSQL 15</p>
-            <p>인스턴스: {isProd ? 'db.t3.medium' : 'db.t3.micro'}</p>
-            <p>Multi-AZ: {isProd ? 'ON' : 'OFF'}</p>
-            <p>백업 보존: {isProd ? '30일' : '0일'}</p>
-            <p>암호화: {isProd ? 'ON' : 'OFF'}</p>
+          <div className="npc-sg-block">
+            <div className="npc-sg-title">RDS PostgreSQL · {projectForm.environment}</div>
+            <div className="npc-sg-rows">
+              <div className="npc-sg-row">
+                <div className="npc-sg-key">엔진</div>
+                <div className="npc-sg-val">PostgreSQL 15</div>
+              </div>
+              <div className="npc-sg-row">
+                <div className="npc-sg-key">인스턴스</div>
+                <div className="npc-sg-val npc-mono">{isProd ? 'db.t3.medium' : 'db.t3.micro'}</div>
+              </div>
+              <div className="npc-sg-row">
+                <div className="npc-sg-key">Multi-AZ</div>
+                <div className="npc-sg-val">
+                  <span className={`npc-pill ${isProd ? 'npc-pill-on' : 'npc-pill-off'}`}>{isProd ? 'ON' : 'OFF'}</span>
+                  {isProd && <span className="npc-sg-note">이중화로 DB 장애 시 자동 전환</span>}
+                </div>
+              </div>
+              <div className="npc-sg-row">
+                <div className="npc-sg-key">백업 보존</div>
+                <div className="npc-sg-val">
+                  <span className="npc-mono">{isProd ? '30일' : '0일'}</span>
+                  {isProd && <span className="npc-sg-note">금융보안원 요건</span>}
+                </div>
+              </div>
+              <div className="npc-sg-row">
+                <div className="npc-sg-key">암호화</div>
+                <div className="npc-sg-val">
+                  <span className={`npc-pill ${isProd ? 'npc-pill-on' : 'npc-pill-off'}`}>{isProd ? 'ON' : 'OFF'}</span>
+                  {isProd && <span className="npc-sg-note">tfsec 필수 항목</span>}
+                </div>
+              </div>
+            </div>
           </div>
+          {isProd && (
+            <p className="npc-helper">
+              ※ 이 설정 없이는 다음 단계(Validation Loop)의 tfsec·checkov 보안 스캔을 통과할 수 없습니다.
+            </p>
+          )}
         </WizardLayout>
-      </div>
+      </>
     )
   }
 
+  // ── phase: summary ────────────────────────────────────────────
   if (phase === 'summary') {
-    const isProd        = projectForm.environment === 'prod'
-    const vpcCidr       = (stepConfigs['2-2']?.vpc_cidr as string) || '10.0.0.0/16'
-    const albName       = `${projectForm.prefix}-${projectForm.environment}-alb`
+    const vpcCidr        = (stepConfigs['2-2']?.vpc_cidr as string) || '10.0.0.0/16'
+    const albName        = `${projectForm.prefix}-${projectForm.environment}-alb`
     const containerImage = (stepConfigs['2-5']?.container_image as string) || DEFAULT_CONTAINER_IMAGE
 
     return (
-      <div className="px-6 py-8 md:px-12 md:py-12 max-w-2xl space-y-4">
-        <div className="flex justify-between items-center">
-          <h1 className="text-2xl font-bold">📋 리소스 요약</h1>
-          <span className="text-sm text-[#9ca3af]">배포 전 최종 확인</span>
+      <>
+        <style>{styles}</style>
+        <TopBar
+          stepLabel="Summary · 배포 직전"
+          onBack={() => setPhase('2-6')}
+          backLabel="← 설정으로"
+        />
+
+        <div className="npc-shell">
+          <div className="npc-shell-inner npc-wide">
+
+            <div className="npc-step-header">
+              <div className="npc-step-eyebrow">
+                <span className="npc-pip" />
+                Step 07 · 최종 확인
+              </div>
+              <h1 className="npc-step-title">배포 전 최종 확인</h1>
+              <p className="npc-step-desc">
+                아래 <span className="npc-emph">16개 리소스</span>가 AWS{' '}
+                <span className="npc-mono-inline">{projectForm.region}</span>에 생성됩니다. 배포 후 AWS 요금이 발생하니 내용을 확인하세요.
+              </p>
+            </div>
+
+            <div className="npc-summary-grid">
+
+              {/* 기본 설정 */}
+              <div className="npc-sum-card">
+                <div className="npc-sum-head">
+                  <div className="npc-sum-num">01</div>
+                  <div className="npc-sum-title">기본 설정</div>
+                </div>
+                <div className="npc-sum-rows">
+                  <div className="npc-sum-row"><span>서비스 이름</span><span className="npc-mono">{projectForm.name}</span></div>
+                  <div className="npc-sum-row"><span>네이밍 규칙</span><span className="npc-mono">{projectForm.prefix}-{projectForm.environment}-*</span></div>
+                  <div className="npc-sum-row"><span>배포 리전</span><span className="npc-mono">{projectForm.region}</span></div>
+                  <div className="npc-sum-row"><span>환경</span><span className="npc-mono">{projectForm.environment}</span></div>
+                </div>
+              </div>
+
+              {/* 네트워크 */}
+              <div className="npc-sum-card">
+                <div className="npc-sum-head">
+                  <div className="npc-sum-num">02</div>
+                  <div className="npc-sum-title">네트워크</div>
+                  <div className="npc-sum-sub">VPC · 서브넷 · IGW · NAT</div>
+                </div>
+                <div className="npc-sum-rows">
+                  <div className="npc-sum-row"><span>VPC CIDR</span><span className="npc-mono">{vpcCidr}</span></div>
+                  <div className="npc-sum-row"><span>서브넷</span><span className="npc-mono">{isProd ? 'Public 2 + Private 2 (Multi-AZ)' : 'Public 1 + Private 1'}</span></div>
+                  <div className="npc-sum-row"><span>NAT Gateway</span><span className="npc-mono">{isProd ? '생성' : '미생성'}</span></div>
+                </div>
+              </div>
+
+              {/* 보안 그룹 */}
+              <div className="npc-sum-card">
+                <div className="npc-sum-head">
+                  <div className="npc-sum-num">03</div>
+                  <div className="npc-sum-title">보안 그룹</div>
+                  <div className="npc-sum-sub">금융보안 3-Tier 망분리</div>
+                </div>
+                <div className="npc-sum-rows">
+                  <div className="npc-sum-row"><span className="npc-mono">SG-ALB</span><span className="npc-mono">외부 → 443, 80</span></div>
+                  <div className="npc-sum-row"><span className="npc-mono">SG-App</span><span className="npc-mono">ALB → 8080</span></div>
+                  <div className="npc-sum-row"><span className="npc-mono">SG-DB</span><span className="npc-mono">App → 5432</span></div>
+                </div>
+              </div>
+
+              {/* ALB */}
+              <div className="npc-sum-card">
+                <div className="npc-sum-head">
+                  <div className="npc-sum-num">04</div>
+                  <div className="npc-sum-title">ALB</div>
+                  <div className="npc-sum-sub">로드 밸런서</div>
+                </div>
+                <div className="npc-sum-rows">
+                  <div className="npc-sum-row"><span>이름</span><span className="npc-mono">{albName}</span></div>
+                  <div className="npc-sum-row"><span>리스너</span><span className="npc-mono">HTTPS:443</span></div>
+                </div>
+              </div>
+
+              {/* ECS */}
+              <div className="npc-sum-card npc-sum-wide">
+                <div className="npc-sum-head">
+                  <div className="npc-sum-num">05</div>
+                  <div className="npc-sum-title">ECS Fargate</div>
+                  <div className="npc-sum-sub">앱 서버</div>
+                </div>
+                <div className="npc-sum-rows">
+                  <div className="npc-sum-row"><span>vCPU / 메모리</span><span className="npc-mono">1 vCPU · 2048 MB</span></div>
+                  <div className="npc-sum-row"><span>이미지</span><span className="npc-mono npc-break">{containerImage}</span></div>
+                  <div className="npc-sum-row"><span>최소 태스크</span><span className="npc-mono">{isProd ? '2 (고가용성)' : '1'}</span></div>
+                  <div className="npc-sum-row"><span>오토스케일링</span><span className="npc-mono">{isProd ? 'ON · CPU 70%' : 'OFF'}</span></div>
+                </div>
+              </div>
+
+              {/* RDS */}
+              <div className="npc-sum-card npc-sum-wide">
+                <div className="npc-sum-head">
+                  <div className="npc-sum-num">06</div>
+                  <div className="npc-sum-title">RDS PostgreSQL</div>
+                  <div className="npc-sum-sub">데이터베이스</div>
+                </div>
+                <div className="npc-sum-rows">
+                  <div className="npc-sum-row"><span>인스턴스</span><span className="npc-mono">{isProd ? 'db.t3.medium' : 'db.t3.micro'}</span></div>
+                  <div className="npc-sum-row"><span>Multi-AZ</span><span className="npc-mono">{isProd ? 'ON' : 'OFF'}</span></div>
+                  <div className="npc-sum-row"><span>백업 보존</span><span className="npc-mono">{isProd ? '30일' : '0일'}</span></div>
+                  <div className="npc-sum-row"><span>암호화</span><span className="npc-mono">{isProd ? 'ON' : 'OFF'}</span></div>
+                </div>
+              </div>
+            </div>
+
+            {/* Next steps banner */}
+            <div className="npc-next-banner">
+              <div className="npc-next-ico">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M9 11l3 3 7-7"/>
+                  <path d="M20 12v6a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h9"/>
+                </svg>
+              </div>
+              <div>
+                <div className="npc-next-label">다음 단계 · Validation Loop</div>
+                <div className="npc-next-text">
+                  <span className="npc-mono-inline">terraform validate</span> →{' '}
+                  <span className="npc-mono-inline">tfsec · checkov</span> 보안 스캔 →{' '}
+                  <span className="npc-mono-inline">Infracost</span> 비용 예측 →{' '}
+                  <span className="npc-mono-inline">terraform plan</span> 순서로 자동 검증 후 배포가 실행됩니다.
+                </div>
+              </div>
+            </div>
+
+            <div className="npc-nav-row">
+              <button className="npc-btn-prev" onClick={() => setPhase('2-6')}>
+                <span className="npc-arrow">←</span>
+                설정 다시 보기
+              </button>
+              <button
+                className="npc-btn-next"
+                onClick={() => projectId && router.push(`/projects/${projectId}/validate`)}
+              >
+                <span>검증 시작하기</span>
+                <span className="npc-arrow">→</span>
+              </button>
+            </div>
+          </div>
         </div>
-
-        <div className="space-y-3">
-          {/* 기본 설정 */}
-          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
-            <p className="font-medium text-sm text-[#9ca3af]">기본 설정</p>
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              <p className="text-[#9ca3af]">프로젝트명</p>
-              <p className="font-mono">{projectForm.name}</p>
-              <p className="text-[#9ca3af]">네이밍 규칙</p>
-              <p className="font-mono">{projectForm.prefix}-{projectForm.environment}-*</p>
-              <p className="text-[#9ca3af]">리전</p>
-              <p className="font-mono">{projectForm.region}</p>
-              <p className="text-[#9ca3af]">환경</p>
-              <p className="font-mono">{projectForm.environment}</p>
-            </div>
-          </div>
-
-          {/* 네트워크 */}
-          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
-            <p className="font-medium text-sm text-[#9ca3af]">네트워크</p>
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              <p className="text-[#9ca3af]">VPC CIDR</p>
-              <p className="font-mono">{vpcCidr}</p>
-              <p className="text-[#9ca3af]">서브넷 구성</p>
-              <p className="font-mono">{isProd ? 'Public 2 + Private 2' : 'Public 1 + Private 1'}</p>
-              <p className="text-[#9ca3af]">NAT Gateway</p>
-              <p className="font-mono">{isProd ? '생성' : '미생성'}</p>
-            </div>
-          </div>
-
-          {/* 보안 그룹 */}
-          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
-            <p className="font-medium text-sm text-[#9ca3af]">보안 그룹</p>
-            <div className="text-sm space-y-1">
-              <p className="font-mono">SG-ALB: 443, 80 ← 0.0.0.0/0</p>
-              <p className="font-mono">SG-App: 8080 ← SG-ALB</p>
-              <p className="font-mono">SG-DB: 5432 ← SG-App</p>
-            </div>
-          </div>
-
-          {/* ALB */}
-          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
-            <p className="font-medium text-sm text-[#9ca3af]">ALB</p>
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              <p className="text-[#9ca3af]">이름</p>
-              <p className="font-mono">{albName}</p>
-              <p className="text-[#9ca3af]">리스너</p>
-              <p className="font-mono">HTTPS:443</p>
-            </div>
-          </div>
-
-          {/* ECS */}
-          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
-            <p className="font-medium text-sm text-[#9ca3af]">ECS Fargate</p>
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              <p className="text-[#9ca3af]">vCPU</p>
-              <p className="font-mono">1</p>
-              <p className="text-[#9ca3af]">메모리</p>
-              <p className="font-mono">2048 MB</p>
-              <p className="text-[#9ca3af]">컨테이너 이미지</p>
-              <p className="font-mono text-xs break-all">{containerImage}</p>
-              <p className="text-[#9ca3af]">최소 태스크</p>
-              <p className="font-mono">{isProd ? '2' : '1'}</p>
-              <p className="text-[#9ca3af]">오토스케일링</p>
-              <p className="font-mono">{isProd ? 'ON (CPU 70%)' : 'OFF'}</p>
-            </div>
-          </div>
-
-          {/* RDS */}
-          <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2">
-            <p className="font-medium text-sm text-[#9ca3af]">RDS PostgreSQL</p>
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              <p className="text-[#9ca3af]">인스턴스</p>
-              <p className="font-mono">{isProd ? 'db.t3.medium' : 'db.t3.micro'}</p>
-              <p className="text-[#9ca3af]">Multi-AZ</p>
-              <p className="font-mono">{isProd ? 'ON' : 'OFF'}</p>
-              <p className="text-[#9ca3af]">백업 보존</p>
-              <p className="font-mono">{isProd ? '30일' : '0일'}</p>
-              <p className="text-[#9ca3af]">암호화</p>
-              <p className="font-mono">{isProd ? 'ON' : 'OFF'}</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex justify-between pt-2">
-          <Button variant="outline" onClick={() => setPhase('2-6')}>
-            ← 설정 수정
-          </Button>
-          <Button
-            className="bg-teal-600 hover:bg-teal-700"
-            onClick={() => projectId && router.push(`/projects/${projectId}/validate`)}
-          >
-            검증 시작하기 →
-          </Button>
-        </div>
-      </div>
+      </>
     )
   }
 
   return null
 }
+
+// ─── shared styles ─────────────────────────────────────────────
+const styles = `
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+/* Top bar (reused from WizardLayout look) */
+.npc-topbar {
+  position: sticky; top: 0; z-index: 30;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 18px 36px;
+  background: rgba(11, 14, 23, 0.85);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+.npc-top-left { display: flex; align-items: center; gap: 16px; }
+.npc-brand {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 800; font-size: 16px; letter-spacing: -0.02em;
+  color: #edf0f6;
+}
+.npc-mark {
+  width: 26px; height: 26px;
+  border-radius: 7px;
+  background:
+    radial-gradient(80% 80% at 30% 25%, rgba(255,165,61,0.7), transparent 60%),
+    radial-gradient(80% 80% at 70% 80%, rgba(90,163,255,0.7), transparent 60%),
+    #11151f;
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 0 4px 24px rgba(90,163,255,0.18), inset 0 0 12px rgba(255,255,255,0.06);
+  position: relative; flex-shrink: 0;
+}
+.npc-mark::after {
+  content: ""; position: absolute; top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: 9px; height: 9px; border-radius: 2px;
+  background: #fff; box-shadow: 0 0 12px rgba(255,255,255,0.8);
+}
+.npc-crumb-sep {
+  width: 6px; height: 6px; transform: rotate(45deg);
+  border-top: 1px solid #7a8298;
+  border-right: 1px solid #7a8298;
+}
+.npc-crumb-proj { display: flex; flex-direction: column; gap: 2px; }
+.npc-crumb-eyebrow {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 500;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #ffa53d;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.npc-crumb-name {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 15px;
+  color: #edf0f6; letter-spacing: -0.015em;
+}
+.npc-top-right { display: flex; align-items: center; gap: 14px; }
+.npc-step-counter {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: #aeb4c5;
+  padding: 6px 12px; border: 1px solid rgba(255,255,255,0.13);
+  border-radius: 100px; background: rgba(255,255,255,0.03);
+}
+.npc-btn-exit {
+  font-size: 13px; font-weight: 500;
+  color: #aeb4c5; background: none; border: none;
+  cursor: pointer; padding: 6px 10px;
+  transition: color 160ms; font-family: inherit;
+}
+.npc-btn-exit:hover { color: #edf0f6; }
+
+/* Shell */
+.npc-shell {
+  min-height: calc(100vh - 70px);
+  padding: 48px 36px 80px;
+  display: flex; justify-content: center;
+  color: #edf0f6;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+.npc-shell-inner { width: 100%; max-width: 600px; }
+.npc-shell-inner.npc-wide { max-width: 1080px; }
+
+.npc-step-header { margin-bottom: 28px; }
+.npc-step-eyebrow {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: #ffa53d;
+  padding: 5px 11px;
+  border: 1px solid rgba(255,165,61,0.3);
+  border-radius: 100px;
+  background: rgba(255,165,61,0.06);
+  margin-bottom: 16px;
+}
+.npc-pip {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #ffa53d; box-shadow: 0 0 8px #ffa53d;
+  animation: npc-pulse 1.6s ease-in-out infinite;
+}
+@keyframes npc-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.85); }
+}
+.npc-step-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 36px;
+  letter-spacing: -0.03em; line-height: 1.15;
+  margin: 0 0 12px; color: #edf0f6;
+}
+.npc-step-desc {
+  font-size: 15px; color: #aeb4c5;
+  line-height: 1.6; margin: 0; max-width: 560px;
+}
+.npc-emph { color: #edf0f6; font-weight: 600; }
+
+/* Form card */
+.npc-form-card {
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.005));
+  padding: 28px;
+  margin-bottom: 20px;
+  display: flex; flex-direction: column; gap: 22px;
+}
+
+.npc-field { display: flex; flex-direction: column; gap: 8px; }
+.npc-label {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #aeb4c5;
+}
+.npc-hint {
+  font-size: 12.5px; color: #7a8298;
+  line-height: 1.5; margin: 0;
+}
+.npc-hint.npc-preview { color: #aeb4c5; }
+.npc-mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+.npc-mono-inline {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  color: #edf0f6;
+  background: rgba(255,255,255,0.05);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.92em;
+}
+
+.npc-input-wrap {
+  position: relative;
+  display: flex; align-items: center;
+  border: 1px solid rgba(255,255,255,0.13);
+  border-radius: 10px;
+  background: rgba(255,255,255,0.025);
+  transition: border-color 200ms, background 200ms, box-shadow 200ms;
+}
+.npc-input-wrap:hover { border-color: rgba(255,255,255,0.20); }
+.npc-input-wrap:focus-within {
+  border-color: rgba(255,165,61,0.55);
+  background: rgba(255,255,255,0.04);
+  box-shadow: 0 0 0 4px rgba(255,165,61,0.10);
+}
+.npc-input-wrap.npc-error {
+  border-color: rgba(255,118,118,0.55);
+  box-shadow: 0 0 0 4px rgba(255,118,118,0.10);
+}
+.npc-input-wrap.npc-readonly {
+  background: rgba(255,255,255,0.015);
+  border-style: dashed;
+}
+.npc-input {
+  flex: 1; min-width: 0;
+  background: transparent; border: none; outline: none;
+  color: #edf0f6;
+  font-family: 'Pretendard Variable', -apple-system, sans-serif;
+  font-size: 14.5px;
+  padding: 13px 16px;
+  letter-spacing: -0.005em;
+}
+.npc-input.npc-mono { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 13.5px; letter-spacing: 0.01em; }
+.npc-input::placeholder { color: #7a8298; }
+.npc-input-wrap.npc-readonly .npc-input { color: #aeb4c5; cursor: not-allowed; }
+
+.npc-field-error {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; color: #ff7676;
+  margin: 0;
+  display: flex; align-items: center; gap: 6px;
+}
+.npc-field-error::before {
+  content: "!"; display: grid; place-items: center;
+  width: 14px; height: 14px; border-radius: 50%;
+  background: rgba(255,118,118,0.18);
+  font-size: 9px; font-weight: 700;
+}
+
+.npc-grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.npc-helper {
+  font-size: 12.5px; color: #7a8298;
+  line-height: 1.55; margin: 4px 0 0;
+}
+
+/* Env selector cards */
+.npc-env-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.npc-env-card {
+  position: relative;
+  padding: 14px 14px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: rgba(255,255,255,0.02);
+  text-align: left;
+  cursor: pointer;
+  transition: all 180ms;
+  display: flex; flex-direction: column; gap: 4px;
+  font-family: inherit;
+}
+.npc-env-card:hover { border-color: rgba(255,255,255,0.20); background: rgba(255,255,255,0.04); }
+.npc-env-card .npc-env-name {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px; font-weight: 600;
+  color: #edf0f6; letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.npc-env-card .npc-env-desc { font-size: 11.5px; color: #aeb4c5; line-height: 1.4; }
+.npc-env-card .npc-env-check {
+  position: absolute; top: 12px; right: 12px;
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  background: transparent; color: transparent;
+  border: 1px solid rgba(255,255,255,0.20);
+  transition: all 200ms;
+}
+.npc-env-card.npc-active {
+  background: rgba(255,165,61,0.06);
+  border-color: rgba(255,165,61,0.45);
+  box-shadow: 0 0 0 4px rgba(255,165,61,0.08), 0 0 24px -8px rgba(255,165,61,0.4);
+}
+.npc-env-card.npc-active .npc-env-name { color: #ffa53d; }
+.npc-env-card.npc-active .npc-env-check {
+  background: #ffa53d;
+  border-color: #ffa53d;
+  color: #0a0d14;
+}
+.npc-env-card[data-tone="yellow"].npc-active {
+  background: rgba(245,208,97,0.06);
+  border-color: rgba(245,208,97,0.45);
+  box-shadow: 0 0 0 4px rgba(245,208,97,0.08), 0 0 24px -8px rgba(245,208,97,0.4);
+}
+.npc-env-card[data-tone="yellow"].npc-active .npc-env-name { color: #f5d061; }
+.npc-env-card[data-tone="yellow"].npc-active .npc-env-check { background: #f5d061; border-color: #f5d061; }
+.npc-env-card[data-tone="blue"].npc-active {
+  background: rgba(90,163,255,0.06);
+  border-color: rgba(90,163,255,0.45);
+  box-shadow: 0 0 0 4px rgba(90,163,255,0.08), 0 0 24px -8px rgba(90,163,255,0.4);
+}
+.npc-env-card[data-tone="blue"].npc-active .npc-env-name { color: #5aa3ff; }
+.npc-env-card[data-tone="blue"].npc-active .npc-env-check { background: #5aa3ff; border-color: #5aa3ff; }
+
+.npc-region-note {
+  font-size: 12.5px;
+  color: #7a8298;
+  line-height: 1.55; margin: 0;
+  padding-top: 4px;
+}
+
+/* Preview block (used for naming preview, subnet preview, etc) */
+.npc-preview-block {
+  padding: 16px 18px;
+  border-radius: 10px;
+  border: 1px dashed rgba(255,165,61,0.25);
+  background: rgba(255,165,61,0.04);
+}
+.npc-preview-label {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #ffa53d; margin-bottom: 10px;
+}
+.npc-preview-list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 5px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px;
+  color: #edf0f6;
+}
+.npc-preview-list li::before {
+  content: "›";
+  color: #ffa53d;
+  margin-right: 8px;
+}
+.npc-preview-more {
+  font-family: 'Pretendard Variable', -apple-system, sans-serif;
+  font-size: 12px;
+  color: #7a8298;
+  margin-top: 8px;
+  padding-left: 18px;
+}
+
+/* Security group / RDS read-only block */
+.npc-sg-block {
+  padding: 20px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.10);
+  background: rgba(255,255,255,0.018);
+}
+.npc-sg-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px; font-weight: 600;
+  color: #edf0f6;
+  margin-bottom: 14px;
+  letter-spacing: -0.01em;
+}
+.npc-sg-rows { display: flex; flex-direction: column; }
+.npc-sg-row {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 16px;
+  padding: 10px 0;
+  border-bottom: 1px dashed rgba(255,255,255,0.06);
+  align-items: center;
+}
+.npc-sg-row:last-child { border-bottom: none; }
+.npc-sg-key {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px; font-weight: 600;
+  color: #ffa53d;
+  letter-spacing: 0.04em;
+}
+.npc-sg-val {
+  font-size: 13.5px;
+  color: #aeb4c5;
+  line-height: 1.5;
+  display: flex; align-items: center; gap: 10px;
+  flex-wrap: wrap;
+}
+.npc-sg-val.npc-mono { font-family: 'JetBrains Mono', ui-monospace, monospace; color: #edf0f6; }
+.npc-arrow-glyph {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  color: #7a8298; font-size: 14px;
+}
+.npc-sg-note { font-size: 11.5px; color: #7a8298; }
+
+.npc-pill {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  padding: 2px 8px;
+  border-radius: 100px;
+  border: 1px solid;
+}
+.npc-pill-on { color: #6ee7a0; border-color: rgba(110,231,160,0.35); background: rgba(110,231,160,0.10); }
+.npc-pill-off { color: #7a8298; border-color: rgba(255,255,255,0.13); background: rgba(255,255,255,0.025); }
+
+/* Nav buttons (mirror WizardLayout) */
+.npc-nav-row { display: flex; justify-content: space-between; align-items: center; padding-top: 8px; }
+.npc-btn-prev {
+  font-size: 13.5px; font-weight: 500;
+  color: #aeb4c5; background: none; border: none;
+  cursor: pointer; padding: 10px 8px;
+  display: inline-flex; align-items: center; gap: 8px;
+  transition: color 160ms;
+  font-family: inherit;
+}
+.npc-btn-prev:hover:not(:disabled) { color: #edf0f6; }
+.npc-btn-prev:hover:not(:disabled) .npc-arrow { transform: translateX(-3px); }
+.npc-btn-prev .npc-arrow { transition: transform 200ms; display: inline-block; }
+.npc-btn-prev:disabled { opacity: 0.3; cursor: not-allowed; }
+
+.npc-btn-next {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 13px 22px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px; font-weight: 600;
+  letter-spacing: -0.005em;
+  border-radius: 10px;
+  border: 1px solid #f3f4f8;
+  background: linear-gradient(180deg, #ffffff, #e8eaf0);
+  color: #0a0d14;
+  cursor: pointer;
+  transition: transform 180ms, box-shadow 180ms, filter 180ms;
+}
+.npc-btn-next:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 30px -8px rgba(255,255,255,0.35), 0 0 30px -10px rgba(255,165,61,0.5);
+}
+.npc-btn-next:disabled { opacity: 0.6; cursor: not-allowed; filter: saturate(0.6); }
+.npc-btn-next .npc-arrow { transition: transform 200ms; display: inline-block; }
+.npc-btn-next:hover:not(:disabled) .npc-arrow { transform: translateX(3px); }
+
+.npc-spinner {
+  width: 14px; height: 14px; border-radius: 50%;
+  border: 2px solid rgba(10,13,20,0.2);
+  border-top-color: rgba(10,13,20,0.9);
+  animation: npc-spin 700ms linear infinite;
+  display: inline-block;
+}
+@keyframes npc-spin { to { transform: rotate(360deg); } }
+
+/* Summary cards */
+.npc-summary-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+.npc-sum-card {
+  position: relative;
+  padding: 22px 22px 20px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.10);
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.005));
+  overflow: hidden;
+}
+.npc-sum-card::before {
+  content: ""; position: absolute;
+  top: 0; left: 22px; right: 22px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255,165,61,0.5), transparent);
+}
+.npc-sum-card.npc-sum-wide { grid-column: span 2; }
+.npc-sum-head {
+  display: flex; align-items: baseline; gap: 12px;
+  margin-bottom: 14px;
+}
+.npc-sum-num {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px; font-weight: 600;
+  letter-spacing: 0.12em;
+  color: #ffa53d;
+}
+.npc-sum-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 16px; font-weight: 700;
+  letter-spacing: -0.015em;
+  color: #edf0f6;
+}
+.npc-sum-sub {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; color: #7a8298;
+  letter-spacing: 0.06em;
+  margin-left: auto;
+}
+.npc-sum-rows { display: flex; flex-direction: column; }
+.npc-sum-row {
+  display: flex; justify-content: space-between; gap: 16px;
+  padding: 8px 0;
+  border-bottom: 1px dashed rgba(255,255,255,0.06);
+  font-size: 13.5px;
+  align-items: center;
+}
+.npc-sum-row:last-child { border-bottom: none; }
+.npc-sum-row > span:first-child { color: #aeb4c5; flex-shrink: 0; }
+.npc-sum-row > span:last-child { color: #edf0f6; font-weight: 500; text-align: right; }
+.npc-mono.npc-break { word-break: break-all; font-size: 12px; }
+
+/* Validation next-step banner */
+.npc-next-banner {
+  display: flex; gap: 14px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  border: 1px solid rgba(90,163,255,0.22);
+  background: linear-gradient(135deg, rgba(90,163,255,0.06), rgba(90,163,255,0.02));
+  margin-bottom: 24px;
+}
+.npc-next-ico {
+  flex-shrink: 0;
+  width: 32px; height: 32px;
+  border-radius: 8px;
+  border: 1px solid rgba(90,163,255,0.3);
+  background: rgba(90,163,255,0.10);
+  color: #5aa3ff;
+  display: grid; place-items: center;
+}
+.npc-next-label {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #5aa3ff; margin-bottom: 4px;
+}
+.npc-next-text { font-size: 13px; color: #aeb4c5; line-height: 1.6; }
+
+@media (max-width: 900px) {
+  .npc-topbar { padding: 14px 20px; }
+  .npc-top-left .npc-crumb-sep, .npc-top-left .npc-crumb-proj { display: none; }
+  .npc-shell { padding: 32px 20px 64px; }
+  .npc-step-title { font-size: 28px; }
+  .npc-env-grid { grid-template-columns: 1fr; }
+  .npc-grid-2 { grid-template-columns: 1fr; }
+  .npc-summary-grid { grid-template-columns: 1fr; }
+  .npc-sum-card.npc-sum-wide { grid-column: span 1; }
+}
+`

--- a/frontend/components/craftops/IntentAnalysis.tsx
+++ b/frontend/components/craftops/IntentAnalysis.tsx
@@ -3,10 +3,6 @@
 
 import { useState } from 'react'
 import { apiClient } from '@/lib/api'
-import { Button } from '@/components/ui/button'
-import { Textarea } from '@/components/ui/textarea'
-import { Card, CardContent } from '@/components/ui/card'
-import { Alert, AlertDescription } from '@/components/ui/alert'
 
 interface AnalysisResult {
   analysis_id: string
@@ -28,10 +24,10 @@ const RESOURCE_LABELS: Record<string, string> = {
 }
 
 export function IntentAnalysis({ projectId, onComplete }: Props) {
-  const [prompt, setPrompt] = useState('')
+  const [prompt, setPrompt]           = useState('')
   const [isAnalyzing, setIsAnalyzing] = useState(false)
-  const [result, setResult] = useState<AnalysisResult | null>(null)
-  const [error, setError] = useState('')
+  const [result, setResult]           = useState<AnalysisResult | null>(null)
+  const [error, setError]             = useState('')
 
   const handleAnalyze = async () => {
     if (!prompt.trim()) return
@@ -55,58 +51,258 @@ export function IntentAnalysis({ projectId, onComplete }: Props) {
   }
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <label className="text-sm font-medium">인프라 요구사항을 자연어로 입력하세요</label>
-        <Textarea
-          value={prompt}
-          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setPrompt(e.target.value)}
-          placeholder="예) 프로덕션용 Python API 서버, PostgreSQL DB, 오레곤 리전, 오토스케일링 필요"
-          rows={4}
-        />
-      </div>
+    <>
+      <style>{styles}</style>
 
-      <Button
-        className="bg-teal-600 hover:bg-teal-700"
-        onClick={handleAnalyze}
-        disabled={isAnalyzing || !prompt.trim()}
-      >
-        {isAnalyzing ? (
-          <span className="flex items-center gap-2">
-            <span className="animate-spin">⏳</span> AI 분석 중...
-          </span>
-        ) : (
-          '분석하기 →'
-        )}
-      </Button>
+      <div className="ia-wrap">
 
-      {error && (
-        <Alert variant="destructive">
-          <AlertDescription>{error}</AlertDescription>
-        </Alert>
-      )}
-
-      {result && (
-        <Card className="border-white/8 bg-[#121214]">
-          <CardContent className="p-4 space-y-3">
-            <p className="font-medium text-[#9ca3af]">── AI 분석 결과 ──</p>
-            <div className="space-y-1">
-              {result.resources.map((r) => (
-                <div key={r} className="flex items-center gap-2 text-sm">
-                  <span className="text-emerald-400">✅</span>
-                  <span>{RESOURCE_LABELS[r] ?? r}</span>
-                </div>
-              ))}
+        {/* Prompt input */}
+        <div className="ia-field">
+          <label className="ia-label">
+            <span className="ia-label-text">인프라 요구사항을 자연어로 입력하세요</span>
+            <span className="ia-label-hint">Gemini가 분석해 16개 AWS 리소스 구성을 제안합니다.</span>
+          </label>
+          <div className="ia-textarea-wrap">
+            <textarea
+              className="ia-textarea"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="예) 프로덕션용 Python API 서버, PostgreSQL DB, 오레곤 리전, 오토스케일링 필요"
+              rows={4}
+            />
+            <div className="ia-textarea-foot">
+              <span className="ia-char-count">{prompt.length}자</span>
+              <span className="ia-hint-row">
+                <kbd className="ia-kbd">⌘</kbd>
+                <kbd className="ia-kbd">↵</kbd>
+                <span>분석 실행</span>
+              </span>
             </div>
-            <Button
-              className="w-full bg-teal-600 hover:bg-teal-700 mt-2"
-              onClick={() => onComplete(result)}
-            >
-              설정 시작하기 →
-            </Button>
-          </CardContent>
-        </Card>
-      )}
-    </div>
+          </div>
+        </div>
+
+        {/* Analyze button */}
+        <button
+          className="ia-btn-primary"
+          onClick={handleAnalyze}
+          disabled={isAnalyzing || !prompt.trim()}
+        >
+          {isAnalyzing ? (
+            <>
+              <span className="ia-spinner" />
+              <span>AI 분석 중...</span>
+            </>
+          ) : (
+            <>
+              <span>분석하기</span>
+              <span className="ia-arrow">→</span>
+            </>
+          )}
+        </button>
+
+        {/* Error */}
+        {error && (
+          <div className="ia-alert" role="alert">
+            <span className="ia-alert-ico">!</span>
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Result */}
+        {result && (
+          <div className="ia-result">
+            <div className="ia-result-head">
+              <div className="ia-result-eyebrow">
+                <span className="ia-pip" />
+                AI 분석 결과
+              </div>
+              <span className="ia-result-count">{result.resources.length}개 컴포넌트</span>
+            </div>
+
+            <ul className="ia-result-list">
+              {result.resources.map((r) => (
+                <li key={r} className="ia-result-item">
+                  <span className="ia-check">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                      <polyline points="20 6 9 17 4 12"/>
+                    </svg>
+                  </span>
+                  <span className="ia-item-label">{RESOURCE_LABELS[r] ?? r}</span>
+                </li>
+              ))}
+            </ul>
+
+            <button className="ia-btn-primary ia-btn-full" onClick={() => onComplete(result)}>
+              <span>설정 시작하기</span>
+              <span className="ia-arrow">→</span>
+            </button>
+          </div>
+        )}
+      </div>
+    </>
   )
 }
+
+const styles = `
+.ia-wrap {
+  display: flex; flex-direction: column; gap: 22px;
+  color: #edf0f6;
+  font-family: 'Pretendard Variable', -apple-system, sans-serif;
+}
+
+.ia-field { display: flex; flex-direction: column; gap: 10px; }
+.ia-label { display: flex; flex-direction: column; gap: 4px; }
+.ia-label-text {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #aeb4c5;
+}
+.ia-label-hint { font-size: 12.5px; color: #7a8298; line-height: 1.5; }
+
+.ia-textarea-wrap {
+  border: 1px solid rgba(255,255,255,0.13);
+  border-radius: 12px;
+  background: rgba(255,255,255,0.025);
+  transition: border-color 200ms, background 200ms, box-shadow 200ms;
+  overflow: hidden;
+}
+.ia-textarea-wrap:hover { border-color: rgba(255,255,255,0.20); }
+.ia-textarea-wrap:focus-within {
+  border-color: rgba(255,165,61,0.55);
+  background: rgba(255,255,255,0.04);
+  box-shadow: 0 0 0 4px rgba(255,165,61,0.10);
+}
+.ia-textarea {
+  width: 100%;
+  background: transparent;
+  border: none; outline: none; resize: vertical;
+  color: #edf0f6;
+  font-family: inherit;
+  font-size: 14.5px;
+  line-height: 1.6;
+  padding: 16px 18px 12px;
+  letter-spacing: -0.005em;
+  min-height: 110px;
+}
+.ia-textarea::placeholder { color: #7a8298; }
+.ia-textarea-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 18px 12px;
+  border-top: 1px dashed rgba(255,255,255,0.06);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; color: #7a8298;
+  letter-spacing: 0.02em;
+}
+.ia-hint-row { display: inline-flex; align-items: center; gap: 6px; }
+.ia-kbd {
+  display: inline-grid; place-items: center;
+  min-width: 18px; height: 18px;
+  padding: 0 5px;
+  font-family: inherit; font-size: 10.5px;
+  color: #aeb4c5;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.13);
+  border-radius: 4px;
+}
+
+.ia-btn-primary {
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 13px 22px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px; font-weight: 600;
+  letter-spacing: -0.005em;
+  border-radius: 10px;
+  border: 1px solid #f3f4f8;
+  background: linear-gradient(180deg, #ffffff, #e8eaf0);
+  color: #0a0d14;
+  cursor: pointer;
+  transition: transform 180ms, box-shadow 180ms, filter 180ms;
+}
+.ia-btn-primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 30px -8px rgba(255,255,255,0.35), 0 0 30px -10px rgba(255,165,61,0.5);
+}
+.ia-btn-primary:disabled { opacity: 0.5; cursor: not-allowed; filter: saturate(0.6); }
+.ia-btn-primary .ia-arrow { transition: transform 200ms; display: inline-block; }
+.ia-btn-primary:hover:not(:disabled) .ia-arrow { transform: translateX(3px); }
+.ia-btn-full { width: 100%; justify-content: center; }
+
+.ia-spinner {
+  width: 14px; height: 14px; border-radius: 50%;
+  border: 2px solid rgba(10,13,20,0.2);
+  border-top-color: rgba(10,13,20,0.9);
+  animation: ia-spin 700ms linear infinite;
+  display: inline-block;
+}
+@keyframes ia-spin { to { transform: rotate(360deg); } }
+
+.ia-alert {
+  display: flex; gap: 10px; align-items: center;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,118,118,0.3);
+  background: rgba(255,118,118,0.06);
+  color: #ff7676;
+  font-size: 13px; line-height: 1.5;
+}
+.ia-alert-ico {
+  flex-shrink: 0; width: 18px; height: 18px;
+  border-radius: 50%; background: rgba(255,118,118,0.18);
+  display: grid; place-items: center;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-weight: 700; font-size: 11px;
+}
+
+.ia-result {
+  border-radius: 14px;
+  border: 1px solid rgba(110,231,160,0.22);
+  background: linear-gradient(180deg, rgba(110,231,160,0.05), rgba(110,231,160,0.01));
+  padding: 22px 22px 20px;
+  display: flex; flex-direction: column; gap: 16px;
+}
+.ia-result-head { display: flex; align-items: center; justify-content: space-between; }
+.ia-result-eyebrow {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #6ee7a0;
+}
+.ia-pip {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #6ee7a0; box-shadow: 0 0 8px #6ee7a0;
+}
+.ia-result-count {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; color: #aeb4c5;
+  letter-spacing: 0.1em;
+  padding: 3px 9px;
+  border-radius: 100px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: rgba(255,255,255,0.04);
+}
+
+.ia-result-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.ia-result-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(255,255,255,0.025);
+  border: 1px solid rgba(255,255,255,0.08);
+}
+.ia-check {
+  flex-shrink: 0;
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: rgba(110,231,160,0.18);
+  border: 1px solid rgba(110,231,160,0.4);
+  display: grid; place-items: center;
+  color: #6ee7a0;
+}
+.ia-item-label {
+  font-size: 13.5px; color: #edf0f6;
+  font-weight: 500; letter-spacing: -0.005em;
+}
+`

--- a/frontend/components/craftops/WizardLayout.tsx
+++ b/frontend/components/craftops/WizardLayout.tsx
@@ -6,15 +6,16 @@ import { ReactNode } from 'react'
 interface Step {
   id: string
   label: string
+  sub: string
 }
 
 const STEPS: Step[] = [
-  { id: '2-1', label: '기본 설정' },
-  { id: '2-2', label: '네트워크' },
-  { id: '2-3', label: '보안 그룹' },
-  { id: '2-4', label: 'ALB' },
-  { id: '2-5', label: 'ECS' },
-  { id: '2-6', label: 'RDS' },
+  { id: '2-1', label: '기본 설정',   sub: 'Naming · Region' },
+  { id: '2-2', label: '네트워크',    sub: 'VPC · Subnet' },
+  { id: '2-3', label: '보안 그룹',   sub: '3-Tier 망분리' },
+  { id: '2-4', label: '로드 밸런서', sub: 'ALB · Multi-AZ' },
+  { id: '2-5', label: '애플리케이션', sub: 'ECS Fargate' },
+  { id: '2-6', label: '데이터베이스', sub: 'RDS PostgreSQL' },
 ]
 
 interface Props {
@@ -26,6 +27,14 @@ interface Props {
   onPrev?: () => void
   onNext?: () => void
   isSubmitting?: boolean
+  // ─ optional chrome (used by NewProjectPageContent) ─────────
+  projectName?: string
+  region?: string
+  onExit?: () => void
+  /** title above the step content, e.g. "VPC 네트워크 대역을 정해주세요." */
+  title?: string
+  /** sub-description shown under title */
+  description?: string
 }
 
 export function WizardLayout({
@@ -36,70 +45,466 @@ export function WizardLayout({
   onPrev,
   onNext,
   isSubmitting,
+  projectName,
+  region,
+  onExit,
+  title,
+  description,
 }: Props) {
   const stepIndex = STEPS.findIndex((s) => s.id === currentStep)
+  const current   = STEPS[stepIndex]
+  const totalDone = completedSteps.length
+  const pct       = Math.round((totalDone / STEPS.length) * 100)
+  const stepNum   = String(stepIndex + 1).padStart(2, '0')
 
   return (
-    <div className="grid grid-cols-3 gap-6">
-      {/* 왼쪽: 설정 폼 영역 */}
-      <div className="col-span-2 space-y-4">
-        <div>
-          <p className="text-xs text-[#9ca3af]">
-            Step 2-{stepIndex + 1} / 6
-          </p>
-          <h2 className="text-xl font-bold">
-            {STEPS[stepIndex]?.label}
-          </h2>
-        </div>
+    <>
+      <style>{styles}</style>
 
-        {children}
-
-        {sidekick && (
-          <div className="bg-blue-500/10 border border-blue-500/20 rounded p-3 text-sm text-blue-400">
-            💡 {sidekick}
-          </div>
-        )}
-
-        <div className="flex justify-between pt-4">
-          <button
-            onClick={onPrev}
-            disabled={!onPrev}
-            className="text-[#9ca3af] hover:text-white disabled:opacity-30 transition-colors"
-          >
-            ← 이전
-          </button>
-          <button
-            onClick={onNext}
-            disabled={isSubmitting}
-            className="bg-teal-600 text-white px-4 py-2 rounded hover:bg-teal-700 disabled:opacity-50"
-          >
-            {isSubmitting ? '저장 중...' : '다음 →'}
-          </button>
-        </div>
-      </div>
-
-      {/* 오른쪽: 의존성 트리 */}
-      <div className="col-span-1">
-        <div className="bg-[#121214] border border-white/8 rounded-2xl p-4 space-y-2 sticky top-4">
-          <p className="text-sm font-medium text-[#9ca3af]">── 의존성 트리 ──</p>
-          {STEPS.map((step) => {
-            const isDone    = completedSteps.includes(step.id)
-            const isCurrent = step.id === currentStep
-            return (
-              <div
-                key={step.id}
-                className={`text-sm flex items-center gap-2 ${
-                  isCurrent ? 'font-bold text-teal-400' : 'text-[#9ca3af]'
-                }`}
-              >
-                <span>{isDone ? '✅' : isCurrent ? '⏳' : '⬜'}</span>
-                <span>{step.label}</span>
+      {/* ─── Top bar ─── */}
+      <div className="wz-topbar">
+        <div className="wz-top-left">
+          <span className="wz-brand">
+            <span className="wz-mark"></span>
+            AutoOps
+          </span>
+          {projectName && (
+            <>
+              <span className="wz-crumb-sep" />
+              <div className="wz-crumb-proj">
+                <span className="wz-crumb-eyebrow">
+                  <span className="wz-pip" />
+                  CraftOps · 인프라 설계
+                </span>
+                <span className="wz-crumb-name">{projectName}</span>
               </div>
-            )
-          })}
-          <p className="text-xs text-[#9ca3af] pt-2">총 16개 리소스</p>
+            </>
+          )}
+        </div>
+        <div className="wz-top-right">
+          <span className="wz-step-counter">
+            Step <span className="wz-num">{stepNum}</span> / 06
+          </span>
+          {onExit && (
+            <button className="wz-btn-exit" onClick={onExit}>나가기</button>
+          )}
         </div>
       </div>
-    </div>
+
+      {/* ─── Page ─── */}
+      <div className="wz-page">
+
+        {/* Sidebar */}
+        <aside className="wz-sidebar">
+          <div className="wz-progress-card">
+
+            <div className="wz-progress-head">
+              <div className="wz-progress-eyebrow">진행 상황</div>
+              <h2 className="wz-progress-title">AWS 인프라 설계</h2>
+              <div className="wz-bar-wrap">
+                <div className="wz-bar"><div className="wz-bar-fill" style={{ width: `${pct}%` }} /></div>
+                <span className="wz-bar-pct">{pct}%</span>
+              </div>
+            </div>
+
+            <div className="wz-steps">
+              {STEPS.map((s, idx) => {
+                const isDone    = completedSteps.includes(s.id)
+                const isCurrent = s.id === currentStep
+                const cls = `wz-step${isDone ? ' wz-done' : ''}${isCurrent ? ' wz-current' : ''}`
+                return (
+                  <div key={s.id} className={cls}>
+                    <div className="wz-step-num">
+                      {isDone ? (
+                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                          <polyline points="20 6 9 17 4 12"/>
+                        </svg>
+                      ) : (idx + 1)}
+                    </div>
+                    <div className="wz-step-body">
+                      <div className="wz-step-label">{s.label}</div>
+                      <div className="wz-step-sub">
+                        {isCurrent ? `진행 중 · ${s.sub}` : s.sub}
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+
+            <div className="wz-progress-foot">
+              <span>리소스</span>
+              <span><span className="wz-foot-count">16</span>개 / AWS {region ?? 'us-west-2'}</span>
+            </div>
+          </div>
+        </aside>
+
+        {/* Main */}
+        <main className="wz-main">
+
+          <div className="wz-step-header">
+            <div className="wz-step-eyebrow">
+              <span className="wz-pip" />
+              Step {stepNum} · {current?.label}
+            </div>
+            {title && <h1 className="wz-step-title">{title}</h1>}
+            {description && <p className="wz-step-desc">{description}</p>}
+          </div>
+
+          <div className="wz-form-card">
+            {children}
+          </div>
+
+          {sidekick && (
+            <div className="wz-sidekick">
+              <div className="wz-sidekick-ico">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="10"/>
+                  <path d="M12 16v-4M12 8h.01"/>
+                </svg>
+              </div>
+              <div className="wz-sidekick-body">
+                <div className="wz-sidekick-label">CraftOps Tip</div>
+                <p className="wz-sidekick-text">{sidekick}</p>
+              </div>
+            </div>
+          )}
+
+          <div className="wz-nav-row">
+            <button className="wz-btn-prev" onClick={onPrev} disabled={!onPrev}>
+              <span className="wz-arrow">←</span>
+              이전
+            </button>
+            <button className="wz-btn-next" onClick={onNext} disabled={isSubmitting}>
+              {isSubmitting ? (
+                <>
+                  <span className="wz-spinner" />
+                  <span>저장 중...</span>
+                </>
+              ) : (
+                <>
+                  <span>다음</span>
+                  <span className="wz-arrow">→</span>
+                </>
+              )}
+            </button>
+          </div>
+
+        </main>
+      </div>
+    </>
   )
 }
+
+// ─── styles ─────────────────────────────────────────────────────
+const styles = `
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+.wz-topbar {
+  position: sticky; top: 0; z-index: 30;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 18px 36px;
+  background: rgba(11, 14, 23, 0.85);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+.wz-top-left { display: flex; align-items: center; gap: 16px; }
+.wz-brand {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 800; font-size: 16px; letter-spacing: -0.02em;
+  color: #edf0f6;
+}
+.wz-mark {
+  width: 26px; height: 26px;
+  border-radius: 7px;
+  background:
+    radial-gradient(80% 80% at 30% 25%, rgba(255,165,61,0.7), transparent 60%),
+    radial-gradient(80% 80% at 70% 80%, rgba(90,163,255,0.7), transparent 60%),
+    #11151f;
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 0 4px 24px rgba(90,163,255,0.18), inset 0 0 12px rgba(255,255,255,0.06);
+  position: relative; flex-shrink: 0;
+}
+.wz-mark::after {
+  content: ""; position: absolute; top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: 9px; height: 9px; border-radius: 2px;
+  background: #fff; box-shadow: 0 0 12px rgba(255,255,255,0.8);
+}
+.wz-crumb-sep {
+  width: 6px; height: 6px; transform: rotate(45deg);
+  border-top: 1px solid #7a8298;
+  border-right: 1px solid #7a8298;
+}
+.wz-crumb-proj { display: flex; flex-direction: column; gap: 2px; }
+.wz-crumb-eyebrow {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 500;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #ffa53d;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.wz-crumb-name {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 15px;
+  color: #edf0f6; letter-spacing: -0.015em;
+}
+.wz-top-right { display: flex; align-items: center; gap: 14px; }
+.wz-step-counter {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: #aeb4c5;
+  padding: 6px 12px; border: 1px solid rgba(255,255,255,0.13);
+  border-radius: 100px; background: rgba(255,255,255,0.03);
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.wz-step-counter .wz-num { color: #ffa53d; font-weight: 600; }
+.wz-btn-exit {
+  font-size: 13px; font-weight: 500;
+  color: #aeb4c5; background: none; border: none;
+  cursor: pointer; padding: 6px 10px;
+  transition: color 160ms; font-family: inherit;
+}
+.wz-btn-exit:hover { color: #edf0f6; }
+
+.wz-page {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 40px 36px 80px;
+  gap: 56px;
+  color: #edf0f6;
+}
+
+.wz-sidebar { position: sticky; top: 95px; align-self: start; height: fit-content; }
+.wz-progress-card {
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.008));
+  overflow: hidden;
+}
+.wz-progress-head { padding: 22px 22px 20px; border-bottom: 1px solid rgba(255,255,255,0.08); }
+.wz-progress-eyebrow {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: #aeb4c5; margin-bottom: 14px;
+  display: flex; align-items: center; gap: 8px;
+}
+.wz-progress-eyebrow::before { content: ""; width: 14px; height: 1px; background: #ffa53d; }
+.wz-progress-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 17px;
+  letter-spacing: -0.015em; color: #edf0f6;
+  margin: 0 0 16px;
+}
+.wz-bar-wrap { display: flex; align-items: center; gap: 12px; }
+.wz-bar { flex: 1; height: 4px; background: rgba(255,255,255,0.06); border-radius: 2px; overflow: hidden; }
+.wz-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #ffa53d, #ffc875);
+  border-radius: 2px;
+  box-shadow: 0 0 10px rgba(255,165,61,0.5);
+  transition: width 600ms cubic-bezier(.22,.8,.18,1);
+}
+.wz-bar-pct {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px; font-weight: 600;
+  color: #ffa53d; min-width: 38px; text-align: right;
+}
+
+.wz-steps { padding: 14px 14px 18px; display: flex; flex-direction: column; gap: 2px; }
+.wz-step {
+  position: relative;
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px;
+  border-radius: 10px;
+  transition: background 160ms;
+}
+.wz-step:not(:last-child)::after {
+  content: ""; position: absolute;
+  left: 27px; top: 38px; bottom: -2px;
+  width: 1px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.13), transparent);
+}
+.wz-step.wz-done:not(:last-child)::after,
+.wz-step.wz-current:not(:last-child)::after {
+  background: linear-gradient(180deg, rgba(255,165,61,0.25), transparent);
+}
+.wz-step-num {
+  flex-shrink: 0;
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px; font-weight: 600;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: rgba(255,255,255,0.02);
+  color: #7a8298;
+  transition: all 200ms;
+}
+.wz-step.wz-done .wz-step-num {
+  border-color: rgba(110,231,160,0.4);
+  background: rgba(110,231,160,0.12);
+  color: #6ee7a0;
+}
+.wz-step.wz-current .wz-step-num {
+  border-color: #ffa53d;
+  background: rgba(255,165,61,0.15);
+  color: #ffa53d;
+  box-shadow: 0 0 0 4px rgba(255,165,61,0.10), 0 0 20px rgba(255,165,61,0.25);
+}
+.wz-step-body { flex: 1; min-width: 0; }
+.wz-step-label {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 13.5px; font-weight: 600;
+  letter-spacing: -0.005em;
+  color: #aeb4c5; margin-bottom: 2px;
+  transition: color 200ms;
+}
+.wz-step.wz-done .wz-step-label,
+.wz-step.wz-current .wz-step-label { color: #edf0f6; }
+.wz-step-sub {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; color: #7a8298; letter-spacing: 0.04em;
+}
+.wz-step.wz-current .wz-step-sub { color: #ffa53d; }
+
+.wz-progress-foot {
+  padding: 14px 22px 18px;
+  border-top: 1px solid rgba(255,255,255,0.08);
+  display: flex; align-items: center; justify-content: space-between;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; color: #aeb4c5;
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.wz-foot-count { color: #ffa53d; font-weight: 600; }
+
+.wz-main { min-width: 0; max-width: 760px; }
+.wz-step-header { margin-bottom: 28px; }
+.wz-step-eyebrow {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: #ffa53d;
+  padding: 5px 11px;
+  border: 1px solid rgba(255,165,61,0.3);
+  border-radius: 100px;
+  background: rgba(255,165,61,0.06);
+  margin-bottom: 16px;
+}
+.wz-pip {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #ffa53d; box-shadow: 0 0 8px #ffa53d;
+  animation: wz-pulse 1.6s ease-in-out infinite;
+}
+.wz-step-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 36px;
+  letter-spacing: -0.03em; line-height: 1.15;
+  margin: 0 0 12px; color: #edf0f6;
+}
+.wz-step-desc {
+  font-size: 15px; color: #aeb4c5;
+  line-height: 1.6; margin: 0; max-width: 560px;
+}
+
+.wz-form-card {
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.005));
+  padding: 28px;
+  margin-bottom: 20px;
+}
+
+.wz-sidekick {
+  display: flex; gap: 14px;
+  padding: 18px 20px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,165,61,0.22);
+  background: linear-gradient(135deg, rgba(255,165,61,0.06), rgba(255,165,61,0.02));
+  margin-bottom: 28px;
+}
+.wz-sidekick-ico {
+  flex-shrink: 0;
+  width: 32px; height: 32px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,165,61,0.3);
+  background: rgba(255,165,61,0.10);
+  color: #ffa53d;
+  display: grid; place-items: center;
+}
+.wz-sidekick-body { flex: 1; min-width: 0; }
+.wz-sidekick-label {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #ffa53d; margin-bottom: 4px;
+}
+.wz-sidekick-text {
+  font-size: 13.5px; color: #aeb4c5;
+  line-height: 1.6; margin: 0;
+}
+
+.wz-nav-row { display: flex; justify-content: space-between; align-items: center; padding-top: 8px; }
+.wz-btn-prev {
+  font-size: 13.5px; font-weight: 500;
+  color: #aeb4c5; background: none; border: none;
+  cursor: pointer; padding: 10px 8px;
+  display: inline-flex; align-items: center; gap: 8px;
+  transition: color 160ms;
+  font-family: inherit;
+}
+.wz-btn-prev:hover:not(:disabled) { color: #edf0f6; }
+.wz-btn-prev:hover:not(:disabled) .wz-arrow { transform: translateX(-3px); }
+.wz-btn-prev .wz-arrow { transition: transform 200ms; display: inline-block; }
+.wz-btn-prev:disabled { opacity: 0.3; cursor: not-allowed; }
+
+.wz-btn-next {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 13px 22px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px; font-weight: 600;
+  letter-spacing: -0.005em;
+  border-radius: 10px;
+  border: 1px solid #f3f4f8;
+  background: linear-gradient(180deg, #ffffff, #e8eaf0);
+  color: #0a0d14;
+  cursor: pointer;
+  transition: transform 180ms, box-shadow 180ms, filter 180ms;
+}
+.wz-btn-next:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 30px -8px rgba(255,255,255,0.35), 0 0 30px -10px rgba(255,165,61,0.5);
+}
+.wz-btn-next:disabled { opacity: 0.6; cursor: not-allowed; filter: saturate(0.6); }
+.wz-btn-next .wz-arrow { transition: transform 200ms; display: inline-block; }
+.wz-btn-next:hover:not(:disabled) .wz-arrow { transform: translateX(3px); }
+.wz-spinner {
+  width: 14px; height: 14px; border-radius: 50%;
+  border: 2px solid rgba(10,13,20,0.2);
+  border-top-color: rgba(10,13,20,0.9);
+  animation: wz-spin 700ms linear infinite;
+  display: inline-block;
+}
+@keyframes wz-spin { to { transform: rotate(360deg); } }
+@keyframes wz-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.85); }
+}
+
+@media (max-width: 1100px) {
+  .wz-page { grid-template-columns: 280px 1fr; gap: 40px; padding: 36px 28px 80px; }
+}
+@media (max-width: 900px) {
+  .wz-page { grid-template-columns: 1fr; gap: 32px; }
+  .wz-sidebar { position: static; }
+  .wz-step-title { font-size: 28px; }
+  .wz-topbar { padding: 14px 20px; }
+  .wz-top-left .wz-crumb-sep, .wz-top-left .wz-crumb-proj { display: none; }
+}
+`

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -30,7 +30,7 @@ export interface AWSAccount {
 }
 
 // 프로젝트
-export type ProjectStatus = 'created' | 'deploying' | 'completed' | 'failed' | 'partial_failed'
+export type ProjectStatus = 'created' | 'deploying' | 'completed' | 'failed' | 'partial_failed' | 'destroying' | 'destroy_completed' | 'destroy_failed'
 export type DRStatusValue = 'not_ready' | 'syncing' | 'ready'
 export type Environment = 'prod' | 'staging' | 'dev'
 
@@ -48,7 +48,7 @@ export interface Project {
 }
 
 // Deployment
-export type DeploymentStatus = 'created' | 'deploying' | 'completed' | 'failed' | 'partial_failed'
+export type DeploymentStatus = 'created' | 'deploying' | 'completed' | 'failed' | 'partial_failed' | 'destroying' | 'destroyed' | 'destroy_failed'
 
 export interface Deployment {
   deployment_id: string


### PR DESCRIPTION
Backend
- craft.py: full_destroy completed/failed/destroy_failed 상태 허용, destroying 분리
- craft.py: destroyed 콜백 → DB 전체 삭제 연동 (_delete_project_records)
- projects.py: destroy_aws_resources=True 시 ECS spawn_destroy_task 실행
- entrypoint.sh: destroy 실패 콜백 destroy_failed로 분리

Frontend — 랜딩/인증
- app/page.tsx: 다크 시네마틱 랜딩+로그인 통합 페이지 신규 생성
  (그리드 배경, 오빗 링, 오렌지/블루 라이트 스트림 SVG, 글로우 워드마크)
- login/page.tsx: 랜딩 동일 톤 재설계, 우하단 Made By 뚝딱 제거
  (글로우 카드, 코너 라벨, show/hide 토글, 기존 로직 100% 보존)

Frontend — 대시보드
- dashboard/page.tsx: DeployToast 추가 (우하단 슬라이드업, 4초 자동 닫힘)
  STATUS_CONFIG destroying/destroy_completed/destroy_failed 3종 추가
  컨테이너 1600px, 타이틀 36px, KPI 48px, 테이블 셀 20px 등 전체 사이즈 업

Frontend — 배포 플로우
- deploy/page.tsx: 배포 완료 후 /mirror → /dashboard 리다이렉트 수정
  localStorage deploy_toast 저장, projectName API 조회
- projects/[id]/page.tsx: destroying/destroy_completed/destroy_failed 상태 UI 분기

Frontend — CraftOps 위저드
- WizardLayout.tsx: 전면 재설계 (API/props 시그니처 100% 호환)
  좌측 320px sticky 진행 카드, 오렌지 그라디언트 프로그레스 바
  스텝 아이콘 번호 원형 + 체크마크 SVG (완료=그린/현재=오렌지/대기=회색)
  sidekick → CraftOps Tip 오렌지 톤 카드
  다음 버튼 화이트 primary, 이전 버튼 ghost
- IntentAnalysis.tsx: 다크 폼 + 글자 수 카운터 + 결과 그린 톤 카드
- NewProjectPageContent.tsx: 전 phase sticky 톱바 적용
  project-create 환경 선택 3개 카드 segmented control (prod=오렌지/staging=옐로/dev=블루)
  2-2 CIDR 자동 서브넷 미리보기
  2-3 보안 그룹 dashed row 구조화
  2-6 RDS ON/OFF pill 시각화
  summary 6개 카드 그리드 + Validation Loop 안내 배너
  UX 텍스트 핀테크 타겟 맞춤 개선 (금융보안원, tfsec, 망분리 적재 배치)

Types
- types/index.ts: ProjectStatus/DeploymentStatus destroy 관련 타입 추가
  (partial_failed, destroying, destroy_completed, destroy_failed, destroyed)