### PR TITLE
feat(epic8): MirrorOps E2E 파이프라인 안정화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 .DS_Store
 Thumbs.db 
 session-manager-plugin.deb
+response.json

--- a/backend/app/api/mirror.py
+++ b/backend/app/api/mirror.py
@@ -80,6 +80,7 @@ def get_resources(
         ).order_by(GCPMapping.created_at.desc()).first()
 
         result.append({
+            "resource_id":       res.resource_id, 
             "aws_resource_type": res.resource_type,
             "aws_resource_name": res.resource_name,
             "aws_resource_id":   res.resource_id_aws,
@@ -88,6 +89,7 @@ def get_resources(
             "confidence":        mapping.confidence        if mapping else "manual",
             "review_reason":     mapping.review_reason     if mapping else None,
             "user_confirmed":    mapping.user_confirmed    if mapping else False,
+            "terraform_code":    mapping.terraform_code    if mapping else None,
         })
 
     return {"success": True, "data": result}
@@ -327,13 +329,26 @@ def failover(
     db.add(fh)
     db.commit()
 
-    # simulation 실행 연결
     if body.mode == "simulation" and sim_package:
+        # [수정] S3 경로에서 실제 HCL 파일 내용을 읽어서 전달
+        hcl_content = ""
+        s3_path = sim_package.terraform_code_path or ""
+        if s3_path.startswith("s3://"):
+            try:
+                import boto3 as _boto3
+                path_body  = s3_path.replace("s3://", "")
+                bucket, key = path_body.split("/", 1)
+                s3_client   = _boto3.client("s3", region_name="us-west-2")
+                obj         = s3_client.get_object(Bucket=bucket, Key=key)
+                hcl_content = obj["Body"].read().decode("utf-8")
+            except Exception as e:
+                print(f"[Failover] HCL 파일 읽기 실패: {e}")
+
         background_tasks.add_task(
             _run_failover_simulation,
             project_id  = project_id,
             failover_id = failover_id,
-            hcl_code    = sim_package.terraform_code_path or "",
+            hcl_code    = hcl_content,
             db          = SessionLocal(),
         )
 
@@ -354,29 +369,78 @@ def _run_failover_simulation(
     hcl_code: str,
     db: Session,
 ) -> None:
+    import json as _json
+
     work_dir = tempfile.mkdtemp(prefix=f"autoops-failover-{project_id[:8]}-")
     try:
         (Path(work_dir) / "main.tf").write_text(hcl_code, encoding="utf-8")
+
         subprocess.run(
             ["terraform", "init", "-backend=false"],
-            cwd=work_dir, capture_output=True
+            cwd=work_dir, capture_output=True,
         )
-        subprocess.run(
+
+        plan_result = subprocess.run(
             ["terraform", "plan", "-json"],
-            cwd=work_dir, capture_output=True, text=True
+            cwd=work_dir, capture_output=True, text=True,
         )
-        add_count = 11
+
+        # [수정] terraform plan -json 파싱 → 실제 생성될 리소스 수 추출
+        # terraform plan -json은 NDJSON 형식으로 여러 줄 출력
+        # "change_summary" 타입의 라인에서 add 수를 읽음
+        add_count = 0
+        for line in plan_result.stdout.splitlines():
+            try:
+                obj = _json.loads(line)
+                if obj.get("type") == "change_summary":
+                    add_count = obj.get("changes", {}).get("add", 0)
+                    break
+            except _json.JSONDecodeError:
+                continue
 
         fh = db.query(FailoverHistory).filter(
             FailoverHistory.failover_id == failover_id
         ).first()
         if fh:
-            fh.status              = "completed"
-            fh.gcp_resources_created = add_count
-            fh.actual_rto_seconds  = 12 * 60
-            fh.completed_at = __import__("datetime").datetime.utcnow()
+            fh.status                = "completed"
+            fh.gcp_resources_created = add_count if add_count > 0 else None
+            fh.actual_rto_seconds    = 15 * 60   # [수정] 12분 → 15분
+            fh.completed_at          = __import__("datetime").datetime.utcnow()
             db.commit()
+
     finally:
         import shutil
         shutil.rmtree(work_dir, ignore_errors=True)
         db.close()
+
+# 신규 엔드포인트 추가
+from pydantic import BaseModel as _BaseModel
+
+class TerraformCodeUpdate(_BaseModel):
+    terraform_code: str
+
+@router.patch("/{project_id}/resources/{resource_id}/terraform-code")
+def update_terraform_code(
+    project_id: str,
+    resource_id: str,
+    body: TerraformCodeUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _get_project_or_404(project_id, current_user.user_id, db)
+
+    mapping = db.query(GCPMapping).filter(
+        GCPMapping.resource_id == resource_id,
+        GCPMapping.project_id  == project_id,
+    ).first()
+
+    if not mapping:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "NOT_FOUND", "message": "매핑을 찾을 수 없습니다."},
+        )
+
+    mapping.terraform_code = body.terraform_code
+    db.commit()
+
+    return {"success": True, "data": {"resource_id": resource_id}}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,11 +11,19 @@ from app.services.mirrorops.sqs_worker import start_sqs_worker
 from app.core.config import settings
 
 @asynccontextmanager
-async def lifespan(app):
-    task = asyncio.create_task(start_sqs_worker())
-    yield
-    task.cancel()
-
+async def lifespan(app: FastAPI):
+    # 서버 켜질 때 SQS 워커를 백그라운드 태스크로 실행
+    worker_task = asyncio.create_task(start_sqs_worker())
+    print("✅ MirrorOps SQS 워커 백그라운드 실행 시작")
+    
+    yield # API 서버 동작 중...
+    
+    # 서버 꺼질 때 워커 종료 처리
+    worker_task.cancel()
+    try:
+        await worker_task
+    except asyncio.CancelledError:
+        print("🛑 MirrorOps SQS 워커 종료 완료")
 
 app = FastAPI(
     title="AutoOps API",

--- a/backend/app/services/mirrorops/dr_packager.py
+++ b/backend/app/services/mirrorops/dr_packager.py
@@ -115,6 +115,15 @@ class DRPackager:
     ) -> None:
         s3_base = f"projects/{project_id}/latest"
         export_prefix = f"{s3_base}/data/exports/"
+        # [추가] 스냅샷 available 상태 대기 (최대 20분)
+        snapshot_id = snapshot_arn.split(":")[-1]
+        print(f"[DRPackager] 스냅샷 완료 대기 중: {snapshot_id}")
+        waiter = self.rds.get_waiter("db_snapshot_available")
+        waiter.wait(
+            DBSnapshotIdentifier = snapshot_id,
+            WaiterConfig         = {"Delay": 30, "MaxAttempts": 40},
+        )
+        print(f"[DRPackager] 스냅샷 사용 가능 — Export 시작")
 
         export_task_id = f"autoops-export-{project_id[:8]}-{int(datetime.now().timestamp())}"
         self.rds.start_export_task(
@@ -155,59 +164,87 @@ class DRPackager:
             package.snapshot_export_s3_path = (
                 f"s3://{self.S3_BUCKET}/{export_prefix}"
             )
+            # [추가] DB 체크리스트 업데이트 (S3 dr-report.json과 동기화)
+            updated_checklist = []
+            for item in (package.checklist or []):
+                if item.get("item") == "RDS 스냅샷 Export":
+                    updated_checklist.append({
+                        "item":   item["item"],
+                        "status": "done",
+                    })
+                else:
+                    updated_checklist.append(item)
+            package.checklist = updated_checklist
             db.commit()
 
     # ── Skopeo 이미지 복사 (FR-B-009) ──────────────────────────────
 
     def _copy_image_skopeo(
-        self,
-        prefix: str,
-        environment: str,
-        region: str,
-        gcp_project: str,
-    ) -> tuple[str, str]:
-        
-        account_id = self.user_session.client("sts").get_caller_identity()["Account"]
-        
-        ecr_uri = f"{account_id}.dkr.ecr.us-west-2.amazonaws.com/autoops-sample-app:latest".lower()
-        
-        gcr_uri = (
-            f"us-west1-docker.pkg.dev/{gcp_project}"
-            f"/autoops-repo/autoops-sample-app:latest"
-        ).lower()
+            self,
+            prefix: str,
+            environment: str,
+            region: str,
+            gcp_project: str,
+        ) -> tuple[str, str]:
+            import base64
+            import os
 
-        # ECR 로그인 토큰 취득
-        ecr_token = self.ecr.get_authorization_token()
-        token_data = ecr_token["authorizationData"][0]
-        import base64
-        ecr_creds  = base64.b64decode(token_data["authorizationToken"]).decode()
-        ecr_user, ecr_pass = ecr_creds.split(":", 1)
+            account_id = self.user_session.client("sts").get_caller_identity()["Account"]
 
-        # GCP 액세스 토큰 취득
-        gcp_token_proc = subprocess.run(
-            ["gcloud", "auth", "print-access-token"],
-            capture_output=True, text=True,
-        )
-        gcp_token = gcp_token_proc.stdout.strip()
+            ecr_uri = f"{account_id}.dkr.ecr.us-west-2.amazonaws.com/autoops-sample-app:latest".lower()
+            gcr_uri = (
+                f"us-west1-docker.pkg.dev/{gcp_project}"
+                f"/autoops-repo/autoops-sample-app:latest"
+            ).lower()
 
-        # Skopeo 복사 실행
-        result = subprocess.run(
-            [
-                "skopeo", "copy",
-                "--src-creds",  f"{ecr_user}:{ecr_pass}",
-                "--dest-creds", f"oauth2accesstoken:{gcp_token}",
-                f"docker://{ecr_uri}",
-                f"docker://{gcr_uri}",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
+            # ECR 로그인 토큰 취득
+            ecr_token = self.ecr.get_authorization_token()
+            token_data = ecr_token["authorizationData"][0]
+            ecr_creds  = base64.b64decode(token_data["authorizationToken"]).decode()
+            ecr_user, ecr_pass = ecr_creds.split(":", 1)
 
-        if result.returncode != 0:
-            raise RuntimeError(f"Skopeo 복사 실패:{result.stderr}")
+            # [수정] gcloud 서비스 계정 인증 후 액세스 토큰 취득
+            # GOOGLE_APPLICATION_CREDENTIALS만 설정하면 gcloud가 인식 못함
+            # → activate-service-account로 명시적 인증 필요
+            key_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+            if key_path:
+                activate_result = subprocess.run(
+                    ["gcloud", "auth", "activate-service-account",
+                    "--key-file", key_path],
+                    capture_output=True, text=True,
+                )
+                if activate_result.returncode != 0:
+                    raise RuntimeError(
+                        f"GCP 서비스 계정 인증 실패: {activate_result.stderr}"
+                    )
 
-        return gcr_uri, ecr_uri
+            gcp_token_proc = subprocess.run(
+                ["gcloud", "auth", "print-access-token"],
+                capture_output=True, text=True,
+            )
+            gcp_token = gcp_token_proc.stdout.strip()
+
+            if not gcp_token:
+                raise RuntimeError("GCP 액세스 토큰 취득 실패 — gcloud 인증 상태 확인 필요")
+
+            # Skopeo 복사 실행
+            result = subprocess.run(
+                [
+                    "skopeo", "copy",
+                    "--src-creds",  f"{ecr_user}:{ecr_pass}",
+                    "--dest-creds", f"oauth2accesstoken:{gcp_token}",
+                    f"docker://{ecr_uri}",
+                    f"docker://{gcr_uri}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+
+            if result.returncode != 0:
+                raise RuntimeError(f"Skopeo 복사 실패:{result.stderr}")
+
+            return gcr_uri, ecr_uri
 
     def _create_rds_snapshot(self, db_instance_id: str, snapshot_id: str) -> str:
         try:

--- a/backend/app/services/mirrorops/mapper.py
+++ b/backend/app/services/mirrorops/mapper.py
@@ -1,8 +1,18 @@
 import json
 
-# §5-2 AWS→GCP 매핑 테이블 (매핑 방식 + confidence)
+# GCP에 대응 개념이 없어 매핑이 불필요한 리소스 타입
+NOT_REQUIRED_RESOURCES = {
+    "AWS::EC2::InternetGateway",
+    "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "AWS::ECS::Cluster",
+    "AWS::ECS::TaskDefinition",
+    "AWS::RDS::DBSubnetGroup",
+    "AWS::Logs::LogGroup",
+    "AWS::KMS::Key",
+}
+
+# §5-2 AWS→GCP 매핑 테이블
 RULE_BASED_MAP: dict[str, dict] = {
-    # 룰 기반 (confidence: auto) — 6개 카테고리
     "AWS::EC2::VPC": {
         "gcp_type":   "google_compute_network",
         "confidence": "auto",
@@ -25,7 +35,6 @@ RULE_BASED_MAP: dict[str, dict] = {
             ).lower().replace("_", "-"),
             "ip_cidr_range": cfg.get("cidrBlock", ""),
             "region":        "us-west1",
-            # [수정] GCP 서브넷 생성 시 network는 필수 인자입니다.
             "network":       cfg.get("vpcId", "default-vpc").lower().replace("_", "-"),
         },
     },
@@ -37,7 +46,7 @@ RULE_BASED_MAP: dict[str, dict] = {
                 (cfg.get("tags") or {}).get("Name", "") or
                 "router-" + cfg.get("routeTableId", "default")
             ).lower().replace("_", "-"),
-            "region": "us-west1",
+            "region":  "us-west1",
             "network": cfg.get("vpcId", "default-vpc").lower().replace("_", "-"),
         },
     },
@@ -75,7 +84,6 @@ RULE_BASED_MAP: dict[str, dict] = {
             "display_name": cfg.get("RoleName", ""),
         },
     },
-    # Bedrock 보완 대상 (confidence: review) — 3개 카테고리
     "AWS::EC2::SecurityGroup": {
         "gcp_type":   "google_compute_firewall",
         "confidence": "review",
@@ -93,7 +101,6 @@ RULE_BASED_MAP: dict[str, dict] = {
     },
 }
 
-# §5-2 IAM Action → GCP Role 변환 테이블
 IAM_ACTION_TO_GCP_ROLE: dict[str, str] = {
     "s3:GetObject":             "roles/storage.objectAdmin",
     "s3:PutObject":             "roles/storage.objectAdmin",
@@ -110,11 +117,6 @@ from app.services.mirrorops.bedrock_client import BedrockMapper
 
 
 class MappingEngine:
-    """
-    AWS 리소스 목록을 GCP 리소스로 매핑한다.
-    - 룰 기반: confidence=auto (6개 카테고리)
-    - Bedrock 보완: confidence=review (3개 카테고리)
-    """
 
     def __init__(self):
         self.bedrock = BedrockMapper()
@@ -129,22 +131,23 @@ class MappingEngine:
         mappings = []
 
         for res in aws_resources:
-            # [수정 1] config_json이 list인 경우 dict로 정규화
-            # AWS Config에서 일부 리소스가 list 형태로 반환되는 케이스 방어
             config_json = res.config_json or {}
             if isinstance(config_json, list):
                 config_json = config_json[0] if config_json else {}
 
             rule = RULE_BASED_MAP.get(res.resource_type)
             if not rule:
-                mapping = self._create_manual_mapping(res, project_id, sync_id)
+                # GCP 매핑 불필요 리소스와 수동 설정 리소스 구분
+                if res.resource_type in NOT_REQUIRED_RESOURCES:
+                    mapping = self._create_not_required_mapping(res, project_id, sync_id)
+                else:
+                    mapping = self._create_manual_mapping(res, project_id, sync_id)
                 db.add(mapping)
                 mappings.append(mapping)
                 continue
 
             if rule["confidence"] == "auto" and rule["mapping"]:
-                # 룰 기반 변환 (FR-B-004)
-                attrs = rule["mapping"](config_json)  # 정규화된 config_json 사용
+                attrs = rule["mapping"](config_json)
                 hcl   = self._attrs_to_hcl(rule["gcp_type"], res.resource_name, attrs)
                 mapping = GCPMapping(
                     resource_id       = res.resource_id,
@@ -158,14 +161,11 @@ class MappingEngine:
                     user_confirmed    = False,
                 )
             else:
-                # Bedrock 보완 변환 (FR-B-005)
                 result = self.bedrock.map_resource(
                     resource_type = res.resource_type,
-                    aws_config    = config_json,      # 정규화된 config_json 사용
+                    aws_config    = config_json,
                     gcp_type      = rule["gcp_type"],
                 )
-
-                # [수정 2] result 또는 mapping_info가 list인 경우 방어
                 if isinstance(result, list):
                     result = result[0] if result else {}
 
@@ -174,7 +174,6 @@ class MappingEngine:
                     mapping_info = mapping_info[0] if mapping_info else {}
 
                 review_reason = result.get("review_reason", "")
-
                 hcl = self._generate_hcl_from_mapping_info(
                     gcp_type     = rule["gcp_type"],
                     name         = res.resource_name,
@@ -201,9 +200,36 @@ class MappingEngine:
         db.commit()
         return mappings
 
-    # ──────────────────────────────────────────────────────────
-    # review 리소스용 HCL 템플릿 함수들
-    # ──────────────────────────────────────────────────────────
+    def _create_not_required_mapping(
+        self, res: AWSResource, project_id: str, sync_id: str
+    ) -> GCPMapping:
+        """GCP에 대응 개념이 없어 별도 생성이 불필요한 리소스"""
+        return GCPMapping(
+            resource_id       = res.resource_id,
+            project_id        = project_id,
+            sync_id           = sync_id,
+            gcp_resource_type = "not_required",
+            gcp_resource_name = res.resource_name,
+            terraform_code    = f"# GCP 매핑 불필요: {res.resource_type}",
+            confidence        = "not_required",
+            review_reason     = "GCP에 동일한 개념의 리소스가 없어 별도 생성이 필요하지 않습니다.",
+            user_confirmed    = False,
+        )
+
+    def _create_manual_mapping(
+        self, res: AWSResource, project_id: str, sync_id: str
+    ) -> GCPMapping:
+        return GCPMapping(
+            resource_id       = res.resource_id,
+            project_id        = project_id,
+            sync_id           = sync_id,
+            gcp_resource_type = "unknown",
+            gcp_resource_name = res.resource_name,
+            terraform_code    = f"# 수동 매핑 필요: {res.resource_type}",
+            confidence        = "manual",
+            review_reason     = "자동 변환 규칙이 없습니다. 수동으로 GCP 리소스를 설정하세요.",
+            user_confirmed    = False,
+        )
 
     def _generate_hcl_from_mapping_info(
         self, gcp_type: str, name: str, mapping_info: dict
@@ -214,17 +240,14 @@ class MappingEngine:
             return self._generate_backend_service_hcl(name, mapping_info)
         elif gcp_type == "google_cloud_run_service":
             return self._generate_cloud_run_hcl(name, mapping_info)
-        else:
-            return f'# review 필요: {gcp_type} — {name}'
+        return f'# review 필요: {gcp_type} — {name}'
 
     def _generate_firewall_hcl(self, name: str, info: dict) -> str:
-        # [수정] GCP 리소스명 정규식 통과를 위해 소문자 및 하이픈으로 강제 변환
         gcp_name  = name.lower().replace("_", "-")
         tf_name   = gcp_name.replace("-", "_")
         direction = info.get("direction", "INGRESS")
         rules     = info.get("rules", [{"protocol": "all", "source_ranges": ["0.0.0.0/0"]}])
 
-        # [수정] VPC 이름 동적 추론 (예: DD-prod-sg-db -> dd-prod-vpc)
         name_parts = name.split("-")
         vpc_name = "default"
         if len(name_parts) >= 2:
@@ -259,7 +282,6 @@ class MappingEngine:
 }}'''
 
     def _generate_backend_service_hcl(self, name: str, info: dict) -> str:
-        # [수정] 대문자 에러 방지용 소문자 변환
         gcp_name              = name.lower().replace("_", "-")
         tf_name               = gcp_name.replace("-", "_")
         protocol              = info.get("protocol", "HTTP")
@@ -274,7 +296,6 @@ class MappingEngine:
 }}'''
 
     def _generate_cloud_run_hcl(self, name: str, info: dict) -> str:
-        # [수정] 대문자 에러 방지용 소문자 변환
         gcp_name = name.lower().replace("_", "-")
         tf_name  = gcp_name.replace("-", "_")
         image    = info.get("image", "gcr.io/cloudrun/hello")
@@ -314,14 +335,7 @@ class MappingEngine:
   }}
 }}'''
 
-    # ──────────────────────────────────────────────────────────
-    # 기존 메서드들 (auto 리소스용)
-    # ──────────────────────────────────────────────────────────
-
-    def _apply_iam_mapping(
-        self, mapping: GCPMapping, res: AWSResource
-    ) -> GCPMapping:
-        # [수정 3] config_json이 list인 경우 dict로 정규화
+    def _apply_iam_mapping(self, mapping: GCPMapping, res: AWSResource) -> GCPMapping:
         config = res.config_json or {}
         if isinstance(config, list):
             config = config[0] if config else {}
@@ -347,26 +361,7 @@ class MappingEngine:
 
         return mapping
 
-    def _create_manual_mapping(
-        self, res: AWSResource, project_id: str, sync_id: str
-    ) -> GCPMapping:
-        return GCPMapping(
-            resource_id       = res.resource_id,
-            project_id        = project_id,
-            sync_id           = sync_id,
-            gcp_resource_type = "unknown",
-            gcp_resource_name = res.resource_name,
-            terraform_code    = f"# 수동 매핑 필요: {res.resource_type}",
-            confidence        = "manual",
-            review_reason     = "자동 변환 규칙이 없습니다. 수동으로 GCP 리소스를 설정하세요.",
-            user_confirmed    = False,
-        )
-
-    def _attrs_to_hcl(
-        self, gcp_type: str, name: str, attrs: dict
-    ) -> str:
-        """auto 리소스(룰 기반) 전용"""
-
+    def _attrs_to_hcl(self, gcp_type: str, name: str, attrs: dict) -> str:
         MAP_TYPE_KEYS = {"labels", "annotations", "limits", "requests", "metadata"}
 
         def dict_to_hcl(d: dict, indent: int = 2) -> str:
@@ -398,8 +393,7 @@ class MappingEngine:
                             lines.append(dict_to_hcl(item, indent + 2))
                             lines.append(f"{pad}}}")
                     else:
-                        formatted = json.dumps(v)
-                        lines.append(f'{pad}{k} = {formatted}')
+                        lines.append(f'{pad}{k} = {json.dumps(v)}')
                 elif isinstance(v, bool):
                     lines.append(f'{pad}{k} = {str(v).lower()}')
                 elif isinstance(v, (int, float)):
@@ -408,7 +402,6 @@ class MappingEngine:
                     lines.append(f'{pad}{k} = "{v}"')
             return "\n".join(lines)
 
-        # [수정] TF 리소스 이름도 일관성을 위해 소문자화 (GCP 권장 컨벤션)
         resource_name = name.lower().replace("-", "_")
         body = dict_to_hcl(attrs)
         return f'resource "{gcp_type}" "{resource_name}" {{\n{body}\n}}'

--- a/backend/app/services/mirrorops/pipeline.py
+++ b/backend/app/services/mirrorops/pipeline.py
@@ -151,6 +151,29 @@ class MirrorOpsPipelineService:
             else:
                 # 변경 없음 → DR Package 재생성 스킵
                 print(f"[MirrorOps] 변경 없음 — DR Package 재생성 스킵 (project_id={project_id})")
+                
+                # [추가] 변경 없음: 최신 패키지가 ready면 dr_status 복원
+                latest_pkg = db.query(DRPackageModel).filter(
+                    DRPackageModel.project_id == project_id,
+                    DRPackageModel.is_latest  == True,
+                ).first()
+                if latest_pkg and latest_pkg.status == "ready":
+                    project.dr_status = "ready"
+                    # [추가] 스냅샷 Export 완료 시 체크리스트도 동기화
+                    if latest_pkg.snapshot_status == "ready" and latest_pkg.checklist:
+                        updated = []
+                        for item in latest_pkg.checklist:
+                            if item.get("item") == "RDS 스냅샷 Export":
+                                updated.append({"item": item["item"], "status": "done"})
+                            else:
+                                updated.append(item)
+                        latest_pkg.checklist = updated
+                db.commit()
+
+            # [추가] Phase 1 완료 → sync 상태 업데이트
+            sync.status       = "completed"
+            sync.completed_at = datetime.utcnow()
+            db.commit()
 
         except Exception as e:
             sync.status        = "failed"

--- a/backend/app/services/mirrorops/sqs_worker.py
+++ b/backend/app/services/mirrorops/sqs_worker.py
@@ -125,7 +125,7 @@ async def _handle_rds_snapshot_completed(detail: dict):
             package_id      = package.package_id,
             snapshot_arn    = snapshot_arn,
             export_role_arn = f"arn:aws:iam::{account.aws_account_id}:role/AutoOpsRDSExportRole",
-            kms_key_id      = "alias/aws/rds",
+            kms_key_id      = "alias/autoops-rds-export",
             db              = db,
         )
 

--- a/frontend/app/projects/[id]/failover/page.tsx
+++ b/frontend/app/projects/[id]/failover/page.tsx
@@ -1,4 +1,3 @@
-// frontend/app/projects/[id]/failover/page.tsx
 'use client'
 
 import { useState, useEffect } from 'react'
@@ -9,15 +8,6 @@ import { useDRPackage } from '@/hooks/useMirrorOps'
 import { FailoverResponse } from '@/types/mirror'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-
-const SIMULATION_STEPS = [
-  { label: 'Terraform Init',         duration: '2초' },
-  { label: 'Terraform Plan',         duration: 'GCP 11개' },
-  { label: 'Terraform Apply',        duration: '시뮬레이션' },
-  { label: 'Cloud SQL 복원 예상',     duration: '3분 20초' },
-  { label: 'Cloud Run 배포 예상',     duration: '2분 10초' },
-  { label: 'Load Balancer 헬스체크',  duration: '시뮬레이션' },
-]
 
 export default function FailoverPage() {
   const params = useParams()
@@ -35,9 +25,22 @@ export default function FailoverPage() {
   const { data: packageData } = useDRPackage(projectId)
   const latest = packageData?.latest
 
+  // SIMULATION_STEPS를 컴포넌트 내부로 이동 — latest 참조 가능
+  const SIMULATION_STEPS = [
+    { label: 'Terraform Init',        duration: '2초' },
+    { label: 'Terraform Plan',        duration: `GCP ${
+        latest?.dr_report?.confidence_summary
+          ? (latest.dr_report.confidence_summary.auto + latest.dr_report.confidence_summary.review)
+          : 19
+      }개` },
+    { label: 'Terraform Apply',       duration: '시뮬레이션' },
+    { label: 'Cloud SQL 복원 예상',    duration: '3분 20초' },
+    { label: 'Cloud Run 배포 예상',    duration: '2분 10초' },
+    { label: 'Load Balancer 헬스체크', duration: '시뮬레이션' },
+  ]
+
   const { events } = useWebSocket(
     failoverData ? projectId : null,
-    // [FIX] fo_ 접두사 제거
     failoverData ? failoverData.failover_id : null
   )
 
@@ -45,7 +48,6 @@ export default function FailoverPage() {
   useEffect(() => {
     if (!isRunning || mode !== 'simulation') return
 
-    // [FIX] 마지막 단계에서 isRunning false 전환
     if (simStep >= SIMULATION_STEPS.length - 1) {
       setIsRunning(false)
       return
@@ -225,10 +227,12 @@ export default function FailoverPage() {
               </div>
             ))}
 
-            {/* [FIX] isRunning=false + 마지막 단계 = 완료 표시 */}
+            {/* 완료 표시 — DB의 rto_minutes 사용 */}
             {!isRunning && simStep >= SIMULATION_STEPS.length - 1 && (
               <div className="pt-3 border-t border-white/8">
-                <p className="text-emerald-400 font-semibold">총 예상 RTO: 약 12분</p>
+                <p className="text-emerald-400 font-semibold">
+                  총 예상 RTO: 약 {latest?.dr_report?.rto_minutes ?? 15}분
+                </p>
               </div>
             )}
           </div>
@@ -253,7 +257,7 @@ export default function FailoverPage() {
         </div>
       )}
 
-      {/* [FIX] 완료 후 다시 시뮬레이션 버튼 */}
+      {/* 완료 후 다시 시뮬레이션 버튼 */}
       {!isRunning && simStep >= SIMULATION_STEPS.length - 1 && (
         <Button
           variant="outline"

--- a/frontend/app/projects/[id]/mirror/resources/page.tsx
+++ b/frontend/app/projects/[id]/mirror/resources/page.tsx
@@ -1,4 +1,3 @@
-// frontend/app/projects/[id]/mirror/resources/page.tsx
 'use client'
 
 import { useState } from 'react'
@@ -6,11 +5,15 @@ import { useParams } from 'next/navigation'
 import { useResourceMappings } from '@/hooks/useMirrorOps'
 import { ResourceMapping, Confidence } from '@/types/mirror'
 import { Button } from '@/components/ui/button'
+import { apiClient } from '@/lib/api'
 
-const CONFIDENCE_CONFIG: Record<Confidence, { label: string; badgeClass: string }> = {
-  auto:   { label: '✅ 자동',      badgeClass: 'bg-emerald-500/10 text-emerald-400' },
-  review: { label: '⚠️ 검토 필요', badgeClass: 'bg-yellow-500/10 text-yellow-400' },
-  manual: { label: '❌ 수동 설정', badgeClass: 'bg-red-500/10 text-red-400' },
+type ExtendedConfidence = Confidence | 'not_required'
+
+const CONFIDENCE_CONFIG: Record<ExtendedConfidence, { label: string; badgeClass: string }> = {
+  auto:         { label: '✅ 자동',      badgeClass: 'bg-emerald-500/10 text-emerald-400' },
+  review:       { label: '⚠️ 검토 필요', badgeClass: 'bg-yellow-500/10 text-yellow-400' },
+  manual:       { label: '🔧 수동 설정', badgeClass: 'bg-red-500/10 text-red-400' },
+  not_required: { label: 'ℹ️ 매핑 불필요', badgeClass: 'bg-[#9ca3af]/10 text-[#9ca3af]' },
 }
 
 const AWS_TYPE_SHORT: Record<string, string> = {
@@ -18,13 +21,18 @@ const AWS_TYPE_SHORT: Record<string, string> = {
   'AWS::EC2::Subnet':                              'Subnet',
   'AWS::EC2::RouteTable':                          'Route Table',
   'AWS::EC2::NatGateway':                          'NAT Gateway',
+  'AWS::EC2::InternetGateway':                     'Internet Gateway',
   'AWS::EC2::SecurityGroup':                       'Security Group',
   'AWS::ElasticLoadBalancingV2::LoadBalancer':     'ALB',
   'AWS::ElasticLoadBalancingV2::TargetGroup':      'Target Group',
   'AWS::IAM::Role':                                'IAM Role',
   'AWS::ECS::Cluster':                             'ECS Cluster',
   'AWS::ECS::Service':                             'ECS Service',
+  'AWS::ECS::TaskDefinition':                      'ECS Task Definition',
   'AWS::RDS::DBInstance':                          'RDS',
+  'AWS::RDS::DBSubnetGroup':                       'RDS Subnet Group',
+  'AWS::Logs::LogGroup':                           'Log Group',
+  'AWS::KMS::Key':                                 'KMS Key',
 }
 
 const GCP_TYPE_SHORT: Record<string, string> = {
@@ -39,6 +47,22 @@ const GCP_TYPE_SHORT: Record<string, string> = {
   'google_sql_database_instance':   'Cloud SQL',
 }
 
+// review_reason을 사용자 친화적으로 변환
+const formatReviewReason = (reason: string): string => {
+  if (!reason) return ''
+  // 기술적인 ID 패턴 제거 (sg-xxx, vpc-xxx 등)
+  return reason
+    .replace(/\(sg-[a-z0-9]+\)/g, '')
+    .replace(/\(vpc-[a-z0-9]+\)/g, '')
+    .replace(/\(subnet-[a-z0-9]+\)/g, '')
+    .replace(/source group reference/gi, '다른 보안 그룹 참조')
+    .replace(/source_ranges/g, '허용 IP 범위')
+    .replace(/CIDR/g, 'IP 범위')
+    .replace(/INGRESS/g, '인바운드')
+    .replace(/EGRESS/g, '아웃바운드')
+    .trim()
+}
+
 export default function ResourceMappingsPage() {
   const params = useParams()
   const projectId = params.id as string
@@ -46,19 +70,43 @@ export default function ResourceMappingsPage() {
   const { data: mappings, isLoading, error } = useResourceMappings(projectId)
   const [selectedMapping, setSelectedMapping] = useState<ResourceMapping | null>(null)
   const [confirmedIds, setConfirmedIds]       = useState<Set<string>>(new Set())
+  const [isEditing, setIsEditing]             = useState(false)
+  const [editedCode, setEditedCode]           = useState('')
 
-  const autoCount   = mappings.filter((m) => m.confidence === 'auto').length
-  const reviewCount = mappings.filter((m) => m.confidence === 'review').length
-  const manualCount = mappings.filter((m) => m.confidence === 'manual').length
+  const autoCount        = mappings.filter((m) => m.confidence === 'auto').length
+  const reviewCount      = mappings.filter((m) => m.confidence === 'review').length
+  const manualCount      = mappings.filter((m) => m.confidence === 'manual').length
+  const notRequiredCount = mappings.filter((m) => (m.confidence as string) === 'not_required').length
 
   const handleConfirm = (mapping: ResourceMapping) => {
     setConfirmedIds((prev) => new Set(prev).add(mapping.aws_resource_id))
     setSelectedMapping(null)
-    // TODO: Epic 8 — PATCH /api/mirror/{projectId}/resources/{id}/confirm
+    setIsEditing(false)
+  }
+
+  const handleOpenEdit = (mapping: ResourceMapping) => {
+    setEditedCode(mapping.terraform_code ?? '')
+    setIsEditing(true)
+  }
+
+  const handleSaveEdit = async () => {
+    if (!selectedMapping) return
+    try {
+      await apiClient.patch(
+        `/api/mirror/${projectId}/resources/${selectedMapping.resource_id}/terraform-code`,
+        { terraform_code: editedCode }
+      )
+      setIsEditing(false)
+    } catch (err) {
+      console.error('저장 실패:', err)
+    }
   }
 
   const isConfirmed = (mapping: ResourceMapping) =>
     mapping.user_confirmed || confirmedIds.has(mapping.aws_resource_id)
+
+  const getConfidence = (m: ResourceMapping): ExtendedConfidence =>
+    (m.confidence as ExtendedConfidence) ?? 'manual'
 
   if (isLoading) {
     return (
@@ -79,14 +127,20 @@ export default function ResourceMappingsPage() {
       <h1 className="text-2xl font-bold mb-6">🗂️ 리소스 매핑 현황</h1>
 
       {/* 신뢰도 요약 */}
-      <div className="flex gap-4 text-sm mb-6">
+      <div className="flex flex-wrap gap-4 text-sm mb-6">
         <span className="text-emerald-400 font-medium">✅ 자동 변환 {autoCount}개</span>
         <span className="text-white/20">│</span>
         <span className="text-yellow-400 font-medium">⚠️ 검토 필요 {reviewCount}개</span>
         {manualCount > 0 && (
           <>
             <span className="text-white/20">│</span>
-            <span className="text-red-400 font-medium">❌ 수동 설정 {manualCount}개</span>
+            <span className="text-red-400 font-medium">🔧 수동 설정 {manualCount}개</span>
+          </>
+        )}
+        {notRequiredCount > 0 && (
+          <>
+            <span className="text-white/20">│</span>
+            <span className="text-[#9ca3af] font-medium">ℹ️ 매핑 불필요 {notRequiredCount}개</span>
           </>
         )}
       </div>
@@ -112,9 +166,13 @@ export default function ResourceMappingsPage() {
             </thead>
             <tbody>
               {mappings.map((m, i) => {
-                const conf = CONFIDENCE_CONFIG[m.confidence]
+                const conf       = CONFIDENCE_CONFIG[getConfidence(m)]
+                const isNR       = (m.confidence as string) === 'not_required'
                 return (
-                  <tr key={i} className="border-b border-white/8 hover:bg-white/[0.02]">
+                  <tr
+                    key={i}
+                    className={`border-b border-white/8 hover:bg-white/[0.02] ${isNR ? 'opacity-50' : ''}`}
+                  >
                     <td className="p-4">
                       <p className="font-medium">
                         {AWS_TYPE_SHORT[m.aws_resource_type] ?? m.aws_resource_type}
@@ -122,14 +180,20 @@ export default function ResourceMappingsPage() {
                       <p className="text-xs text-[#9ca3af] mt-0.5">{m.aws_resource_name}</p>
                     </td>
                     <td className="p-4">
-                      <p className="font-medium">
-                        {m.gcp_resource_type
-                          ? GCP_TYPE_SHORT[m.gcp_resource_type] ?? m.gcp_resource_type
-                          : '-'}
-                      </p>
-                      <p className="text-xs text-[#9ca3af] mt-0.5">
-                        {m.gcp_resource_name ?? '-'}
-                      </p>
+                      {isNR ? (
+                        <p className="text-xs text-[#9ca3af] italic">GCP 불필요</p>
+                      ) : (
+                        <>
+                          <p className="font-medium">
+                            {m.gcp_resource_type
+                              ? GCP_TYPE_SHORT[m.gcp_resource_type] ?? m.gcp_resource_type
+                              : '-'}
+                          </p>
+                          <p className="text-xs text-[#9ca3af] mt-0.5">
+                            {m.gcp_resource_name ?? '-'}
+                          </p>
+                        </>
+                      )}
                     </td>
                     <td className="p-4">
                       <span className={`px-2.5 py-1 rounded-full text-xs font-semibold ${conf.badgeClass}`}>
@@ -147,7 +211,7 @@ export default function ResourceMappingsPage() {
                           확인
                         </Button>
                       )}
-                      {isConfirmed(m) && (
+                      {m.confidence === 'review' && isConfirmed(m) && (
                         <span className="text-xs text-emerald-400">✅ 확인됨</span>
                       )}
                     </td>
@@ -173,7 +237,7 @@ export default function ResourceMappingsPage() {
                 매핑 상세
               </p>
               <button
-                onClick={() => setSelectedMapping(null)}
+                onClick={() => { setSelectedMapping(null); setIsEditing(false) }}
                 className="text-[#9ca3af] hover:text-white transition-colors"
               >
                 ✕
@@ -202,27 +266,76 @@ export default function ResourceMappingsPage() {
                 </p>
               </div>
 
+              {/* 검토 안내 — 사용자 친화적 표시 */}
               {selectedMapping.review_reason && (
-                <div className="bg-yellow-500/5 border border-yellow-500/20 rounded-xl p-3 text-xs text-yellow-400">
-                  ⚠️ {selectedMapping.review_reason}
+                <div className="bg-yellow-500/5 border border-yellow-500/20 rounded-xl p-3 text-xs text-yellow-400 space-y-1">
+                  <p className="font-semibold">⚠️ 검토가 필요한 이유</p>
+                  <p className="text-yellow-400/80 leading-relaxed">
+                    {formatReviewReason(selectedMapping.review_reason)}
+                  </p>
                 </div>
               )}
 
+              {/* Terraform 코드 — 수정 모드 */}
+              {isEditing ? (
+                <div>
+                  <p className="text-xs text-[#9ca3af] mb-1">Terraform 코드 수정</p>
+                  <textarea
+                    value={editedCode}
+                    onChange={(e) => setEditedCode(e.target.value)}
+                    rows={8}
+                    className="w-full text-xs font-mono bg-black/30 border border-white/20 rounded-xl p-3 text-white resize-none focus:outline-none focus:border-white/40"
+                  />
+                </div>
+              ) : (
+                selectedMapping.terraform_code && (
+                  <div>
+                    <p className="text-xs text-[#9ca3af] mb-1">Terraform 코드</p>
+                    <pre className="text-xs font-mono bg-black/30 border border-white/8 rounded-xl p-3 text-[#9ca3af] overflow-x-auto whitespace-pre-wrap">
+                      {selectedMapping.terraform_code}
+                    </pre>
+                  </div>
+                )
+              )}
+
               <div className="flex justify-end gap-2 pt-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="border-white/10 text-[#9ca3af] hover:bg-white/5 hover:text-white"
-                >
-                  ✏️ 수정
-                </Button>
-                <Button
-                  size="sm"
-                  className="bg-emerald-600 hover:bg-emerald-700 text-white"
-                  onClick={() => handleConfirm(selectedMapping)}
-                >
-                  ✅ 확인 완료
-                </Button>
+                {isEditing ? (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="border-white/10 text-[#9ca3af] hover:bg-white/5 hover:text-white"
+                      onClick={() => setIsEditing(false)}
+                    >
+                      취소
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="bg-blue-600 hover:bg-blue-700 text-white"
+                      onClick={handleSaveEdit}
+                    >
+                      저장
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="border-white/10 text-[#9ca3af] hover:bg-white/5 hover:text-white"
+                      onClick={() => handleOpenEdit(selectedMapping)}
+                    >
+                      ✏️ 수정
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="bg-emerald-600 hover:bg-emerald-700 text-white"
+                      onClick={() => handleConfirm(selectedMapping)}
+                    >
+                      ✅ 확인 완료
+                    </Button>
+                  </>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/types/mirror.ts
+++ b/frontend/types/mirror.ts
@@ -16,9 +16,10 @@ export interface DRStatus {
 }
 
 // §7-6 GET /api/mirror/{id}/resources 응답 항목
-export type Confidence = 'auto' | 'review' | 'manual'
+export type Confidence = 'auto' | 'review' | 'manual' | 'not_required'
 
 export interface ResourceMapping {
+  resource_id:       string
   aws_resource_type: string
   aws_resource_name: string
   aws_resource_id: string
@@ -27,6 +28,7 @@ export interface ResourceMapping {
   confidence: Confidence
   review_reason: string | null
   user_confirmed: boolean
+  terraform_code:    string | null
 }
 
 // §7-6 GET /api/mirror/{id}/package 응답

--- a/rds-export-s3-policy.json
+++ b/rds-export-s3-policy.json
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::autoops-dr-packages",
+        "arn:aws:s3:::autoops-dr-packages/*"
+      ]
+    }
+  ]
+}

--- a/response.json
+++ b/response.json
@@ -1,0 +1,1 @@
+{"success":true,"data":{"failover_id":"fo_dd6b13f1","mode":"actual","gcp_region":"us-west1","websocket_url":"wss://api.autoops.io/ws/events/b258ad96-7363-49a0-97e4-4530435bf9ef"}}

--- a/response.json
+++ b/response.json
@@ -1,1 +1,0 @@
-{"success":true,"data":{"failover_id":"fo_dd6b13f1","mode":"actual","gcp_region":"us-west1","websocket_url":"wss://api.autoops.io/ws/events/b258ad96-7363-49a0-97e4-4530435bf9ef"}}


### PR DESCRIPTION
- main.py: SQS 워커 lifespan 자동 시동
- bedrock_client.py: terraform_attributes → mapping_info 아키텍처 전환
- mapper.py: NOT_REQUIRED_RESOURCES 분류
- pipeline.py: sync.status completed 처리, has_changes=False dr_status 복원
- sqs_worker.py: KMS 키 alias/autoops-rds-export 수정
- dr_packager.py: Phase2 스냅샷 waiter, 체크리스트 DB 업데이트, gcloud auth 수정
- mirror.py: failover 시뮬레이션 S3 HCL 읽기, plan 파싱, RTO 15분, terraform-code PATCH
- resources/page.tsx: not_required 배지, review_reason 포맷, terraform_code 편집
- failover/page.tsx: SIMULATION_STEPS 동적화, RTO DB 기반 표시
- types/mirror.ts: resource_id, terraform_code, not_required 추가