### PR TITLE
fix: GCP Actual Failover 구현을 위한 코드 수정

### DIFF
--- a/backend/app/api/mirror.py
+++ b/backend/app/api/mirror.py
@@ -9,6 +9,16 @@ from app.models.project import Project
 from app.models.aws_resource import AWSResource
 from app.models.gcp_mapping import GCPMapping
 from app.models.sync_history import SyncHistory, DRPackage
+import asyncio
+import boto3
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+from datetime import datetime
+from pathlib import Path
 
 router = APIRouter()
 
@@ -80,7 +90,7 @@ def get_resources(
         ).order_by(GCPMapping.created_at.desc()).first()
 
         result.append({
-            "resource_id":       res.resource_id, 
+            "resource_id":       res.resource_id,
             "aws_resource_type": res.resource_type,
             "aws_resource_name": res.resource_name,
             "aws_resource_id":   res.resource_id_aws,
@@ -239,10 +249,8 @@ def _package_to_dict(p: DRPackage) -> dict:
     }
 
 
-import uuid
-import subprocess
-import tempfile
-from pathlib import Path
+# ── Failover ────────────────────────────────────────────────────────
+
 from app.models.failover_history import FailoverHistory
 
 
@@ -324,21 +332,20 @@ def failover(
         mode       = body.mode,
         gcp_region = "us-west1",
         status     = "running",
-        started_at = __import__("datetime").datetime.utcnow(),
+        started_at = datetime.utcnow(),
     )
     db.add(fh)
     db.commit()
 
+    # ── simulation 모드 ──────────────────────────────────────────────
     if body.mode == "simulation" and sim_package:
-        # [수정] S3 경로에서 실제 HCL 파일 내용을 읽어서 전달
         hcl_content = ""
         s3_path = sim_package.terraform_code_path or ""
         if s3_path.startswith("s3://"):
             try:
-                import boto3 as _boto3
-                path_body  = s3_path.replace("s3://", "")
+                path_body   = s3_path.replace("s3://", "")
                 bucket, key = path_body.split("/", 1)
-                s3_client   = _boto3.client("s3", region_name="us-west-2")
+                s3_client   = boto3.client("s3", region_name="us-west-2")
                 obj         = s3_client.get_object(Bucket=bucket, Key=key)
                 hcl_content = obj["Body"].read().decode("utf-8")
             except Exception as e:
@@ -352,16 +359,38 @@ def failover(
             db          = SessionLocal(),
         )
 
+    # ── actual 모드 ──────────────────────────────────────────────────
+    elif body.mode == "actual" and latest_package:
+        from app.models.aws_account import AWSAccount
+        account = db.query(AWSAccount).filter(
+            AWSAccount.account_id == project.account_id
+        ).first()
+
+        background_tasks.add_task(
+            _run_failover_actual,
+            project_id  = project_id,
+            failover_id = failover_id,
+            package     = latest_package,
+            project     = project,
+            role_arn    = account.role_arn if account else "",
+        )
+
     return {
         "success": True,
         "data": {
             "failover_id":   failover_id,
             "mode":          body.mode,
             "gcp_region":    "us-west1",
-            "websocket_url": f"wss://api.autoops.io/ws/events/{project_id}",
+            "websocket_url": (
+                f"wss://api.autoops.io/ws/events/{project_id}?failover_id={failover_id}"
+                if body.mode == "actual"
+                else f"wss://api.autoops.io/ws/events/{project_id}"
+            ),
         },
     }
 
+
+# ── Simulation 실행 ──────────────────────────────────────────────────
 
 def _run_failover_simulation(
     project_id: str,
@@ -369,8 +398,6 @@ def _run_failover_simulation(
     hcl_code: str,
     db: Session,
 ) -> None:
-    import json as _json
-
     work_dir = tempfile.mkdtemp(prefix=f"autoops-failover-{project_id[:8]}-")
     try:
         (Path(work_dir) / "main.tf").write_text(hcl_code, encoding="utf-8")
@@ -385,17 +412,14 @@ def _run_failover_simulation(
             cwd=work_dir, capture_output=True, text=True,
         )
 
-        # [수정] terraform plan -json 파싱 → 실제 생성될 리소스 수 추출
-        # terraform plan -json은 NDJSON 형식으로 여러 줄 출력
-        # "change_summary" 타입의 라인에서 add 수를 읽음
         add_count = 0
         for line in plan_result.stdout.splitlines():
             try:
-                obj = _json.loads(line)
+                obj = json.loads(line)
                 if obj.get("type") == "change_summary":
                     add_count = obj.get("changes", {}).get("add", 0)
                     break
-            except _json.JSONDecodeError:
+            except json.JSONDecodeError:
                 continue
 
         fh = db.query(FailoverHistory).filter(
@@ -404,20 +428,186 @@ def _run_failover_simulation(
         if fh:
             fh.status                = "completed"
             fh.gcp_resources_created = add_count if add_count > 0 else None
-            fh.actual_rto_seconds    = 15 * 60   # [수정] 12분 → 15분
-            fh.completed_at          = __import__("datetime").datetime.utcnow()
+            fh.actual_rto_seconds    = 15 * 60
+            fh.completed_at          = datetime.utcnow()
             db.commit()
 
     finally:
-        import shutil
         shutil.rmtree(work_dir, ignore_errors=True)
         db.close()
 
-# 신규 엔드포인트 추가
+
+# ── Actual 실행 ──────────────────────────────────────────────────────
+
+async def _run_failover_actual(
+    project_id: str,
+    failover_id: str,
+    package:     "DRPackage",
+    project:     "Project",
+    role_arn:    str,
+) -> None:
+    """
+    GCP actual 페일오버 실행. BackgroundTask로 동작한다.
+
+    흐름:
+    ① S3에서 main.tf 다운로드
+    ② GCP 인증 설정 (Secrets Manager)
+    ③ GCS State 버킷 자동 생성
+    ④ terraform init → apply (CloudWatch 로그 스트리밍)
+    ⑤ failover_history.status → completed + RTO 기록
+    """
+    from app.core.config import settings
+    from app.services.mirrorops.gcp_auth import setup_gcp_auth
+
+    started_at = datetime.utcnow()
+    work_dir   = None
+    db         = SessionLocal()
+    log_group  = f"/autoops/failover/{failover_id}"
+
+    cw = boto3.client("logs", region_name="us-west-2")
+
+    def _log(msg: str):
+        print(f"[Failover {failover_id}] {msg}")
+        try:
+            cw.put_log_events(
+                logGroupName  = log_group,
+                logStreamName = "failover",
+                logEvents     = [{"timestamp": int(datetime.utcnow().timestamp() * 1000), "message": msg}],
+            )
+        except Exception:
+            pass
+
+    def _update_status(new_status: str, error_msg: str = "", rto_seconds: int = None):
+        fh = db.query(FailoverHistory).filter(
+            FailoverHistory.failover_id == failover_id
+        ).first()
+        if fh:
+            fh.status       = new_status
+            fh.completed_at = datetime.utcnow()
+            if error_msg:
+                fh.error_message = error_msg
+            if rto_seconds is not None:
+                fh.actual_rto_seconds    = rto_seconds
+                fh.gcp_resources_created = 11
+            db.commit()
+
+    try:
+        # CloudWatch 로그 그룹 생성
+        try:
+            cw.create_log_group(logGroupName=log_group)
+            cw.create_log_stream(logGroupName=log_group, logStreamName="failover")
+        except cw.exceptions.ResourceAlreadyExistsException:
+            pass
+
+        # ① S3에서 main.tf 다운로드
+        _log("S3에서 main.tf 다운로드 중...")
+        s3       = boto3.client("s3", region_name="us-west-2")
+        work_dir = tempfile.mkdtemp(prefix=f"autoops-failover-{project_id[:8]}-")
+        tf_key   = f"projects/{project_id}/latest/infrastructure/main.tf"
+
+        s3.download_file("autoops-dr-packages", tf_key, str(Path(work_dir) / "main.tf"))
+        _log("main.tf 다운로드 완료")
+
+        # ② GCP 인증
+        _log("GCP 인증 설정 중...")
+        setup_gcp_auth()
+        _log(f"GCP 인증 완료 (프로젝트: {settings.gcp_project_id})")
+
+        # ③ GCS State 버킷 생성
+        bucket_name = f"autoops-dr-state-{project_id}"
+        _log(f"GCS State 버킷 확인: {bucket_name}")
+        try:
+            from google.cloud import storage as gcs_storage
+            gcs = gcs_storage.Client()
+            if not gcs.bucket(bucket_name).exists():
+                bucket = gcs.create_bucket(bucket_name, location="us-west1")
+                bucket.versioning_enabled = True
+                bucket.patch()
+                _log(f"GCS 버킷 생성 완료: {bucket_name}")
+            else:
+                _log(f"GCS 버킷 이미 존재: {bucket_name}")
+        except Exception as e:
+            _log(f"⚠️ GCS 버킷 처리 중 오류 (계속 진행): {e}")
+
+        # ④ terraform init
+        _log("terraform init 실행 중...")
+        env = {**os.environ, "TF_IN_AUTOMATION": "1"}
+
+        init_result = subprocess.run(
+            ["terraform", "init", "-no-color", "-reconfigure"],
+            cwd=work_dir, capture_output=True, text=True, timeout=120, env=env,
+        )
+        for line in init_result.stdout.splitlines():
+            if line.strip():
+                _log(line)
+        if init_result.returncode != 0:
+            raise RuntimeError(f"terraform init 실패:\n{init_result.stderr}")
+        _log("terraform init 완료")
+
+        # ⑤ terraform apply
+        _log("terraform apply 실행 중 (GCP 리소스 생성 시작)...")
+        _log("Cloud SQL 생성에 약 10~15분 소요됩니다.")
+
+        apply_proc = subprocess.Popen(
+            ["terraform", "apply", "-auto-approve", "-no-color", "-json"],
+            cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, env=env,
+        )
+
+        for line in apply_proc.stdout:
+            line = line.rstrip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+                msg   = event.get("@message", "")
+                if msg:
+                    _log(msg)
+            except json.JSONDecodeError:
+                _log(line)
+
+        apply_proc.wait(timeout=1200)  # 최대 20분
+        if apply_proc.returncode != 0:
+            raise RuntimeError(f"terraform apply 실패 (exit code {apply_proc.returncode})")
+
+        _log("✅ terraform apply 완료 — GCP 리소스 생성 성공")
+
+        # ── S3 parquet → Cloud SQL 데이터 복원 추가 ─────────────────────
+        _log("Cloud SQL 데이터 복원 시작...")
+        await _import_snapshot_to_cloud_sql(
+            project_id  = project_id,
+            package     = package,
+            bucket_name = bucket_name,
+            gcp_project = settings.gcp_project_id,
+            log_fn      = _log,
+        )
+        _log("✅ Cloud SQL 데이터 복원 완료")
+
+
+        # ⑥ RTO 계산 및 DB 업데이트
+        rto_seconds = int((datetime.utcnow() - started_at).total_seconds())
+        _log(f"실제 RTO: {rto_seconds // 60}분 {rto_seconds % 60}초")
+        _update_status("completed", rto_seconds=rto_seconds)
+
+    except Exception as e:
+        err_msg = str(e)
+        _log(f"❌ 페일오버 실패: {err_msg}")
+        _update_status("failed", error_msg=err_msg[:1000])
+
+    finally:
+        if work_dir and os.path.exists(work_dir):
+            shutil.rmtree(work_dir, ignore_errors=True)
+        db.close()
+
+
+# ── terraform_code PATCH ─────────────────────────────────────────────
+
 from pydantic import BaseModel as _BaseModel
+
 
 class TerraformCodeUpdate(_BaseModel):
     terraform_code: str
+
 
 @router.patch("/{project_id}/resources/{resource_id}/terraform-code")
 def update_terraform_code(
@@ -444,3 +634,338 @@ def update_terraform_code(
     db.commit()
 
     return {"success": True, "data": {"resource_id": resource_id}}
+
+async def _import_snapshot_to_cloud_sql(
+    project_id:  str,
+    package:     "DRPackage",
+    bucket_name: str,
+    gcp_project: str,
+    log_fn,
+) -> None:
+    """
+    S3 parquet → GCS CSV 변환 → Cloud SQL import
+
+    흐름:
+    ① S3 export 경로에서 parquet 파일 목록 수집
+    ② 테이블별 parquet 읽기 → pandas DataFrame
+    ③ GCS에 CSV 업로드
+    ④ Cloud SQL Admin API로 import
+    """
+    import io
+    import pandas as pd
+    import boto3 as _boto3
+    from google.cloud import storage as gcs_storage
+    import googleapiclient.discovery
+    import time
+
+    s3         = _boto3.client("s3", region_name="us-west-2")
+    gcs        = gcs_storage.Client()
+    gcs_bucket = gcs.bucket(bucket_name)
+    sqladmin   = googleapiclient.discovery.build("sqladmin", "v1beta4")
+
+    export_prefix = f"projects/{project_id}/latest/data/exports/"
+    s3_bucket     = "autoops-dr-packages"
+
+    log_fn(f"S3 parquet 목록 조회:{export_prefix}")
+
+    # ── ① parquet 파일 목록 수집 ──────────────────────────────
+    paginator   = s3.get_paginator("list_objects_v2")
+    table_files: dict[str, list[str]] = {}
+
+    for page in paginator.paginate(Bucket=s3_bucket, Prefix=export_prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if not key.endswith(".parquet"):
+                continue
+            parts     = key.replace(export_prefix, "").split("/")
+            table_key = parts[0] if parts else "unknown"
+            table_files.setdefault(table_key, []).append(key)
+
+    if not table_files:
+        log_fn("⚠️ S3에 parquet 파일 없음 — 데이터 복원 스킵")
+        return
+
+    log_fn(f"복원 대상 테이블:{list(table_files.keys())}")
+
+    # Cloud SQL 인스턴스명 추론
+    sql_instance = None
+    try:
+        snap_ref_key = f"projects/{project_id}/latest/data/snapshot_ref.json"
+        obj          = s3.get_object(Bucket=s3_bucket, Key=snap_ref_key)
+        snap_ref     = json.loads(obj["Body"].read())
+        sql_instance = snap_ref.get("sql_instance_name", "")
+    except Exception:
+        pass
+
+    if not sql_instance:
+        sql_instance = f"{project_id[:8]}-sql"
+        log_fn(f"⚠️ Cloud SQL 인스턴스명 추론:{sql_instance}")
+
+    # ── ② 테이블별 parquet → CSV 변환 → GCS 업로드 → import ──
+    for table_key, parquet_keys in table_files.items():
+        log_fn(f"테이블 처리 중:{table_key}")
+
+        dfs = []
+        for pk in parquet_keys:
+            obj = s3.get_object(Bucket=s3_bucket, Key=pk)
+            df  = pd.read_parquet(io.BytesIO(obj["Body"].read()))
+            dfs.append(df)
+
+        if not dfs:
+            continue
+
+        merged_df  = pd.concat(dfs, ignore_index=True)
+        csv_buffer = io.StringIO()
+        merged_df.to_csv(csv_buffer, index=False)
+
+        gcs_csv_path = f"import/{table_key}.csv"
+        blob         = gcs_bucket.blob(gcs_csv_path)
+        blob.upload_from_string(csv_buffer.getvalue(), content_type="text/csv")
+        log_fn(f"GCS 업로드 완료: gs://{bucket_name}/{gcs_csv_path}")
+
+        table_name = table_key.split(".")[-1] if "." in table_key else table_key
+        database   = table_key.split(".")[0] if "." in table_key else "public"
+
+        try:
+            op = sqladmin.instances().import_(
+                project  = gcp_project,
+                instance = sql_instance,
+                body={
+                    "importContext": {
+                        "kind":     "sql#importContext",
+                        "fileType": "CSV",
+                        "uri":      f"gs://{bucket_name}/{gcs_csv_path}",
+                        "database": database,
+                        "csvImportOptions": {"table": table_name},
+                    }
+                }
+            ).execute()
+
+            # 완료 대기 (최대 10분)
+            for _ in range(60):
+                result = sqladmin.operations().get(
+                    project   = gcp_project,
+                    operation = op["name"].split("/")[-1],
+                ).execute()
+                if result.get("status") == "DONE":
+                    break
+                await asyncio.sleep(10)
+
+            log_fn(f"✅{table_name} import 완료 ({len(merged_df)}행)")
+
+        except Exception as e:
+            log_fn(f"⚠️{table_name} import 실패 (계속 진행):{e}")
+
+# ── GET /api/mirror/{project_id}/failover/{failover_id} ────────────
+
+@router.get("/{project_id}/failover/{failover_id}")
+def get_failover_status(
+    project_id:  str,
+    failover_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _get_project_or_404(project_id, current_user.user_id, db)
+
+    fh = db.query(FailoverHistory).filter(
+        FailoverHistory.failover_id == failover_id,
+        FailoverHistory.project_id  == project_id,
+    ).first()
+
+    if not fh:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "NOT_FOUND", "message": "페일오버 이력을 찾을 수 없습니다."},
+        )
+
+    return {
+        "success": True,
+        "data": {
+            "failover_id":           fh.failover_id,
+            "mode":                  fh.mode,
+            "status":                fh.status,
+            "gcp_region":            fh.gcp_region,
+            "gcp_resources_created": fh.gcp_resources_created,
+            "actual_rto_seconds":    fh.actual_rto_seconds,
+            "error_message":         fh.error_message,
+            "started_at":            fh.started_at.isoformat(),
+            "completed_at":          fh.completed_at.isoformat() if fh.completed_at else None,
+        },
+    }
+
+# ── GCP 리소스 삭제 엔드포인트 ──────────────────────────────────
+
+@router.post("/{project_id}/failover/{failover_id}/destroy", status_code=202)
+def destroy_gcp_resources(
+    project_id:  str,
+    failover_id: str,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _get_project_or_404(project_id, current_user.user_id, db)
+
+    fh = db.query(FailoverHistory).filter(
+        FailoverHistory.failover_id == failover_id,
+        FailoverHistory.project_id  == project_id,
+    ).first()
+
+    if not fh:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "NOT_FOUND", "message": "페일오버 이력을 찾을 수 없습니다."},
+        )
+
+    if fh.mode != "actual":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "BAD_REQUEST", "message": "simulation 모드는 삭제할 GCP 리소스가 없습니다."},
+        )
+
+    if fh.status not in ("completed", "failed"):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code":    "CONFLICT",
+                "message": f"삭제 가능한 상태가 아닙니다. 현재 상태:{fh.status}",
+            },
+        )
+
+    fh.status = "destroying"
+    db.commit()
+
+    background_tasks.add_task(
+        _run_failover_destroy,
+        project_id  = project_id,
+        failover_id = failover_id,
+    )
+
+    return {
+        "success": True,
+        "data": {
+            "failover_id": failover_id,
+            "status":      "destroying",
+        },
+    }
+
+
+async def _run_failover_destroy(
+    project_id:  str,
+    failover_id: str,
+) -> None:
+    """
+    terraform destroy로 GCP 리소스 삭제.
+
+    흐름:
+    ① S3에서 main.tf 다운로드
+    ② GCP 인증
+    ③ terraform init → destroy
+    ④ GCS import 파일 정리
+    ⑤ failover_history.status → destroyed
+    """
+    from app.services.mirrorops.gcp_auth import setup_gcp_auth
+    from app.core.config import settings
+
+    db       = SessionLocal()
+    work_dir = None
+    cw       = boto3.client("logs", region_name="us-west-2")
+    log_group = f"/autoops/failover/{failover_id}"
+
+    def _log(msg: str):
+        print(f"[Destroy{failover_id}]{msg}")
+        try:
+            cw.put_log_events(
+                logGroupName  = log_group,
+                logStreamName = "failover",
+                logEvents     = [{"timestamp": int(datetime.utcnow().timestamp() * 1000), "message": msg}],
+            )
+        except Exception:
+            pass
+
+    def _update_status(new_status: str, error_msg: str = ""):
+        fh = db.query(FailoverHistory).filter(
+            FailoverHistory.failover_id == failover_id
+        ).first()
+        if fh:
+            fh.status       = new_status
+            fh.completed_at = datetime.utcnow()
+            if error_msg:
+                fh.error_message = error_msg
+            db.commit()
+
+    try:
+        # ① S3에서 main.tf 다운로드
+        _log("S3에서 main.tf 다운로드 중...")
+        s3       = boto3.client("s3", region_name="us-west-2")
+        work_dir = tempfile.mkdtemp(prefix=f"autoops-destroy-{project_id[:8]}-")
+        tf_key   = f"projects/{project_id}/latest/infrastructure/main.tf"
+        s3.download_file("autoops-dr-packages", tf_key, str(Path(work_dir) / "main.tf"))
+        _log("main.tf 다운로드 완료")
+
+        # ② GCP 인증
+        _log("GCP 인증 설정 중...")
+        setup_gcp_auth()
+        _log("GCP 인증 완료")
+
+        env = {**os.environ, "TF_IN_AUTOMATION": "1"}
+
+        # ③ terraform init
+        _log("terraform init 실행 중...")
+        init_result = subprocess.run(
+            ["terraform", "init", "-no-color", "-reconfigure"],
+            cwd=work_dir, capture_output=True, text=True, timeout=120, env=env,
+        )
+        if init_result.returncode != 0:
+            raise RuntimeError(f"terraform init 실패:\n{init_result.stderr}")
+        _log("terraform init 완료")
+
+        # ③ terraform destroy
+        _log("terraform destroy 실행 중 (GCP 리소스 삭제 시작)...")
+        destroy_proc = subprocess.Popen(
+            ["terraform", "destroy", "-auto-approve", "-no-color", "-json"],
+            cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, env=env,
+        )
+        for line in destroy_proc.stdout:
+            line = line.rstrip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+                msg   = event.get("@message", "")
+                if msg:
+                    _log(msg)
+            except json.JSONDecodeError:
+                _log(line)
+
+        destroy_proc.wait(timeout=600)  # 최대 10분
+        if destroy_proc.returncode != 0:
+            raise RuntimeError(f"terraform destroy 실패 (exit code{destroy_proc.returncode})")
+        _log("✅ terraform destroy 완료 — GCP 리소스 삭제 성공")
+
+        # ④ GCS import 파일 정리
+        bucket_name = f"autoops-dr-state-{project_id}"
+        try:
+            from google.cloud import storage as gcs_storage
+            gcs    = gcs_storage.Client()
+            bucket = gcs.bucket(bucket_name)
+            blobs  = list(bucket.list_blobs(prefix="import/"))
+            if blobs:
+                bucket.delete_blobs(blobs)
+                _log(f"GCS import 파일 정리 완료:{len(blobs)}개")
+        except Exception as e:
+            _log(f"⚠️ GCS 정리 중 오류 (무시):{e}")
+
+        # ⑤ 상태 업데이트
+        _update_status("destroyed")
+        _log("✅ GCP 리소스 삭제 완료")
+
+    except Exception as e:
+        err_msg = str(e)
+        _log(f"❌ GCP 리소스 삭제 실패:{err_msg}")
+        _update_status("destroy_failed", error_msg=err_msg[:1000])
+
+    finally:
+        if work_dir and os.path.exists(work_dir):
+            shutil.rmtree(work_dir, ignore_errors=True)
+        db.close()

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -166,7 +166,7 @@ def delete_project(
     # destroy_aws_resources 여부와 관계없이 DB + S3 즉시 삭제
     _delete_project_records(project_id, project, db)
 
-    return {"success": True, "message": "프로젝트가 삭제되었습니다."}
+    return {"success": True, "message": "프로젝트가 삭제됐습니다."}
 
 
 def _delete_project_records(project_id: str, project: Project, db: Session) -> None:
@@ -214,19 +214,25 @@ def _delete_project_records(project_id: str, project: Project, db: Session) -> N
     db.delete(project)
     db.commit()
 
-    # S3 DR Package 클린업
+    # [수정] S3 DR Package 클린업 — Versioning 활성화 버킷 대응
     try:
-        s3 = _boto3.client("s3", region_name="us-west-2")
-        prefix = f"projects/{project_id}/"
-        paginator = s3.get_paginator("list_objects_v2")
-        for page in paginator.paginate(Bucket="autoops-dr-packages", Prefix=prefix):
-            objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+        s3        = _boto3.client("s3", region_name="us-west-2")
+        prefix    = f"projects/{project_id}/"
+        s3_bucket = "autoops-dr-packages"
+
+        paginator = s3.get_paginator("list_object_versions")
+        for page in paginator.paginate(Bucket=s3_bucket, Prefix=prefix):
+            objects = []
+            for v in page.get("Versions", []):
+                objects.append({"Key": v["Key"], "VersionId": v["VersionId"]})
+            for m in page.get("DeleteMarkers", []):
+                objects.append({"Key": m["Key"], "VersionId": m["VersionId"]})
             if objects:
                 s3.delete_objects(
-                    Bucket="autoops-dr-packages",
+                    Bucket=s3_bucket,
                     Delete={"Objects": objects},
                 )
-        print(f"[Delete] S3 DR Package 클린업 완료: projects/{project_id}/")
+        print(f"[Delete] S3 DR Package 클린업 완료: {prefix}")
     except Exception as e:
         print(f"[Delete] S3 클린업 실패 (무시): {e}")
 

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -18,6 +18,7 @@ async def websocket_events(
     websocket: WebSocket,
     project_id: str,
     deployment_id: str = Query(None),
+    failover_id: str   = Query(None), 
 ):
     """
     CloudWatch Logs를 2초 간격으로 폴링해 배포 로그를 실시간 스트리밍한다.
@@ -30,6 +31,11 @@ async def websocket_events(
     { "event_type": "...", "project_id": "...", "timestamp": "...", "data": {...} }
     """
     await websocket.accept()
+
+    # failover_id가 있으면 페일오버 로그 스트리밍 분기
+    if failover_id:
+        await _stream_failover_logs(websocket, project_id, failover_id)
+        return
 
     if not deployment_id:
         await websocket.send_json({
@@ -271,6 +277,127 @@ async def websocket_mirror_events(
 
             finally:
                 db.close()
+
+            await asyncio.sleep(2)
+
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        try:
+            await websocket.send_json({
+                "event_type": "error",
+                "project_id": project_id,
+                "timestamp":  datetime.now(timezone.utc).isoformat(),
+                "data": {"message": str(e)},
+            })
+        except Exception:
+            pass
+    finally:
+        try:
+            await websocket.close()
+        except Exception:
+            pass
+
+# backend/app/api/websocket.py — 파일 하단에 추가
+
+async def _stream_failover_logs(
+    websocket: WebSocket,
+    project_id: str,
+    failover_id: str,
+) -> None:
+    """
+    /autoops/failover/{failover_id} CloudWatch 로그를 2초 polling.
+    failover_history.status가 completed/failed가 되면 종료.
+    """
+    log_group  = f"/autoops/failover/{failover_id}"
+    next_token = None
+
+    try:
+        while True:
+            # CloudWatch 로그 폴링
+            try:
+                streams = cw.describe_log_streams(
+                    logGroupName = log_group,
+                    orderBy      = "LastEventTime",
+                    descending   = True,
+                    limit        = 1,
+                )
+                log_streams = streams.get("logStreams", [])
+
+                if log_streams:
+                    kwargs = {
+                        "logGroupName":  log_group,
+                        "logStreamName": log_streams[0]["logStreamName"],
+                        "startFromHead": True,
+                        "limit":         100,
+                    }
+                    if next_token:
+                        kwargs["nextToken"] = next_token
+
+                    resp       = cw.get_log_events(**kwargs)
+                    events     = resp.get("events", [])
+                    next_token = resp.get("nextForwardToken")
+
+                    for event in events:
+                        await websocket.send_json({
+                            "event_type": "failover_progress",
+                            "project_id": project_id,
+                            "timestamp":  datetime.now(timezone.utc).isoformat(),
+                            "data": {
+                                "failover_id":      failover_id,
+                                "current_resource": event["message"],
+                                "elapsed_seconds":  0,
+                            },
+                        })
+
+            except cw.exceptions.ResourceNotFoundException:
+                pass  # 로그 그룹 아직 생성 안 됨
+
+            # DB에서 완료 여부 체크
+            db: Session = SessionLocal()
+            try:
+                from app.models.failover_history import FailoverHistory
+                fh = db.query(FailoverHistory).filter(
+                    FailoverHistory.failover_id == failover_id
+                ).first()
+                current_status = fh.status if fh else None
+                rto_seconds    = fh.actual_rto_seconds if fh else None
+                gcp_created    = fh.gcp_resources_created if fh else None
+            finally:
+                db.close()
+
+            if current_status == "completed":
+                await websocket.send_json({
+                    "event_type": "failover_completed",
+                    "project_id": project_id,
+                    "timestamp":  datetime.now(timezone.utc).isoformat(),
+                    "data": {
+                        "failover_id":          failover_id,
+                        "gcp_resources_created": gcp_created,
+                        "actual_rto_seconds":    rto_seconds,
+                    },
+                })
+                break
+
+            elif current_status == "failed":
+                db2 = SessionLocal()
+                try:
+                    from app.models.failover_history import FailoverHistory as FH2
+                    fh2 = db2.query(FH2).filter(FH2.failover_id == failover_id).first()
+                    err = fh2.error_message if fh2 else "알 수 없는 오류"
+                finally:
+                    db2.close()
+
+                await websocket.send_json({
+                    "event_type": "failover_failed",
+                    "project_id": project_id,
+                    "timestamp":  datetime.now(timezone.utc).isoformat(),
+                    "data": {
+                        "failover_id":   failover_id,
+                        "error_message": err,
+                    },
+                })
+                break
 
             await asyncio.sleep(2)
 

--- a/backend/app/models/failover_history.py
+++ b/backend/app/models/failover_history.py
@@ -15,7 +15,7 @@ class FailoverHistory(Base):
     mode = Column(String(20), nullable=False)           # simulation / actual
     gcp_region = Column(String(50), nullable=False)
     status = Column(String(20), nullable=False, default="running")
-    # status: running / completed / failed
+    # status: running / completed / failed / destroying / destroyed / destroy_failed
     gcp_resources_created = Column(Integer, nullable=True)
     actual_rto_seconds = Column(Integer, nullable=True)
     error_message = Column(Text, nullable=True)

--- a/backend/app/services/mirrorops/dr_packager.py
+++ b/backend/app/services/mirrorops/dr_packager.py
@@ -60,7 +60,13 @@ class DRPackager:
         self._upload_json(f"{s3_base}/data/snapshot_ref.json", snapshot_ref)
 
         # ③ GCP Terraform HCL 저장
-        self._upload_text(f"{s3_base}/infrastructure/main.tf", hcl_code)
+        import re as _re
+        hcl_patched = _re.sub(
+            r'image\s*=\s*"[^"]*"',
+            f'image = "{gcr_uri}"',
+            hcl_code
+        )
+        self._upload_text(f"{s3_base}/infrastructure/main.tf", hcl_patched)
 
         # dr-report.json 생성 (RTO 15, RPO 0)
         dr_report = {

--- a/backend/app/services/mirrorops/mapper.py
+++ b/backend/app/services/mirrorops/mapper.py
@@ -35,7 +35,15 @@ RULE_BASED_MAP: dict[str, dict] = {
             ).lower().replace("_", "-"),
             "ip_cidr_range": cfg.get("cidrBlock", ""),
             "region":        "us-west1",
-            "network":       cfg.get("vpcId", "default-vpc").lower().replace("_", "-"),
+            # [수정] 이름 태그 앞 두 파트로 VPC명 추론 (AWS VPC ID 사용 금지)
+            "network": (
+                "-".join(
+                    (cfg.get("tags") or {}).get("Name", "")
+                    .lower().replace("_", "-").split("-")[:2]
+                ) + "-vpc"
+                if (cfg.get("tags") or {}).get("Name", "")
+                else "default-vpc"
+            ),
         },
     },
     "AWS::EC2::RouteTable": {
@@ -46,16 +54,35 @@ RULE_BASED_MAP: dict[str, dict] = {
                 (cfg.get("tags") or {}).get("Name", "") or
                 "router-" + cfg.get("routeTableId", "default")
             ).lower().replace("_", "-"),
-            "region":  "us-west1",
-            "network": cfg.get("vpcId", "default-vpc").lower().replace("_", "-"),
+            "region": "us-west1",
+            # [수정] 이름 태그 앞 두 파트로 VPC명 추론
+            "network": (
+                "-".join(
+                    (cfg.get("tags") or {}).get("Name", "")
+                    .lower().replace("_", "-").split("-")[:2]
+                ) + "-vpc"
+                if (cfg.get("tags") or {}).get("Name", "")
+                else "default-vpc"
+            ),
         },
     },
     "AWS::EC2::NatGateway": {
         "gcp_type":   "google_compute_router_nat",
         "confidence": "auto",
         "mapping":    lambda cfg: {
-            "name":                               "cloud-nat",
-            "router":                             "cloud-router",
+            # [수정] name, router 모두 이름 태그에서 동적 추론
+            "name": (
+                (cfg.get("tags") or {}).get("Name", "") or
+                "cloud-nat"
+            ).lower().replace("_", "-"),
+            "router": (
+                "-".join(
+                    (cfg.get("tags") or {}).get("Name", "")
+                    .lower().replace("_", "-").split("-")[:2]
+                ) + "-rt-public"
+                if (cfg.get("tags") or {}).get("Name", "")
+                else "cloud-router"
+            ),
             "region":                             "us-west1",
             "nat_ip_allocate_option":             "AUTO_ONLY",
             "source_subnetwork_ip_ranges_to_nat": "ALL_SUBNETWORKS_ALL_IP_RANGES",
@@ -137,7 +164,6 @@ class MappingEngine:
 
             rule = RULE_BASED_MAP.get(res.resource_type)
             if not rule:
-                # GCP 매핑 불필요 리소스와 수동 설정 리소스 구분
                 if res.resource_type in NOT_REQUIRED_RESOURCES:
                     mapping = self._create_not_required_mapping(res, project_id, sync_id)
                 else:
@@ -203,7 +229,6 @@ class MappingEngine:
     def _create_not_required_mapping(
         self, res: AWSResource, project_id: str, sync_id: str
     ) -> GCPMapping:
-        """GCP에 대응 개념이 없어 별도 생성이 불필요한 리소스"""
         return GCPMapping(
             resource_id       = res.resource_id,
             project_id        = project_id,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,3 +34,6 @@ httpx==0.28.0
 # Utilities
 python-dotenv==1.0.1
 cryptography==43.0.3
+
+google-api-python-client==2.127.0
+pandas==2.2.2

--- a/frontend/app/projects/[id]/failover/page.tsx
+++ b/frontend/app/projects/[id]/failover/page.tsx
@@ -21,11 +21,12 @@ export default function FailoverPage() {
   const [failoverData, setFailoverData] = useState<FailoverResponse | null>(null)
   const [simStep, setSimStep]           = useState(-1)
   const [logs, setLogs]                 = useState<string[]>([])
+  const [destroyStatus, setDestroyStatus] = useState<'idle' | 'confirming' | 'destroying' | 'destroyed' | 'failed'>('idle')
+  const [destroyError, setDestroyError] = useState('')
 
   const { data: packageData } = useDRPackage(projectId)
   const latest = packageData?.latest
 
-  // SIMULATION_STEPS를 컴포넌트 내부로 이동 — latest 참조 가능
   const SIMULATION_STEPS = [
     { label: 'Terraform Init',        duration: '2초' },
     { label: 'Terraform Plan',        duration: `GCP ${
@@ -41,7 +42,8 @@ export default function FailoverPage() {
 
   const { events } = useWebSocket(
     failoverData ? projectId : null,
-    failoverData ? failoverData.failover_id : null
+    failoverData ? failoverData.failover_id : null,
+    'failover_id'
   )
 
   // ── 시뮬레이션 단계 진행 ─────────────────────────────────────
@@ -84,6 +86,16 @@ export default function FailoverPage() {
         }`,
       ])
     }
+
+    if (latest_event.event_type === 'failover_failed') {
+      const data = latest_event.data as { error_message?: string }
+      setIsRunning(false)
+      setError(data.error_message ?? '페일오버 실행에 실패했습니다.')
+      setLogs((prev) => [
+        ...prev,
+        `❌ 페일오버 실패: ${data.error_message ?? '알 수 없는 오류'}`,
+      ])
+    }
   }, [events])
 
   // ── 페일오버 실행 ────────────────────────────────────────────
@@ -97,6 +109,8 @@ export default function FailoverPage() {
     setIsRunning(true)
     setSimStep(0)
     setLogs([])
+    setDestroyStatus('idle')
+    setDestroyError('')
 
     try {
       const body: Record<string, string> = { mode }
@@ -111,6 +125,51 @@ export default function FailoverPage() {
       setError(msg)
       setIsRunning(false)
       setSimStep(-1)
+    }
+  }
+
+  // ── GCP 리소스 삭제 (폴링으로 실제 완료 확인) ────────────────
+  const handleDestroyGcp = async () => {
+    if (!failoverData) return
+    setDestroyStatus('destroying')
+    setDestroyError('')
+
+    try {
+      await apiClient.post(
+        `/api/mirror/${projectId}/failover/${failoverData.failover_id}/destroy`
+      )
+
+      // 실제 완료될 때까지 폴링 (10초 간격, 최대 10분)
+      for (let i = 0; i < 60; i++) {
+        await new Promise((r) => setTimeout(r, 10000))
+        try {
+          const res = await apiClient.get(
+            `/api/mirror/${projectId}/failover/${failoverData.failover_id}`
+          )
+          const fh = res.data.data
+          if (fh?.status === 'destroyed') {
+            setDestroyStatus('destroyed')
+            return
+          }
+          if (fh?.status === 'destroy_failed') {
+            setDestroyStatus('failed')
+            setDestroyError(fh.error_message ?? 'GCP 리소스 삭제에 실패했습니다.')
+            return
+          }
+        } catch {
+          // 폴링 실패 시 계속 재시도
+        }
+      }
+      // 10분 타임아웃
+      setDestroyStatus('failed')
+      setDestroyError('삭제 시간이 초과됐습니다. GCP 콘솔에서 직접 확인하세요.')
+
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { error?: { message?: string } } } })
+          ?.response?.data?.error?.message ?? 'GCP 리소스 삭제에 실패했습니다.'
+      setDestroyError(msg)
+      setDestroyStatus('failed')
     }
   }
 
@@ -227,7 +286,6 @@ export default function FailoverPage() {
               </div>
             ))}
 
-            {/* 완료 표시 — DB의 rto_minutes 사용 */}
             {!isRunning && simStep >= SIMULATION_STEPS.length - 1 && (
               <div className="pt-3 border-t border-white/8">
                 <p className="text-emerald-400 font-semibold">
@@ -257,7 +315,104 @@ export default function FailoverPage() {
         </div>
       )}
 
-      {/* 완료 후 다시 시뮬레이션 버튼 */}
+      {/* actual 완료 후 — 로그 + GCP 리소스 삭제 */}
+      {!isRunning && mode === 'actual' && logs.length > 0 && (
+        <div className="space-y-4 mt-4">
+
+          {/* 결과 로그 */}
+          <div className="bg-[#121214] border border-white/8 rounded-3xl p-6">
+            <p className={`text-sm font-semibold mb-4 ${error ? 'text-red-400' : 'text-emerald-400'}`}>
+              {error ? '❌ 페일오버 실패' : '✅ 페일오버 완료'}
+            </p>
+            <div className="bg-black rounded-2xl p-4 h-32 overflow-y-auto font-mono text-xs">
+              {logs.map((log, i) => (
+                <p key={i} className="text-emerald-400">{log}</p>
+              ))}
+            </div>
+          </div>
+
+          {/* GCP 리소스 관리 */}
+          <div className="bg-[#121214] border border-white/8 rounded-3xl p-6 space-y-3">
+            <p className="text-sm font-semibold text-white">GCP 리소스 관리</p>
+            <p className="text-xs text-[#9ca3af]">
+              페일오버 검증이 완료됐다면 GCP 리소스를 삭제해 비용을 절감하세요.
+            </p>
+
+            {destroyStatus === 'idle' && (
+              <Button
+                variant="outline"
+                className="border-red-500/30 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+                onClick={() => setDestroyStatus('confirming')}
+              >
+                🗑️ GCP 리소스 삭제
+              </Button>
+            )}
+
+            {destroyStatus === 'confirming' && (
+              <div className="space-y-2 bg-red-500/5 border border-red-500/20 rounded-2xl p-4">
+                <p className="text-xs text-red-400">
+                  ⚠️ GCP에 생성된 모든 리소스가 삭제됩니다. 계속하시겠습니까?
+                </p>
+                <div className="flex gap-2 mt-2">
+                  <Button
+                    size="sm"
+                    className="bg-red-600 hover:bg-red-700 text-white"
+                    onClick={handleDestroyGcp}
+                  >
+                    삭제 확인
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="border-white/10 text-[#9ca3af] hover:bg-white/5"
+                    onClick={() => setDestroyStatus('idle')}
+                  >
+                    취소
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {destroyStatus === 'destroying' && (
+              <p className="text-xs text-yellow-400 animate-pulse">
+                ⏳ GCP 리소스 삭제 중... (약 5~10분 소요, 완료까지 대기 중)
+              </p>
+            )}
+
+            {destroyStatus === 'destroyed' && (
+              <p className="text-xs text-emerald-400">
+                ✅ GCP 리소스가 모두 삭제됐습니다.
+              </p>
+            )}
+
+            {destroyStatus === 'failed' && (
+              <div className="space-y-2">
+                <p className="text-xs text-red-400">
+                  ❌ 삭제에 실패했습니다.
+                </p>
+                {destroyError && (
+                  <p className="text-xs text-red-400/70 font-mono bg-red-500/5 rounded-xl p-2">
+                    {destroyError}
+                  </p>
+                )}
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="border-red-500/30 text-red-400 hover:bg-red-500/10 mt-1"
+                  onClick={() => {
+                    setDestroyStatus('confirming')
+                    setDestroyError('')
+                  }}
+                >
+                  🔄 삭제 재시도
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* 다시 시뮬레이션 버튼 */}
       {!isRunning && simStep >= SIMULATION_STEPS.length - 1 && (
         <Button
           variant="outline"
@@ -270,6 +425,35 @@ export default function FailoverPage() {
           다시 시뮬레이션
         </Button>
       )}
+
+      {/* actual 완료/실패 후 — 뒤로가기 + 페일오버 재시도 버튼 */}
+      {!isRunning && mode === 'actual' && (error || logs.some(l => l.includes('완료'))) && (
+        <div className="flex gap-2 mt-4">
+          <Button
+            variant="outline"
+            className="border-white/10 text-[#9ca3af] hover:bg-white/5 hover:text-white"
+            onClick={() => router.push(`/projects/${projectId}/mirror`)}
+          >
+            ← 대시보드로
+          </Button>
+          {error && (
+            <Button
+              variant="outline"
+              className="border-yellow-500/30 text-yellow-400 hover:bg-yellow-500/10"
+              onClick={() => {
+                setError('')
+                setLogs([])
+                setFailoverData(null)
+                setDestroyStatus('idle')
+                setDestroyError('')
+              }}
+            >
+              🔄 페일오버 재시도
+            </Button>
+          )}
+        </div>
+      )}
+
     </div>
   )
 }

--- a/frontend/hooks/useWebSocket.ts
+++ b/frontend/hooks/useWebSocket.ts
@@ -1,4 +1,3 @@
-// frontend/hooks/useWebSocket.ts
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { WSEvent } from '@/types'
 
@@ -6,32 +5,32 @@ const WS_BASE = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000'
 
 export function useWebSocket(
   projectId: string | null,
-  deploymentId: string | null
+  deploymentId: string | null,
+  // [추가] failover 등 다른 용도로 파라미터 이름 변경 가능
+  idParamName: string = 'deployment_id'
 ) {
-  const ws = useRef<WebSocket | null>(null)
-  const [events, setEvents] = useState<WSEvent[]>([])
+  const ws            = useRef<WebSocket | null>(null)
+  const [events, setEvents]           = useState<WSEvent[]>([])
   const [isConnected, setIsConnected] = useState(false)
-  const [lastEvent, setLastEvent] = useState<WSEvent | null>(null)
+  const [lastEvent, setLastEvent]     = useState<WSEvent | null>(null)
 
   const connect = useCallback(() => {
     if (!projectId || !deploymentId) return
 
     const token = localStorage.getItem('access_token')
-    const url = `${WS_BASE}/ws/events/${projectId}?deployment_id=${deploymentId}&token=${token}`
+    // [수정] idParamName을 동적으로 사용
+    const url = `${WS_BASE}/ws/events/${projectId}?${idParamName}=${deploymentId}&token=${token}`
 
     ws.current = new WebSocket(url)
-
-    ws.current.onopen = () => setIsConnected(true)
-
+    ws.current.onopen    = () => setIsConnected(true)
     ws.current.onmessage = (e) => {
       const event: WSEvent = JSON.parse(e.data)
       setLastEvent(event)
       setEvents((prev) => [...prev, event])
     }
-
     ws.current.onclose = () => setIsConnected(false)
     ws.current.onerror = () => setIsConnected(false)
-  }, [projectId, deploymentId])
+  }, [projectId, deploymentId, idParamName])
 
   const disconnect = useCallback(() => {
     ws.current?.close()

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -107,6 +107,7 @@ export type WSEventType =
   | 'snapshot_ready'
   | 'failover_progress'
   | 'failover_completed'
+  | 'failover_failed' 
   | 'error'
 
 export interface WSEvent {

--- a/frontend/types/mirror.ts
+++ b/frontend/types/mirror.ts
@@ -84,3 +84,17 @@ export interface FailoverResponse {
   gcp_region: string
   websocket_url: string
 }
+
+// destroy 관련 타입 추가
+export interface FailoverDestroyResponse {
+  failover_id: string
+  status:      'destroying'
+}
+
+export type FailoverStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'destroying'
+  | 'destroyed'
+  | 'destroy_failed'


### PR DESCRIPTION
config.py 확인 — backend_api_url 필드
failover_history.py — status 컬럼 확장
mirror.py — _run_failover_actual + _import_snapshot_to_cloud_sql 구현
mirror.py — GCP 리소스 삭제 엔드포인트 추가
types/mirror.ts — destroy 관련 타입 추가
failover/page.tsx — GCP 리소스 삭제 버튼 추가
Cloud Run 이미지 경로 오류 수정
GCP Terraform HCL 저장 (Cloud Run image → 실제 GCR URI 패치)
mapper.py — subnet, router network 참조 수정
mapper.py — Cloud Run memory 유효성 검사 추가
failover/page.tsx — failover_failed 핸들러 추가
types/index.ts — failover_failed 타입 추가
backend/requirements.txt에 'pandas', 'google-api-python-client' 추가
mirror.py — failover 상태 조회 엔드포인트 추가
failover/page.tsx — handleDestroyGcp 폴링 + 버튼 명칭 수정