### PR TITLE
fest(epic9): GCP 계정 연동 기능 구현 및 DB 마이그레이션

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,4 +35,4 @@ RUN pip install checkov
 
 COPY . .
 EXPOSE 8000
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"]

--- a/backend/alembic/versions/d9856a9e87c4_add_gcp_connect_columns_to_projects.py
+++ b/backend/alembic/versions/d9856a9e87c4_add_gcp_connect_columns_to_projects.py
@@ -1,0 +1,32 @@
+"""add_gcp_connect_columns_to_projects
+
+Revision ID: d9856a9e87c4
+Revises: d69c0a036a7b
+Create Date: 2026-05-28 15:22:22.495891
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd9856a9e87c4'
+down_revision: Union[str, None] = 'd69c0a036a7b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('projects', sa.Column('gcp_project_id',   sa.String(length=100), nullable=True))
+    op.add_column('projects', sa.Column('gcp_secret_arn',   sa.String(length=500), nullable=True))
+    op.add_column('projects', sa.Column('gcp_sa_email',     sa.String(length=200), nullable=True))
+    op.add_column('projects', sa.Column('gcp_connected_at', sa.DateTime(),          nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('projects', 'gcp_connected_at')
+    op.drop_column('projects', 'gcp_sa_email')
+    op.drop_column('projects', 'gcp_secret_arn')
+    op.drop_column('projects', 'gcp_project_id')

--- a/backend/app/api/gcp_connect.py
+++ b/backend/app/api/gcp_connect.py
@@ -1,0 +1,268 @@
+# backend/app/api/gcp_connect.py
+
+import boto3
+import json
+import os
+import subprocess
+import tempfile
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from app.core.auth import get_current_user
+from app.core.database import get_db
+from app.models.project import Project
+from app.models.user import User
+
+router = APIRouter()
+
+
+class GCPConnectRequest(BaseModel):
+    gcp_project_id: str
+    service_account_key: dict
+
+
+@router.post("/{project_id}/gcp/connect")
+def connect_gcp(
+    project_id: str,
+    body: GCPConnectRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    GCP 서비스 계정 JSON 키를 업로드하여 AutoOps에 연동한다.
+
+    흐름:
+    1. 서비스 계정 JSON 키 유효성 검증 (실제 GCP API 호출)
+    2. Artifact Registry autoops-repo 자동 생성 (없으면 생성, 있으면 스킵)
+    3. AWS Secrets Manager 저장
+    4. projects 테이블 업데이트
+    """
+    project = db.query(Project).filter(
+        Project.project_id == project_id,
+        Project.user_id    == current_user.user_id,
+    ).first()
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "NOT_FOUND", "message": "프로젝트를 찾을 수 없습니다."},
+        )
+
+    key_dict = body.service_account_key
+
+    # ① 키 유효성 검증
+    sa_email = _validate_gcp_credentials(key_dict, body.gcp_project_id)
+
+    # ② Artifact Registry 자동 생성
+    _ensure_artifact_registry(key_dict, body.gcp_project_id)
+
+    # ③ Secrets Manager 저장
+    secret_arn = _store_gcp_secret(project_id, key_dict)
+
+    # ④ DB 업데이트
+    project.gcp_project_id   = body.gcp_project_id
+    project.gcp_secret_arn   = secret_arn
+    project.gcp_sa_email     = sa_email
+    project.gcp_connected_at = datetime.utcnow()
+    db.commit()
+
+    return {
+        "success": True,
+        "data": {
+            "gcp_project_id": body.gcp_project_id,
+            "sa_email":       sa_email,
+            "connected_at":   project.gcp_connected_at.isoformat(),
+        },
+    }
+
+
+@router.get("/{project_id}/gcp/status")
+def get_gcp_status(
+    project_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """GCP 연동 상태를 반환한다."""
+    project = db.query(Project).filter(
+        Project.project_id == project_id,
+        Project.user_id    == current_user.user_id,
+    ).first()
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "NOT_FOUND", "message": "프로젝트를 찾을 수 없습니다."},
+        )
+
+    return {
+        "success": True,
+        "data": {
+            "is_connected":   bool(project.gcp_connected_at),
+            "gcp_project_id": project.gcp_project_id,
+            "sa_email":       project.gcp_sa_email,
+            "connected_at":   (
+                project.gcp_connected_at.isoformat()
+                if project.gcp_connected_at else None
+            ),
+        },
+    }
+
+
+@router.delete("/{project_id}/gcp/disconnect")
+def disconnect_gcp(
+    project_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """GCP 연동을 해제한다. Secrets Manager 시크릿도 삭제한다."""
+    project = db.query(Project).filter(
+        Project.project_id == project_id,
+        Project.user_id    == current_user.user_id,
+    ).first()
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "NOT_FOUND", "message": "프로젝트를 찾을 수 없습니다."},
+        )
+
+    # Secrets Manager 시크릿 삭제
+    if project.gcp_secret_arn:
+        try:
+            sm = boto3.client("secretsmanager", region_name="us-west-2")
+            sm.delete_secret(
+                SecretId=project.gcp_secret_arn,
+                ForceDeleteWithoutRecovery=True,
+            )
+        except Exception as e:
+            print(f"[GCP Disconnect] Secrets Manager 삭제 실패 (무시):{e}")
+
+    # DB 초기화
+    project.gcp_project_id   = None
+    project.gcp_secret_arn   = None
+    project.gcp_sa_email     = None
+    project.gcp_connected_at = None
+    db.commit()
+
+    return {"success": True, "message": "GCP 연동이 해제되었습니다."}
+
+
+# ── 내부 함수 ────────────────────────────────────────────────────────
+
+def _validate_gcp_credentials(key_dict: dict, gcp_project_id: str) -> str:
+    """
+    서비스 계정 JSON 키로 gcloud auth를 실행하여 유효성을 검증한다.
+    성공 시 서비스 계정 이메일을 반환한다.
+    """
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(key_dict, f)
+        key_path = f.name
+
+    try:
+        # gcloud auth 실행
+        result = subprocess.run(
+            [
+                "gcloud", "auth", "activate-service-account",
+                "--key-file", key_path,
+                "--project", gcp_project_id,
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code":    "GCP_AUTH_ERROR",
+                    "message": f"GCP 인증 실패:{result.stderr.strip()}",
+                },
+            )
+
+        # 프로젝트 접근 권한 확인
+        check = subprocess.run(
+            ["gcloud", "projects", "describe", gcp_project_id],
+            capture_output=True, text=True, timeout=30,
+        )
+        if check.returncode != 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code":    "GCP_AUTH_ERROR",
+                    "message": "GCP 프로젝트 접근 권한 없음. 서비스 계정 권한을 확인하세요.",
+                },
+            )
+
+        return key_dict.get("client_email", "")
+
+    finally:
+        os.unlink(key_path)
+
+
+def _ensure_artifact_registry(key_dict: dict, gcp_project_id: str) -> None:
+    """
+    autoops-repo Artifact Registry가 없으면 자동 생성한다.
+    이미 있으면 스킵한다.
+    """
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(key_dict, f)
+        key_path = f.name
+
+    try:
+        subprocess.run(
+            [
+                "gcloud", "auth", "activate-service-account",
+                "--key-file", key_path,
+                "--project", gcp_project_id,
+            ],
+            check=True, capture_output=True,
+        )
+
+        # 존재 여부 확인
+        check = subprocess.run(
+            [
+                "gcloud", "artifacts", "repositories", "describe", "autoops-repo",
+                "--location=us-west1",
+                f"--project={gcp_project_id}",
+            ],
+            capture_output=True, text=True,
+        )
+
+        if check.returncode != 0:
+            # 없으면 생성
+            subprocess.run(
+                [
+                    "gcloud", "artifacts", "repositories", "create", "autoops-repo",
+                    "--repository-format=docker",
+                    "--location=us-west1",
+                    f"--project={gcp_project_id}",
+                    "--description=AutoOps DR container registry",
+                ],
+                check=True, capture_output=True,
+            )
+            print(f"[GCP Connect] Artifact Registry 생성 완료:{gcp_project_id}")
+        else:
+            print(f"[GCP Connect] Artifact Registry 이미 존재:{gcp_project_id}")
+
+    finally:
+        os.unlink(key_path)
+
+
+def _store_gcp_secret(project_id: str, key_dict: dict) -> str:
+    """
+    AWS Secrets Manager에 프로젝트별 GCP SA 키를 저장한다.
+    이미 존재하면 값을 업데이트하고, 없으면 새로 생성한다.
+    반환: 시크릿 ARN
+    """
+    sm          = boto3.client("secretsmanager", region_name="us-west-2")
+    secret_name = f"autoops/gcp/{project_id}/service-account"
+
+    try:
+        resp = sm.put_secret_value(
+            SecretId     = secret_name,
+            SecretString = json.dumps(key_dict),
+        )
+        return resp["ARN"]
+    except sm.exceptions.ResourceNotFoundException:
+        resp = sm.create_secret(
+            Name         = secret_name,
+            SecretString = json.dumps(key_dict),
+            Tags         = [{"Key": "autoops", "Value": "gcp-sa"}],
+        )
+        return resp["ARN"]

--- a/backend/app/api/mirror.py
+++ b/backend/app/api/mirror.py
@@ -125,6 +125,15 @@ def manual_sync(
                 "message": "인프라 배포가 완료된 프로젝트만 동기화할 수 있습니다."
             }
         )
+    # GCP 연동 확인
+    if not project.gcp_project_id:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code":    "GCP_NOT_CONNECTED",
+                "message": "GCP 계정을 먼저 연동해야 합니다. 프로젝트 설정에서 GCP 연동을 진행해주세요.",
+            },
+        )
     
     from app.services.mirrorops.pipeline import MirrorOpsPipelineService
     pipeline = MirrorOpsPipelineService()
@@ -281,6 +290,16 @@ def failover(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"code": "VALIDATION_ERROR", "message": "mode는 simulation 또는 actual이어야 합니다."},
+        )
+    
+    # GCP 연동 확인 (simulation/actual 모두 차단)
+    if not project.gcp_secret_arn:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code":    "GCP_NOT_CONNECTED",
+                "message": "GCP 계정을 먼저 연동해야 합니다. 프로젝트 설정에서 GCP 연동을 진행해주세요.",
+            },
         )
 
     latest_package = None
@@ -517,10 +536,13 @@ async def _run_failover_actual(
         s3.download_file("autoops-dr-packages", tf_key, str(Path(work_dir) / "main.tf"))
         _log("main.tf 다운로드 완료")
 
+        # gcp_project_id 결정 — 연동된 프로젝트 우선
+        gcp_project_id = project.gcp_project_id or settings.gcp_project_id
+
         # ② GCP 인증
         _log("GCP 인증 설정 중...")
-        setup_gcp_auth()
-        _log(f"GCP 인증 완료 (프로젝트: {settings.gcp_project_id})")
+        setup_gcp_auth(project=project)
+        _log(f"GCP 인증 완료 (프로젝트: {gcp_project_id})")
 
         # ③ GCS State 버킷 생성
         bucket_name = f"autoops-dr-state-{project_id}"
@@ -594,7 +616,7 @@ async def _run_failover_actual(
             project_id  = project_id,
             package     = package,
             bucket_name = bucket_name,
-            gcp_project = settings.gcp_project_id,
+            gcp_project = gcp_project_id,
             log_fn      = _log,
         )
         _log("✅ Cloud SQL 데이터 복원 완료")
@@ -884,6 +906,11 @@ async def _run_failover_destroy(
 
     db       = SessionLocal()
     work_dir = None
+    # project 조회 (gcp_secret_arn 사용을 위해)
+    from app.models.project import Project as ProjectModel
+    project = db.query(ProjectModel).filter(
+        ProjectModel.project_id == project_id
+    ).first()
     cw       = boto3.client("logs", region_name="us-west-2")
     log_group = f"/autoops/failover/{failover_id}"
 
@@ -924,7 +951,7 @@ async def _run_failover_destroy(
 
         # ② GCP 인증
         _log("GCP 인증 설정 중...")
-        setup_gcp_auth()
+        setup_gcp_auth(project=project)
         _log("GCP 인증 완료")
 
         env = {**os.environ, "TF_IN_AUTOMATION": "1"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.api import auth, accounts, projects, craft, mirror, websocket
+from app.api.gcp_connect import router as gcp_connect_router
 from app.services.mirrorops.sqs_worker import start_sqs_worker
 from app.services.governance.drift_worker import start_drift_worker
 from app.core.config import settings
@@ -84,6 +85,7 @@ app.include_router(mirror.router, prefix="/api/mirror", tags=["mirrorops"])
 app.include_router(websocket.router, tags=["websocket"])
 app.include_router(onboarding_router)
 app.include_router(drift_router)
+app.include_router(gcp_connect_router, prefix="/api/projects", tags=["gcp"])
 
 @app.get("/health", tags=["health"])
 def health_check():

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -22,6 +22,12 @@ class Project(Base):
     last_synced_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    
+    # GCP 연동 — 모두 nullable=True (미연동 프로젝트 대응)
+    gcp_project_id   = Column(String(100), nullable=True)
+    gcp_secret_arn   = Column(String(500), nullable=True)
+    gcp_sa_email     = Column(String(200), nullable=True)
+    gcp_connected_at = Column(DateTime,    nullable=True)
     source = Column(String(20), nullable=False, default="craftops_deploy")  # craftops_deploy | onboarding
 
     # Relationships

--- a/backend/app/services/mirrorops/gcp_hcl_generator.py
+++ b/backend/app/services/mirrorops/gcp_hcl_generator.py
@@ -16,9 +16,10 @@ class GCPHCLGenerator:
 
     def generate(
         self,
-        project_id: str,
-        mappings: list[GCPMapping],
+        project_id:  str,
+        mappings:    list[GCPMapping],
         gcp_project: str,
+        gcp_region:  str = "us-west1",   # 현재 us-west1 단일 지원. 향후 사용자 선택 예정
     ) -> tuple[str, str]:
         """
         GCP Terraform HCL 전체를 생성하고 임시 디렉토리에 저장한다.
@@ -39,7 +40,7 @@ terraform{{
 }}
 provider "google"{{
   project = "{gcp_project}"
-  region  = "{settings.gcp_region}"
+  region  = "{gcp_region}"
 }}
 """
 

--- a/backend/app/services/mirrorops/pipeline.py
+++ b/backend/app/services/mirrorops/pipeline.py
@@ -29,9 +29,6 @@ class MirrorOpsPipelineService:
         파이프라인을 실행하고 sync_id를 반환한다.
         Phase 1이 완료되면 즉시 반환한다 (Phase 2는 비동기).
         """
-        # GCP 인증 설정 (§5-4)
-        setup_gcp_auth()
-
         # 프로젝트 및 AWS 계정 조회
         project = db.query(Project).filter(
             Project.project_id == project_id
@@ -40,13 +37,17 @@ class MirrorOpsPipelineService:
             AWSAccount.account_id == project.account_id
         ).first()
 
+        # GCP 인증 설정 — project별 SA 키 사용
+        gcp_project_id = project.gcp_project_id or settings.gcp_project_id
+        setup_gcp_auth(project=project)
+
         # sync_history 레코드 생성
         sync = SyncHistory(
-            project_id   = project_id,
-            trigger_type = trigger_type,
-            status       = "running",
+            project_id      = project_id,
+            trigger_type    = trigger_type,
+            status          = "running",
             snapshot_status = "pending",
-            started_at   = datetime.utcnow(),
+            started_at      = datetime.utcnow(),
         )
         db.add(sync)
         db.commit()
@@ -68,14 +69,14 @@ class MirrorOpsPipelineService:
                 AWSResourceModel.project_id == project_id
             ).delete()
             db.commit()
-            
+
             # ① 리소스 감지 (FR-B-003)
             assumed_session = boto3.Session(
                 region_name=project.region,
             )
             detector = ResourceDetector(
-                role_arn=account.role_arn,
-                region=project.region,
+                role_arn    = account.role_arn,
+                region      = project.region,
                 external_id = project.user_id,
             )
             aws_resources = detector.detect_all(
@@ -128,7 +129,8 @@ class MirrorOpsPipelineService:
                 hcl_code, work_dir = generator.generate(
                     project_id  = project_id,
                     mappings    = mappings,
-                    gcp_project = settings.gcp_project_id,
+                    gcp_project = gcp_project_id,
+                    gcp_region  = settings.gcp_region,
                 )
                 passed, error_msg = generator.validate(work_dir)
                 generator.cleanup(work_dir)
@@ -145,13 +147,13 @@ class MirrorOpsPipelineService:
                     environment = project.environment,
                     region      = project.region,
                     hcl_code    = hcl_code,
-                    gcp_project = settings.gcp_project_id,
+                    gcp_project = gcp_project_id,
                     db          = db,
                 )
             else:
                 # 변경 없음 → DR Package 재생성 스킵
                 print(f"[MirrorOps] 변경 없음 — DR Package 재생성 스킵 (project_id={project_id})")
-                
+
                 # [추가] 변경 없음: 최신 패키지가 ready면 dr_status 복원
                 latest_pkg = db.query(DRPackageModel).filter(
                     DRPackageModel.project_id == project_id,


### PR DESCRIPTION
- `projects` 테이블에 GCP 연동을 위한 컬럼 4개(gcp_project_id 등) 추가 및 마이그레이션 적용
- GCP 계정 연동, 상태 조회, 해제 API 구현 (gcp_connect.py)
- 프로젝트별 GCP 서비스 계정(SA) 인증 로직 분리 (gcp_auth.py)
- GCP 미연동 상태일 경우 MirrorOps Sync 및 Failover 요청 차단 방어 로직 추가
- FastAPI 라우터 등록 및 ECR 빌드/ECS 배포 완료