### PR TITLE
Feature/epic9 dashboard governance

### DIFF
--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -1,0 +1,79 @@
+# backend/app/api/audit.py
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+from app.core.database import get_db
+from app.core.auth import get_current_user
+from app.models.user import User
+from app.models.governance import AuditLog
+
+router = APIRouter(tags=["audit"])
+
+
+@router.get("/api/projects/{project_id}/audit-logs")
+def list_project_audit_logs(
+    project_id: str,
+    layer:  str = None,
+    limit:  int = Query(default=50, le=200),
+    offset: int = Query(default=0),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    query = db.query(AuditLog).filter(AuditLog.project_id == project_id)
+    if layer:
+        query = query.filter(AuditLog.layer == layer)
+
+    total = query.count()
+    logs  = query.order_by(AuditLog.created_at.desc()).offset(offset).limit(limit).all()
+
+    return {
+        "success": True,
+        "data": {
+            "total": total,
+            "items": [
+                {
+                    "id":         log.id,
+                    "layer":      log.layer,
+                    "action":     log.action,
+                    "actor":      log.actor,
+                    "detail":     log.detail,
+                    "created_at": log.created_at.isoformat() if log.created_at else None,
+                }
+                for log in logs
+            ],
+        },
+    }
+
+
+@router.get("/api/audit-logs")
+def list_all_audit_logs(
+    layer:  str = None,
+    limit:  int = Query(default=100, le=500),
+    offset: int = Query(default=0),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    query = db.query(AuditLog)
+    if layer:
+        query = query.filter(AuditLog.layer == layer)
+
+    total = query.count()
+    logs  = query.order_by(AuditLog.created_at.desc()).offset(offset).limit(limit).all()
+
+    return {
+        "success": True,
+        "data": {
+            "total": total,
+            "items": [
+                {
+                    "id":         log.id,
+                    "project_id": log.project_id,
+                    "layer":      log.layer,
+                    "action":     log.action,
+                    "actor":      log.actor,
+                    "detail":     log.detail,
+                    "created_at": log.created_at.isoformat() if log.created_at else None,
+                }
+                for log in logs
+            ],
+        },
+    }

--- a/backend/app/api/craft.py
+++ b/backend/app/api/craft.py
@@ -1,6 +1,6 @@
 # backend/app/api/craft.py
 import uuid
-from fastapi import APIRouter, Depends, HTTPException, status, Header
+from fastapi import APIRouter, Depends, HTTPException, status, Header, BackgroundTasks
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
@@ -17,6 +17,7 @@ from app.services.craftops.validator import ValidationLoop
 from app.services.craftops.runner import TerraformRunnerService, upload_hcl_to_s3, EventBridgePublisher
 from app.models.aws_account import AWSAccount
 from datetime import datetime
+from app.services.governance.audit_logger import log_platform_action
 
 router = APIRouter()
 
@@ -511,6 +512,7 @@ class DeployCompleteCallback(BaseModel):
 def deployment_complete_callback(
     deployment_id: str,
     body: DeployCompleteCallback,
+    background_tasks: BackgroundTasks,
     x_internal_secret: str = Header(None),
     db: Session = Depends(get_db),
 ):
@@ -540,6 +542,26 @@ def deployment_complete_callback(
         project.status           = "completed"
         project.last_deployed_at = datetime.utcnow()
         db.commit()
+
+        from app.services.governance.audit_logger import log_platform_action
+        log_platform_action(
+            db         = db,
+            action     = "craftops_deploy",
+            user_id    = project.user_id,
+            project_id = project.project_id,
+            detail     = {
+                "deployment_id":     deployment_id,
+                "completed_resources": body.completed_resources,
+            },
+        )
+        db.commit()
+
+        from app.api.diagram import _generate_diagram_task
+        background_tasks.add_task(
+            _generate_diagram_task,
+            project_id = body.project_id,
+            source     = "craftops_deploy",
+        )
 
         # §7-8 EventBridge 발행
         account = db.query(AWSAccount).filter(
@@ -573,6 +595,16 @@ def deployment_complete_callback(
             print(f"[경고] EventBridge 발행 실패: {e}")
 
     elif body.status == "destroyed" and project:
+
+        from app.services.governance.audit_logger import log_platform_action
+        log_platform_action(
+            db         = db,
+            action     = "craftops_destroy",
+            user_id    = project.user_id,
+            project_id = project.project_id,
+            detail     = {"deployment_id": deployment_id},
+        )
+        db.commit()
         # destroy 완료 →
         # delete_project_records로 DB 전체 삭제 (AWS 리소스 삭제 체크 후 삭제 요청한 경우)
         # projects.py의 _delete_project_records 재사용

--- a/backend/app/api/craft.py
+++ b/backend/app/api/craft.py
@@ -594,6 +594,17 @@ def deployment_complete_callback(
         except Exception as e:
             print(f"[경고] EventBridge 발행 실패: {e}")
 
+        if account:
+            background_tasks.add_task(
+                _run_detect_all,
+                project_id  = project.project_id,
+                role_arn    = account.role_arn,
+                external_id = project.user_id,
+                prefix      = project.prefix,
+                environment = project.environment,
+                region      = project.region,
+            )
+
     elif body.status == "destroyed" and project:
 
         from app.services.governance.audit_logger import log_platform_action
@@ -881,3 +892,32 @@ def _deployment_to_dict(deployment: Deployment) -> dict:
         "started_at":          deployment.started_at.isoformat(),
         "completed_at":        deployment.completed_at.isoformat() if deployment.completed_at else None,
     }
+
+def _run_detect_all(project_id: str, role_arn: str, external_id: str, prefix: str, environment: str, region: str):
+    from app.core.database import SessionLocal
+    from app.services.mirrorops.detector import ResourceDetector
+    from app.models.aws_resource import AWSResource
+    from app.models.project import Project
+    db = SessionLocal()
+    try:
+        # GCP 연동 프로젝트는 pipeline.run()에서 처리하므로 스킵
+        project = db.query(Project).filter(
+            Project.project_id == project_id
+        ).first()
+        if project and project.gcp_project_id:
+            print(f"[CraftOps] GCP 연동 프로젝트 — detect_all 스킵 (pipeline에서 처리)")
+            return
+
+        # 기존 리소스 삭제 후 재저장 (중복 방지)
+        db.query(AWSResource).filter(
+            AWSResource.project_id == project_id
+        ).delete(synchronize_session=False)
+        db.commit()
+
+        detector = ResourceDetector(role_arn=role_arn, region=region, external_id=external_id)
+        detector.detect_all(project_id=project_id, prefix=prefix, environment=environment, db=db)
+        print(f"[CraftOps] 리소스 감지 완료: project_id={project_id}")
+    except Exception as e:
+        print(f"[CraftOps] 리소스 감지 실패: {e}")
+    finally:
+        db.close()

--- a/backend/app/api/diagram.py
+++ b/backend/app/api/diagram.py
@@ -1,0 +1,127 @@
+# backend/app/api/diagram.py
+import uuid
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
+from sqlalchemy.orm import Session
+from app.core.database import get_db
+from app.core.auth import get_current_user
+from app.models.user import User
+from app.models.project import Project
+from app.models.governance import ProjectDocument, OnboardingScan
+from app.models.deployment import DeploymentResource
+
+router = APIRouter(tags=["diagram"])
+
+
+@router.get("/api/projects/{project_id}/documents")
+def get_project_documents(
+    project_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _get_project_or_404(project_id, current_user.user_id, db)
+
+    doc = db.query(ProjectDocument).filter(
+        ProjectDocument.project_id == project_id
+    ).order_by(ProjectDocument.generated_at.desc()).first()
+
+    if not doc:
+        return {"success": True, "data": None}
+
+    return {
+        "success": True,
+        "data": {
+            "id":           doc.id,
+            "source":       doc.source,
+            "mermaid_code": doc.mermaid_code,
+            "description":  doc.description,
+            "generated_at": doc.generated_at.isoformat() if doc.generated_at else None,
+        },
+    }
+
+
+@router.post("/api/projects/{project_id}/documents/regenerate")
+def regenerate_diagram(
+    project_id: str,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    project = _get_project_or_404(project_id, current_user.user_id, db)
+    background_tasks.add_task(
+        _generate_diagram_task,
+        project_id = project_id,
+        source     = project.source,
+    )
+    return {"success": True, "data": {"message": "다이어그램 생성 시작됨"}}
+
+
+def _generate_diagram_task(project_id: str, source: str):
+    from app.core.database import SessionLocal
+    from app.services.mirrorops.bedrock_client import BedrockMapper
+
+    db = SessionLocal()
+    try:
+        resources = []
+
+        if source == "craftops_deploy":
+            from app.models.deployment import Deployment
+            deployment = db.query(Deployment).filter(
+                Deployment.project_id == project_id,
+                Deployment.status     == "completed",
+            ).order_by(Deployment.completed_at.desc()).first()
+
+            if deployment:
+                dep_resources = db.query(DeploymentResource).filter(
+                    DeploymentResource.deployment_id == deployment.deployment_id
+                ).all()
+                resources = [
+                    {
+                        "resource_type": r.resource_type,
+                        "resource_name": r.resource_name,
+                        "resource_id":   r.resource_arn or r.resource_id,
+                    }
+                    for r in dep_resources
+                ]
+        else:
+            scan = db.query(OnboardingScan).filter(
+                OnboardingScan.project_id == project_id,
+                OnboardingScan.status     == "completed",
+            ).order_by(OnboardingScan.confirmed_at.desc()).first()
+
+            if scan and scan.scan_result:
+                for group_data in scan.scan_result.values():
+                    resources.extend(group_data.get("resources", []))
+
+        if not resources:
+            return
+
+        client = BedrockMapper()
+        result = client.generate_architecture_diagram(resources)
+
+        doc = ProjectDocument(
+            id           = str(uuid.uuid4()),
+            project_id   = project_id,
+            source       = source,
+            mermaid_code = result.get("mermaid_code", ""),
+            description  = result.get("description", ""),
+            generated_at = datetime.utcnow(),
+        )
+        db.add(doc)
+        db.commit()
+        print(f"[Diagram] 생성 완료: project_id={project_id}")
+
+    except Exception as e:
+        print(f"[Diagram] 생성 실패: {e}")
+    finally:
+        db.close()
+
+
+def _get_project_or_404(project_id: str, user_id: str, db: Session) -> Project:
+    project = db.query(Project).filter(
+        Project.project_id == project_id,
+        Project.user_id    == user_id,
+    ).first()
+    if not project:
+        raise HTTPException(status_code=404, detail={"code": "NOT_FOUND"})
+    return project

--- a/backend/app/api/diagram.py
+++ b/backend/app/api/diagram.py
@@ -8,7 +8,6 @@ from app.core.auth import get_current_user
 from app.models.user import User
 from app.models.project import Project
 from app.models.governance import ProjectDocument, OnboardingScan
-from app.models.deployment import DeploymentResource
 
 router = APIRouter(tags=["diagram"])
 
@@ -48,10 +47,11 @@ def regenerate_diagram(
     current_user: User = Depends(get_current_user),
 ):
     project = _get_project_or_404(project_id, current_user.user_id, db)
+    source = project.source or "craftops_deploy"  # 수정
     background_tasks.add_task(
         _generate_diagram_task,
         project_id = project_id,
-        source     = project.source,
+        source     = source,  # 수정
     )
     return {"success": True, "data": {"message": "다이어그램 생성 시작됨"}}
 
@@ -65,24 +65,18 @@ def _generate_diagram_task(project_id: str, source: str):
         resources = []
 
         if source == "craftops_deploy":
-            from app.models.deployment import Deployment
-            deployment = db.query(Deployment).filter(
-                Deployment.project_id == project_id,
-                Deployment.status     == "completed",
-            ).order_by(Deployment.completed_at.desc()).first()
-
-            if deployment:
-                dep_resources = db.query(DeploymentResource).filter(
-                    DeploymentResource.deployment_id == deployment.deployment_id
-                ).all()
-                resources = [
-                    {
-                        "resource_type": r.resource_type,
-                        "resource_name": r.resource_name,
-                        "resource_id":   r.resource_arn or r.resource_id,
-                    }
-                    for r in dep_resources
-                ]
+            from app.models.aws_resource import AWSResource
+            aws_res = db.query(AWSResource).filter(
+                AWSResource.project_id == project_id,
+            ).all()
+            resources = [
+                {
+                    "resource_type": r.resource_type,
+                    "resource_name": r.resource_name,
+                    "resource_id":   r.resource_id_aws,
+                }
+                for r in aws_res
+            ]
         else:
             scan = db.query(OnboardingScan).filter(
                 OnboardingScan.project_id == project_id,

--- a/backend/app/api/metrics.py
+++ b/backend/app/api/metrics.py
@@ -1,0 +1,355 @@
+# backend/app/api/metrics.py
+
+import os
+import boto3
+from datetime import datetime, timezone, timedelta
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.auth import get_current_user
+from app.models.project import Project
+from app.models.aws_account import AWSAccount
+from app.models.aws_resource import AWSResource
+
+router = APIRouter()
+
+# ─── 기간별 설정 ─────────────────────────────────────────────────────────────
+PERIOD_CONFIG = {
+    "1h":  {"stat_period": 60,   "lookback_seconds": 3600},
+    "6h":  {"stat_period": 300,  "lookback_seconds": 21600},
+    "24h": {"stat_period": 900,  "lookback_seconds": 86400},
+    "7d":  {"stat_period": 3600, "lookback_seconds": 604800},
+}
+
+
+def _get_cloudwatch_client(role_arn: str, region: str):
+    skip = os.getenv("SKIP_ASSUME_ROLE", "false").lower() == "true"
+    try:
+        sts_client = boto3.client("sts")
+        current_account = sts_client.get_caller_identity()["Account"]
+        target_account = role_arn.split(":")[4]
+        if skip or current_account == target_account:
+            return boto3.client("cloudwatch", region_name=region)
+    except Exception:
+        pass
+    sts = boto3.client("sts")
+    assumed = sts.assume_role(
+        RoleArn=role_arn,
+        RoleSessionName="autoops-metrics-session",
+        DurationSeconds=900,
+    )
+    creds = assumed["Credentials"]
+    return boto3.client(
+        "cloudwatch",
+        region_name=region,
+        aws_access_key_id=creds["AccessKeyId"],
+        aws_secret_access_key=creds["SecretAccessKey"],
+        aws_session_token=creds["SessionToken"],
+    )
+
+
+def _extract_alb_dimension(alb_arn: str) -> str:
+    if not alb_arn:
+        return ""
+    parts = alb_arn.split(":loadbalancer/")
+    return parts[1] if len(parts) == 2 else ""
+
+
+def _build_metric_queries(resources: dict, stat_period: int) -> list:
+    queries = []
+
+    # ── ECS ──────────────────────────────────────────────────────────────────
+    if resources.get("ecs_cluster") and resources.get("ecs_service"):
+        ecs_dims = [
+            {"Name": "ClusterName", "Value": resources["ecs_cluster"]},
+            {"Name": "ServiceName", "Value": resources["ecs_service"]},
+        ]
+        queries += [
+            {
+                "Id": "ecs_cpu",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ECS",
+                        "MetricName": "CPUUtilization",
+                        "Dimensions": ecs_dims,
+                    },
+                    "Period": stat_period,
+                    "Stat": "Average",
+                },
+                "ReturnData": True,
+            },
+            {
+                "Id": "ecs_memory",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ECS",
+                        "MetricName": "MemoryUtilization",
+                        "Dimensions": ecs_dims,
+                    },
+                    "Period": stat_period,
+                    "Stat": "Average",
+                },
+                "ReturnData": True,
+            },
+        ]
+
+    # ── ALB ──────────────────────────────────────────────────────────────────
+    if resources.get("alb_dimension"):
+        alb_dims = [{"Name": "LoadBalancer", "Value": resources["alb_dimension"]}]
+        queries += [
+            {
+                "Id": "alb_requests",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ApplicationELB",
+                        "MetricName": "RequestCount",
+                        "Dimensions": alb_dims,
+                    },
+                    "Period": stat_period,
+                    "Stat": "Sum",
+                },
+                "ReturnData": True,
+            },
+            {
+                "Id": "alb_response_time",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ApplicationELB",
+                        "MetricName": "TargetResponseTime",
+                        "Dimensions": alb_dims,
+                    },
+                    "Period": stat_period,
+                    "Stat": "Average",
+                },
+                "ReturnData": True,
+            },
+            {
+                "Id": "alb_5xx",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ApplicationELB",
+                        "MetricName": "HTTPCode_Target_5XX_Count",
+                        "Dimensions": alb_dims,
+                    },
+                    "Period": stat_period,
+                    "Stat": "Sum",
+                },
+                "ReturnData": True,
+            },
+        ]
+
+    # ── RDS ──────────────────────────────────────────────────────────────────
+    if resources.get("rds_identifier"):
+        rds_dims = [{"Name": "DBInstanceIdentifier", "Value": resources["rds_identifier"]}]
+        queries += [
+            {
+                "Id": "rds_cpu",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/RDS",
+                        "MetricName": "CPUUtilization",
+                        "Dimensions": rds_dims,
+                    },
+                    "Period": stat_period,
+                    "Stat": "Average",
+                },
+                "ReturnData": True,
+            },
+            {
+                "Id": "rds_connections",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/RDS",
+                        "MetricName": "DatabaseConnections",
+                        "Dimensions": rds_dims,
+                    },
+                    "Period": stat_period,
+                    "Stat": "Average",
+                },
+                "ReturnData": True,
+            },
+            {
+                "Id": "rds_storage",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/RDS",
+                        "MetricName": "FreeStorageSpace",
+                        "Dimensions": rds_dims,
+                    },
+                    "Period": stat_period,
+                    "Stat": "Average",
+                },
+                "ReturnData": True,
+            },
+        ]
+
+    return queries
+
+
+def _parse_metric_result(results: list, metric_id: str) -> list:
+    for r in results:
+        if r["Id"] == metric_id:
+            pairs = sorted(
+                zip(r.get("Timestamps", []), r.get("Values", [])),
+                key=lambda x: x[0],
+            )
+            return [
+                {
+                    "timestamp": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "value": round(v, 4),
+                }
+                for ts, v in pairs
+            ]
+    return []
+
+
+@router.get("/projects/{project_id}/metrics")
+async def get_project_metrics(
+    project_id: str,
+    period: Literal["1h", "6h", "24h", "7d"] = "1h",
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    # ── 1. 프로젝트 조회 ──────────────────────────────────────────────────────
+    project = db.query(Project).filter(
+        Project.project_id == project_id,
+        Project.user_id == current_user.user_id,
+    ).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="프로젝트를 찾을 수 없습니다.")
+    if project.status != "completed":
+        raise HTTPException(status_code=400, detail="배포 완료된 프로젝트만 모니터링 가능합니다.")
+
+    # ── 2. AWS 계정 → role_arn 조회 ───────────────────────────────────────────
+    aws_account = db.query(AWSAccount).filter(
+        AWSAccount.account_id == project.account_id
+    ).first()
+    if not aws_account:
+        raise HTTPException(status_code=404, detail="연동된 AWS 계정을 찾을 수 없습니다.")
+
+    # ── 3. aws_resources 테이블에서 리소스 조회 ───────────────────────────────
+    aws_res_list = db.query(AWSResource).filter(
+        AWSResource.project_id == project_id,
+    ).all()
+
+    if not aws_res_list:
+        return {
+            "project_id": project_id,
+            "period": period,
+            "region": project.region,
+            "resources": {},
+            "metrics": {},
+            "message": "모니터링 가능한 리소스가 없습니다.",
+        }
+
+    def find_res(keywords: list):
+        for r in aws_res_list:
+            rt = r.resource_type.lower()
+            if all(k in rt for k in keywords):
+                return r
+        return None
+
+    ecs_cluster_res = find_res(["ecs", "cluster"])
+    ecs_service_res = find_res(["ecs", "service"])
+    alb_res         = find_res(["loadbalancer"]) or find_res(["elasticloadbalancing"])
+    rds_res = find_res(["rds", "dbinstance"]) or find_res(["rds::dbinstance"])
+
+    # ── 4. 리소스 식별자 정리 ─────────────────────────────────────────────────
+    ecs_cluster_name = ecs_cluster_res.resource_name if ecs_cluster_res else None
+    ecs_service_name = ecs_service_res.resource_name if ecs_service_res else None
+    alb_arn          = alb_res.resource_id_aws        if alb_res         else None
+    rds_identifier   = rds_res.resource_name          if rds_res         else None
+    alb_dimension    = _extract_alb_dimension(alb_arn) if alb_arn        else None
+
+    cw_resources = {
+        "ecs_cluster":    ecs_cluster_name,
+        "ecs_service":    ecs_service_name,
+        "alb_dimension":  alb_dimension,
+        "rds_identifier": rds_identifier,
+    }
+
+    if not any([ecs_cluster_name, ecs_service_name, alb_dimension, rds_identifier]):
+        return {
+            "project_id": project_id,
+            "period": period,
+            "region": project.region,
+            "resources": {},
+            "metrics": {},
+            "message": "모니터링 가능한 리소스가 없습니다.",
+        }
+
+    # ── 5. 기간 설정 ──────────────────────────────────────────────────────────
+    cfg = PERIOD_CONFIG[period]
+    now = datetime.now(timezone.utc)
+    start_time = now - timedelta(seconds=cfg["lookback_seconds"])
+
+    # ── 6. CloudWatch 배치 호출 ───────────────────────────────────────────────
+    try:
+        cw = _get_cloudwatch_client(aws_account.role_arn, project.region)
+        queries = _build_metric_queries(cw_resources, cfg["stat_period"])
+
+        if not queries:
+            return {
+                "project_id": project_id,
+                "period": period,
+                "region": project.region,
+                "resources": cw_resources,
+                "metrics": {},
+            }
+
+        response = cw.get_metric_data(
+            MetricDataQueries=queries,
+            StartTime=start_time,
+            EndTime=now,
+        )
+        results = response.get("MetricDataResults", [])
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"CloudWatch 조회 실패: {str(e)}",
+        )
+
+    # ── 7. 응답 구성 ──────────────────────────────────────────────────────────
+    metrics = {}
+
+    if ecs_cluster_name and ecs_service_name:
+        metrics["ecs"] = {
+            "cpu":    _parse_metric_result(results, "ecs_cpu"),
+            "memory": _parse_metric_result(results, "ecs_memory"),
+        }
+
+    if alb_dimension:
+        metrics["alb"] = {
+            "request_count":  _parse_metric_result(results, "alb_requests"),
+            "response_time":  _parse_metric_result(results, "alb_response_time"),
+            "error_5xx":      _parse_metric_result(results, "alb_5xx"),
+        }
+
+    if rds_identifier:
+        rds_storage_raw = _parse_metric_result(results, "rds_storage")
+        rds_storage_gb = [
+            {"timestamp": p["timestamp"], "value": round(p["value"] / (1024**3), 2)}
+            for p in rds_storage_raw
+        ]
+        metrics["rds"] = {
+            "cpu":             _parse_metric_result(results, "rds_cpu"),
+            "connections":     _parse_metric_result(results, "rds_connections"),
+            "storage_free_gb": rds_storage_gb,
+        }
+
+    return {
+        "project_id": project_id,
+        "period": period,
+        "region": project.region,
+        "resources": {
+            "ecs_cluster": ecs_cluster_name,
+            "ecs_service": ecs_service_name,
+            "alb":         alb_dimension,
+            "rds":         rds_identifier,
+        },
+        "metrics": metrics,
+    }

--- a/backend/app/api/mirror.py
+++ b/backend/app/api/mirror.py
@@ -19,6 +19,7 @@ import tempfile
 import uuid
 from datetime import datetime
 from pathlib import Path
+from app.services.governance.audit_logger import log_platform_action
 
 router = APIRouter()
 
@@ -626,6 +627,25 @@ async def _run_failover_actual(
         rto_seconds = int((datetime.utcnow() - started_at).total_seconds())
         _log(f"실제 RTO: {rto_seconds // 60}분 {rto_seconds % 60}초")
         _update_status("completed", rto_seconds=rto_seconds, resources_created=resources_created)
+
+        from app.services.governance.audit_logger import log_platform_action
+        from app.core.database import SessionLocal
+        _audit_db = SessionLocal()
+        try:
+            log_platform_action(
+                db         = _audit_db,
+                action     = "failover_execute",
+                user_id    = project.user_id,
+                project_id = project_id,
+                detail     = {
+                    "failover_id": failover_id,
+                    "rto_seconds": rto_seconds,
+                    "mode":        "actual",
+                },
+            )
+            _audit_db.commit()
+        finally:
+            _audit_db.close()
 
     except Exception as e:
         err_msg = str(e)

--- a/backend/app/api/onboarding.py
+++ b/backend/app/api/onboarding.py
@@ -12,6 +12,7 @@ from app.models.user import User
 from app.models.project import Project
 from app.models.aws_account import AWSAccount
 from app.models.governance import OnboardingScan, ResourceBaseline
+from app.services.governance.audit_logger import log_platform_action
 
 router = APIRouter(prefix="/api/accounts", tags=["onboarding"])
 
@@ -142,6 +143,7 @@ def get_onboard_status(
 def confirm_onboard(
     account_id: str,
     body: dict,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -171,6 +173,23 @@ def confirm_onboard(
     scan.status       = "completed"
     scan.confirmed_at = datetime.utcnow()
     db.commit()
+
+    # Audit Log 기록 추가
+    log_platform_action(
+        db         = db,
+        action     = "onboarding_complete",
+        user_id    = current_user.user_id,
+        project_id = project_id,
+        detail     = {"baselines_created": baselines_created},
+    )
+    db.commit()
+
+    from app.api.diagram import _generate_diagram_task
+    background_tasks.add_task(
+        _generate_diagram_task,
+        project_id = project_id,
+        source     = "onboarding",
+    )
 
     return {
         "success": True,

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -9,6 +9,7 @@ from app.core.database import get_db
 from app.models.project import Project
 from app.models.aws_account import AWSAccount
 from app.models.user import User
+from app.services.governance.audit_logger import log_platform_action
 
 router = APIRouter()
 
@@ -195,6 +196,16 @@ def delete_project(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     detail={"code": "SPAWN_FAILED", "message": f"AWS 리소스 삭제 Task 실행에 실패했습니다: {str(e)}"},
                 )
+
+    from app.services.governance.audit_logger import log_platform_action
+    log_platform_action(
+        db         = db,
+        action     = "project_delete",
+        user_id    = current_user.user_id,
+        project_id = project_id,
+        detail     = {"destroy_aws_resources": request.destroy_aws_resources},
+    )
+    db.commit()
 
     # destroy_aws_resources 여부와 관계없이 DB + S3 즉시 삭제
     _delete_project_records(project_id, project, db)

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -104,6 +104,7 @@ def create_project(
         region=request.region,
         status="created",
         dr_status="not_ready",
+        source="craftops_deploy",
     )
     db.add(project)
     db.commit()

--- a/backend/app/api/resources.py
+++ b/backend/app/api/resources.py
@@ -1,0 +1,116 @@
+# backend/app/api/resources.py
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.core.database import get_db
+from app.core.auth import get_current_user
+from app.models.user import User
+from app.models.project import Project
+from app.models.aws_account import AWSAccount
+from app.models.governance import OnboardingScan, DriftEvent
+
+router = APIRouter(tags=["resources"])
+
+
+@router.get("/api/projects/{project_id}/resources")
+def get_project_resources(
+    project_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    프로젝트 리소스 그룹 + Drift 현황.
+    onboarding_scans.scan_result JSONB 활용.
+    """
+    project = db.query(Project).filter(
+        Project.project_id == project_id,
+        Project.user_id    == current_user.user_id,
+    ).first()
+    if not project:
+        raise HTTPException(status_code=404, detail={"code": "NOT_FOUND"})
+
+    scan = db.query(OnboardingScan).filter(
+        OnboardingScan.project_id == project_id,
+        OnboardingScan.status     == "completed",
+    ).order_by(OnboardingScan.confirmed_at.desc()).first()
+
+    groups = scan.scan_result if scan else {}
+
+    drift_counts = {}
+    drift_events = db.query(DriftEvent).filter(
+        DriftEvent.project_id == project_id,
+        DriftEvent.status     == "detected",
+    ).all()
+
+    for event in drift_events:
+        key = event.resource_id_aws
+        if key not in drift_counts:
+            drift_counts[key] = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
+        drift_counts[key][event.severity] += 1
+
+    enriched_groups = {}
+    for group_key, group_data in groups.items():
+        group_drift = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
+        enriched_resources = []
+
+        for resource in group_data.get("resources", []):
+            rid     = resource.get("resource_id", "")
+            r_drift = drift_counts.get(rid, {})
+            resource["drift"] = r_drift
+
+            for sev, cnt in r_drift.items():
+                group_drift[sev] += cnt
+
+            enriched_resources.append(resource)
+
+        enriched_groups[group_key] = {
+            **group_data,
+            "resources":     enriched_resources,
+            "drift_summary": group_drift,
+        }
+
+    return {
+        "success": True,
+        "data": {
+            "project_id":      project_id,
+            "source":          project.source,
+            "total_resources": sum(len(g["resources"]) for g in enriched_groups.values()),
+            "total_groups":    len(enriched_groups),
+            "groups":          enriched_groups,
+            "drift_summary": {
+                "CRITICAL": sum(d["CRITICAL"] for d in drift_counts.values()),
+                "HIGH":     sum(d["HIGH"]     for d in drift_counts.values()),
+                "MEDIUM":   sum(d["MEDIUM"]   for d in drift_counts.values()),
+                "LOW":      sum(d["LOW"]       for d in drift_counts.values()),
+            },
+        },
+    }
+
+
+@router.get("/api/accounts/{account_id}/resources")
+def get_account_resources(
+    account_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """계정 전체 온보딩 프로젝트 리소스 (리전별 그룹화)"""
+    projects = db.query(Project).filter(
+        Project.account_id == account_id,
+        Project.user_id    == current_user.user_id,
+        Project.source     == "onboarding",
+    ).all()
+
+    all_groups = {}
+    for project in projects:
+        scan = db.query(OnboardingScan).filter(
+            OnboardingScan.project_id == project.project_id,
+            OnboardingScan.status     == "completed",
+        ).order_by(OnboardingScan.confirmed_at.desc()).first()
+
+        if scan and scan.scan_result:
+            for group_key, group_data in scan.scan_result.items():
+                all_groups[group_key] = {
+                    **group_data,
+                    "project_id": project.project_id,
+                }
+
+    return {"success": True, "data": {"groups": all_groups}}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,11 @@ from app.services.governance.drift_worker import start_drift_worker
 from app.core.config import settings
 from app.api.onboarding import router as onboarding_router
 from app.api.drift import router as drift_router
+from prometheus_client import Counter, Gauge, Histogram, generate_latest, CONTENT_TYPE_LATEST
+from fastapi.responses import Response
+from app.api.audit import router as audit_router
+from app.api.resources import router as resources_router
+from app.api.diagram import router as diagram_router
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -37,6 +42,28 @@ async def lifespan(app: FastAPI):
         await drift_task
     except asyncio.CancelledError:
         print("🛑 Drift Worker 종료 완료")
+
+drift_total = Counter(
+    "autoops_drift_events_total",
+    "Total drift events detected",
+    ["project_id", "severity"],
+)
+drift_unresolved = Gauge(
+    "autoops_drift_unresolved",
+    "Unresolved drift events count",
+    ["project_id", "severity"],
+)
+terraform_duration = Histogram(
+    "autoops_terraform_apply_duration_seconds",
+    "Terraform apply duration in seconds",
+    ["environment", "status"],
+    buckets=[30, 60, 120, 300, 600, 1200],
+)
+validation_blocked = Counter(
+    "autoops_validation_blocked_total",
+    "Validation blocked deployments",
+    ["tool", "severity"],
+)
 
 app = FastAPI(
     title="AutoOps API",
@@ -86,7 +113,14 @@ app.include_router(websocket.router, tags=["websocket"])
 app.include_router(onboarding_router)
 app.include_router(drift_router)
 app.include_router(gcp_connect_router, prefix="/api/projects", tags=["gcp"])
+app.include_router(audit_router)
+app.include_router(resources_router)
+app.include_router(diagram_router)
 
 @app.get("/health", tags=["health"])
 def health_check():
     return {"status": "ok", "service": "autoops-backend"}
+
+@app.get("/api/metrics", include_in_schema=False)
+async def metrics():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,24 +13,21 @@ from app.services.governance.drift_worker import start_drift_worker
 from app.core.config import settings
 from app.api.onboarding import router as onboarding_router
 from app.api.drift import router as drift_router
-from prometheus_client import Counter, Gauge, Histogram, generate_latest, CONTENT_TYPE_LATEST
-from fastapi.responses import Response
 from app.api.audit import router as audit_router
 from app.api.resources import router as resources_router
 from app.api.diagram import router as diagram_router
+from app.api import metrics as metrics_router
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # 서버 켜질 때 SQS 워커를 백그라운드 태스크로 실행
     worker_task = asyncio.create_task(start_sqs_worker())
     print("✅ MirrorOps SQS 워커 백그라운드 실행 시작")
 
     drift_task = asyncio.create_task(start_drift_worker())
     print("✅ Drift Worker 백그라운드 실행 시작")
-    
-    yield # API 서버 동작 중...
-    
-    # 서버 꺼질 때 워커 종료 처리
+
+    yield
+
     worker_task.cancel()
     drift_task.cancel()
     try:
@@ -43,27 +40,6 @@ async def lifespan(app: FastAPI):
     except asyncio.CancelledError:
         print("🛑 Drift Worker 종료 완료")
 
-drift_total = Counter(
-    "autoops_drift_events_total",
-    "Total drift events detected",
-    ["project_id", "severity"],
-)
-drift_unresolved = Gauge(
-    "autoops_drift_unresolved",
-    "Unresolved drift events count",
-    ["project_id", "severity"],
-)
-terraform_duration = Histogram(
-    "autoops_terraform_apply_duration_seconds",
-    "Terraform apply duration in seconds",
-    ["environment", "status"],
-    buckets=[30, 60, 120, 300, 600, 1200],
-)
-validation_blocked = Counter(
-    "autoops_validation_blocked_total",
-    "Validation blocked deployments",
-    ["tool", "severity"],
-)
 
 app = FastAPI(
     title="AutoOps API",
@@ -104,23 +80,20 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         },
     )
 
-app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
-app.include_router(accounts.router, prefix="/api/accounts", tags=["accounts"])
-app.include_router(projects.router, prefix="/api/projects", tags=["projects"])
-app.include_router(craft.router, prefix="/api/craft", tags=["craftops"])
-app.include_router(mirror.router, prefix="/api/mirror", tags=["mirrorops"])
-app.include_router(websocket.router, tags=["websocket"])
+app.include_router(auth.router,           prefix="/api/auth",     tags=["auth"])
+app.include_router(accounts.router,       prefix="/api/accounts", tags=["accounts"])
+app.include_router(projects.router,       prefix="/api/projects", tags=["projects"])
+app.include_router(craft.router,          prefix="/api/craft",    tags=["craftops"])
+app.include_router(mirror.router,         prefix="/api/mirror",   tags=["mirrorops"])
+app.include_router(websocket.router,      tags=["websocket"])
 app.include_router(onboarding_router)
 app.include_router(drift_router)
-app.include_router(gcp_connect_router, prefix="/api/projects", tags=["gcp"])
+app.include_router(gcp_connect_router,    prefix="/api/projects", tags=["gcp"])
 app.include_router(audit_router)
 app.include_router(resources_router)
 app.include_router(diagram_router)
+app.include_router(metrics_router.router, prefix="/api",          tags=["metrics"])
 
 @app.get("/health", tags=["health"])
 def health_check():
     return {"status": "ok", "service": "autoops-backend"}
-
-@app.get("/api/metrics", include_in_schema=False)
-async def metrics():
-    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/backend/app/services/governance/audit_logger.py
+++ b/backend/app/services/governance/audit_logger.py
@@ -1,0 +1,81 @@
+# backend/app/services/governance/audit_logger.py
+import uuid
+from datetime import datetime
+from sqlalchemy.orm import Session
+from app.models.governance import AuditLog
+
+
+def log_platform_action(
+    db:         Session,
+    action:     str,
+    user_id:    str  = None,
+    project_id: str  = None,
+    detail:     dict = None,
+):
+    """
+    레이어 1: AutoOps 플랫폼 행위 기록 (동기).
+
+    사용 예:
+        log_platform_action(db, "craftops_deploy", user_id=..., project_id=..., detail={...})
+        log_platform_action(db, "drift_approve",   user_id=..., project_id=..., detail={...})
+    """
+    log = AuditLog(
+        id         = str(uuid.uuid4()),
+        project_id = project_id,
+        user_id    = user_id,
+        layer      = "platform",
+        action     = action,
+        actor      = user_id,
+        detail     = detail or {},
+        created_at = datetime.utcnow(),
+    )
+    db.add(log)
+
+
+def log_aws_change(
+    db:            Session,
+    project_id:    str,
+    actor_arn:     str,
+    action:        str,
+    resource_type: str,
+    detail:        dict,
+):
+    """레이어 2: AWS 계정 변경 이력 (비동기 Worker에서 호출)"""
+    log = AuditLog(
+        id         = str(uuid.uuid4()),
+        project_id = project_id,
+        user_id    = None,
+        layer      = "aws_change",
+        action     = action,
+        actor      = actor_arn,
+        detail     = detail,
+        created_at = datetime.utcnow(),
+    )
+    db.add(log)
+
+
+def log_validation_block(
+    db:         Session,
+    project_id: str,
+    tool:       str,
+    rule_id:    str,
+    resource:   str,
+    message:    str,
+):
+    """레이어 3: Validation 차단 이력 (동기)"""
+    log = AuditLog(
+        id         = str(uuid.uuid4()),
+        project_id = project_id,
+        user_id    = None,
+        layer      = "validation_block",
+        action     = f"validation_blocked_{tool}",
+        actor      = "system",
+        detail     = {
+            "tool":     tool,
+            "rule_id":  rule_id,
+            "resource": resource,
+            "message":  message,
+        },
+        created_at = datetime.utcnow(),
+    )
+    db.add(log)

--- a/backend/app/services/mirrorops/bedrock_client.py
+++ b/backend/app/services/mirrorops/bedrock_client.py
@@ -199,7 +199,7 @@ AWS 설정:
         })
 
         response = self.client.invoke_model(
-            modelId     = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            modelId     = "anthropic.claude-sonnet-4-20250514-v1:0",
             body        = body,
             contentType = "application/json",
             accept      = "application/json",
@@ -209,7 +209,11 @@ AWS 설정:
         raw_text = result["content"][0]["text"]
 
         mermaid_match = re.search(r"```mermaid\n(.*?)```", raw_text, re.DOTALL)
-        mermaid_code  = mermaid_match.group(1).strip() if mermaid_match else ""
+        if mermaid_match:
+            mermaid_code = mermaid_match.group(1).strip()
+        else:
+            print(f"[Diagram] mermaid 코드블록 파싱 실패 — raw_text 앞 200자: {raw_text[:200]}")
+            mermaid_code = ""
         description   = re.sub(r"```mermaid\n.*?```", "", raw_text, flags=re.DOTALL).strip()
 
         return {

--- a/backend/app/services/mirrorops/bedrock_client.py
+++ b/backend/app/services/mirrorops/bedrock_client.py
@@ -5,7 +5,6 @@ from app.core.config import settings
 
 
 # 리소스 타입별 Bedrock 프롬프트
-# "어떤 값으로 매핑하면 되는지"의 의미 정보만 요청
 RESOURCE_PROMPTS: dict[str, str] = {
     "google_compute_firewall": """
 AWS SecurityGroup 설정을 분석하여 GCP Firewall 변환에 필요한 정보를 추출하세요.
@@ -157,3 +156,63 @@ AWS 설정:
                 "mapping_info":  {},
                 "review_reason": f"Bedrock 응답 파싱 실패: {raw[:200]}",
             }
+
+    def generate_architecture_diagram(self, resources: list[dict]) -> dict:
+        """
+        리소스 목록을 기반으로 Mermaid 다이어그램 + 한국어 설명 생성.
+        CraftOps 배포 프로젝트: deployment_resources 전달
+        온보딩 프로젝트: scan_result resources 전달
+
+        반환:
+        {
+            "mermaid_code": "graph TD\\n  ...",
+            "description":  "## 인프라 구조 설명\\n..."
+        }
+        """
+        resource_summary = []
+        for r in resources[:20]:
+            resource_summary.append({
+                "type": r.get("resource_type", r.get("resourceType", "")),
+                "name": r.get("resource_name", r.get("resourceName", r.get("resource_id", ""))),
+                "id":   r.get("resource_id", r.get("resource_id_aws", "")),
+            })
+
+        prompt = f"""당신은 AWS 인프라 아키텍처 설계 전문가입니다.
+아래 AWS 리소스 목록을 분석하여 다음 두 가지를 마크다운 형식으로 작성해주세요.
+
+리소스 목록:
+{json.dumps(resource_summary, ensure_ascii=False, indent=2)}
+
+1. 이 인프라의 구조를 표현하는 Mermaid 다이어그램 코드 (graph TD 스타일)
+   - 리소스 간 연결 관계를 화살표로 표현
+   - 인터넷 트래픽 흐름 포함 (Internet → ALB → ECS → RDS 등)
+   - 반드시 ```mermaid 코드블록으로 감싸기
+
+2. 리소스별 역할 및 전체적인 데이터 흐름/동작 방식 한국어 설명
+
+마크다운 형식으로 응답하세요."""
+
+        body = json.dumps({
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens":         2000,
+            "messages": [{"role": "user", "content": prompt}],
+        })
+
+        response = self.client.invoke_model(
+            modelId     = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            body        = body,
+            contentType = "application/json",
+            accept      = "application/json",
+        )
+
+        result   = json.loads(response["body"].read())
+        raw_text = result["content"][0]["text"]
+
+        mermaid_match = re.search(r"```mermaid\n(.*?)```", raw_text, re.DOTALL)
+        mermaid_code  = mermaid_match.group(1).strip() if mermaid_match else ""
+        description   = re.sub(r"```mermaid\n.*?```", "", raw_text, flags=re.DOTALL).strip()
+
+        return {
+            "mermaid_code": mermaid_code,
+            "description":  description,
+        }

--- a/backend/app/services/mirrorops/detector.py
+++ b/backend/app/services/mirrorops/detector.py
@@ -149,7 +149,7 @@ class ResourceDetector:
                             break
 
                 effective_name = name_tag or res_name
-                if not effective_name.startswith(name_prefix):
+                if not effective_name.lower().startswith(name_prefix.lower()):
                     continue
 
                 results.append({

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,4 +37,3 @@ cryptography==43.0.3
 
 google-api-python-client==2.127.0
 pandas==2.2.2
-prometheus-client==0.21.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,3 +37,4 @@ cryptography==43.0.3
 
 google-api-python-client==2.127.0
 pandas==2.2.2
+prometheus-client==0.21.0

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -622,7 +622,7 @@ export default function DashboardPage() {
                       key={p.project_id}
                       onClick={() => {
                         if (isConfirmingDelete) return
-                        router.push(`/projects/${p.project_id}/${p.project_id}`)
+                        router.push(`/projects/${p.project_id}`)
                       }}
                     >
                       <td>
@@ -677,7 +677,7 @@ export default function DashboardPage() {
                                 className="dx-ibtn"
                                 data-variant="blue"
                                 title="MirrorOps DR 대시보드"
-                                onClick={() => router.push(`/projects/${p.project_id}/${p.project_id}`)}
+                                onClick={() => router.push(`/projects/${p.project_id}`)}
                               >
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
                                   <rect x="3" y="3" width="18" height="18" rx="2"/>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -69,6 +69,7 @@ export default function DashboardPage() {
   const [destroyAws, setDestroyAws] = useState(false)
   const [toast, setToast]           = useState<ToastData | null>(null)
   const [filter, setFilter]         = useState<FilterKey>('all')
+  const [driftCounts, setDriftCounts] = useState<Record<string, number>>({})
 
   // localStorage toast (deploy success carry-over)
   useEffect(() => {
@@ -90,6 +91,25 @@ export default function DashboardPage() {
   }, [])
 
   useEffect(() => { fetchProjects() }, [fetchProjects])
+
+  useEffect(() => {
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || ''
+  const wsUrl   = API_URL.replace('https://', 'wss://').replace('http://', 'ws://')
+  const token   = typeof window !== 'undefined' ? localStorage.getItem('access_token') : ''
+  if (!token) return
+
+  const ws = new WebSocket(`${wsUrl}/ws/events/dashboard?token=${token}`)
+  ws.onmessage = (e) => {
+    const msg = JSON.parse(e.data)
+    if (msg.type === 'drift_detected') {
+      setDriftCounts(prev => ({
+        ...prev,
+        [msg.data.project_id]: (prev[msg.data.project_id] || 0) + 1
+      }))
+    }
+  }
+  return () => ws.close()
+}, [])
 
   const handleDelete = async (projectId: string) => {
     try {
@@ -602,7 +622,7 @@ export default function DashboardPage() {
                       key={p.project_id}
                       onClick={() => {
                         if (isConfirmingDelete) return
-                        router.push(`/projects/${p.project_id}/mirror`)
+                        router.push(`/projects/${p.project_id}/${p.project_id}`)
                       }}
                     >
                       <td>
@@ -623,6 +643,20 @@ export default function DashboardPage() {
                           <span className="pip"></span>
                           {deployConf.text}
                         </span>
+                        {driftCounts[p.project_id] > 0 && (
+                          <span style={{
+                            fontFamily: 'var(--dx-mono)',
+                            fontSize: '10px',
+                            padding: '2px 7px',
+                            borderRadius: '100px',
+                            background: 'rgba(255,118,118,0.1)',
+                            color: 'var(--dx-red)',
+                            border: '1px solid rgba(255,118,118,0.25)',
+                            marginLeft: '6px',
+                          }}>
+                            Drift {driftCounts[p.project_id]}
+                          </span>
+                        )}
                       </td>
                       <td>
                         <span className="dx-status" data-tone={drConf.tone}>
@@ -643,7 +677,7 @@ export default function DashboardPage() {
                                 className="dx-ibtn"
                                 data-variant="blue"
                                 title="MirrorOps DR 대시보드"
-                                onClick={() => router.push(`/projects/${p.project_id}/mirror`)}
+                                onClick={() => router.push(`/projects/${p.project_id}/${p.project_id}`)}
                               >
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
                                   <rect x="3" y="3" width="18" height="18" rx="2"/>

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -1,0 +1,219 @@
+// frontend/app/onboarding/page.tsx
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { apiClient } from '@/lib/api'
+
+type ScanStatus = 'idle' | 'scanning' | 'pending_confirm' | 'confirming' | 'completed' | 'failed'
+
+interface ScanGroup {
+  region: string
+  vpc_id: string | null
+  vpc_name: string | null
+  resources: Array<{ resource_type: string; resource_id: string; resource_name: string }>
+}
+
+export default function OnboardingPage() {
+  const router = useRouter()
+  const [accountId, setAccountId]   = useState<string>('')
+  const [scanId, setScanId]         = useState<string>('')
+  const [projectId, setProjectId]   = useState<string>('')
+  const [status, setStatus]         = useState<ScanStatus>('idle')
+  const [groups, setGroups]         = useState<Record<string, ScanGroup>>({})
+  const [totalResources, setTotal]  = useState(0)
+  const [error, setError]           = useState<string | null>(null)
+  const [slackWebhook, setSlack]    = useState<string>('')
+
+  useEffect(() => {
+    apiClient.get('/api/accounts').then(res => {
+      const accounts = res.data.data
+      if (accounts.length > 0) setAccountId(accounts[0].account_id)
+    })
+  }, [])
+
+  const handleStartScan = async () => {
+    if (!accountId) return
+    setStatus('scanning')
+    setError(null)
+    try {
+      const res = await apiClient.post(`/api/accounts/${accountId}/onboard`)
+      setScanId(res.data.data.scan_id)
+      setProjectId(res.data.data.project_id)
+      pollStatus(accountId)
+    } catch (e: any) {
+      setStatus('failed')
+      setError(e.response?.data?.detail?.message || '스캔 시작 실패')
+    }
+  }
+
+  const pollStatus = (accId: string) => {
+    const interval = setInterval(async () => {
+      try {
+        const res = await apiClient.get(`/api/accounts/${accId}/onboard/status`)
+        const data = res.data.data
+        if (data.status === 'pending_confirm') {
+          setGroups(data.scan_result || {})
+          setTotal(data.total_resources || 0)
+          setStatus('pending_confirm')
+          clearInterval(interval)
+        } else if (data.status === 'failed') {
+          setStatus('failed')
+          clearInterval(interval)
+        }
+      } catch { clearInterval(interval) }
+    }, 3000)
+  }
+
+  const handleConfirm = async () => {
+    setStatus('confirming')
+    try {
+      await apiClient.post(`/api/accounts/${accountId}/onboard/confirm`, {
+        scan_id: scanId,
+        groups,
+      })
+      setStatus('completed')
+      // ⚠️ v3 변경: 거버넌스 통합 허브로 리다이렉트
+      setTimeout(() => router.push(`/projects/${projectId}`), 1500)
+    } catch (e: any) {
+      setStatus('failed')
+      setError(e.response?.data?.detail?.message || '확정 실패')
+    }
+  }
+
+  const handleSaveSlack = async () => {
+    try {
+      await apiClient.patch('/api/users/me', { slack_webhook_url: slackWebhook })
+      alert('Slack Webhook URL이 저장되었습니다.')
+    } catch {
+      alert('저장 실패')
+    }
+  }
+
+  return (
+    <div className="px-6 py-8 max-w-3xl">
+      <h1 className="text-2xl font-bold mb-2">기존 인프라 연동</h1>
+      <p className="text-[#9ca3af] text-sm mb-8">
+        현재 AWS 계정의 인프라를 스캔하여 운영 거버넌스 체계에 편입합니다.
+      </p>
+
+      {status === 'idle' && (
+        <div className="space-y-4">
+          <div className="bg-[#121214] border border-white/8 rounded-3xl p-6">
+            <p className="text-sm text-[#9ca3af] mb-4">
+              연동된 AWS 계정의 전체 리소스를 스캔합니다. (약 1~2분 소요)
+            </p>
+            <button
+              onClick={handleStartScan}
+              className="px-6 py-3 bg-[#ffa53d] text-black font-semibold rounded-2xl hover:bg-[#ff9420] transition-colors"
+            >
+              스캔 시작
+            </button>
+          </div>
+
+          {/* Slack Webhook URL 설정 */}
+          <div className="bg-[#121214] border border-white/8 rounded-3xl p-6">
+            <p className="text-sm font-semibold mb-1">Slack 알림 연동 (선택)</p>
+            <p className="text-xs text-[#9ca3af] mb-3">
+              CRITICAL/HIGH Drift 감지 시 Slack으로 알림을 받습니다.
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="url"
+                placeholder="https://hooks.slack.com/services/..."
+                value={slackWebhook}
+                onChange={(e) => setSlack(e.target.value)}
+                className="flex-1 px-3 py-2 text-sm bg-white/5 border border-white/10 rounded-xl
+                           text-[#edf0f6] placeholder-[#9ca3af] focus:outline-none focus:border-[#ffa53d]"
+              />
+              <button
+                onClick={handleSaveSlack}
+                disabled={!slackWebhook}
+                className="px-4 py-2 text-sm bg-white/8 hover:bg-white/12 border border-white/10
+                           text-[#edf0f6] font-medium rounded-xl transition-colors disabled:opacity-40"
+              >
+                저장
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {status === 'scanning' && (
+        <div className="bg-[#121214] border border-white/8 rounded-3xl p-6 text-center">
+          <div className="text-2xl mb-3 animate-spin inline-block">⚙️</div>
+          <p className="text-sm text-[#9ca3af]">AWS 계정 리소스 스캔 중...</p>
+        </div>
+      )}
+
+      {status === 'pending_confirm' && (
+        <div className="space-y-4">
+          <div className="bg-[#121214] border border-white/8 rounded-3xl p-4">
+            <p className="text-sm font-semibold">
+              스캔 완료 — 리소스 {totalResources}개 발견
+            </p>
+            <p className="text-xs text-[#9ca3af] mt-1">
+              그룹화 결과를 확인하고 확정하세요.
+            </p>
+          </div>
+
+          {Object.entries(groups).map(([key, group]) => (
+            <div key={key} className="bg-[#121214] border border-white/8 rounded-3xl p-4">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-xs font-mono text-[#ffa53d]">{group.region}</span>
+                {group.vpc_id && (
+                  <span className="text-xs text-[#9ca3af]">
+                    {group.vpc_name || group.vpc_id}
+                  </span>
+                )}
+                <span className="ml-auto text-xs text-[#9ca3af]">
+                  {group.resources.length}개
+                </span>
+              </div>
+              <div className="space-y-1">
+                {group.resources.slice(0, 5).map((r, i) => (
+                  <div key={i} className="text-xs text-[#9ca3af] flex justify-between">
+                    <span>{r.resource_type.split('::').pop()}</span>
+                    <span className="font-mono">{r.resource_name || r.resource_id}</span>
+                  </div>
+                ))}
+                {group.resources.length > 5 && (
+                  <p className="text-xs text-[#9ca3af]">
+                    +{group.resources.length - 5}개 더...
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+
+          <button
+            onClick={handleConfirm}
+            className="w-full py-3 bg-[#ffa53d] text-black font-semibold rounded-2xl hover:bg-[#ff9420] transition-colors"
+          >
+            이 그룹화로 Baseline 등록
+          </button>
+        </div>
+      )}
+
+      {status === 'completed' && (
+        <div className="bg-[#121214] border border-emerald-500/30 rounded-3xl p-6 text-center">
+          <p className="text-emerald-400 font-semibold mb-1">✅ 온보딩 완료</p>
+          <p className="text-sm text-[#9ca3af]">거버넌스 대시보드로 이동합니다...</p>
+        </div>
+      )}
+
+      {status === 'failed' && (
+        <div className="bg-[#121214] border border-red-500/30 rounded-3xl p-6">
+          <p className="text-red-400 font-semibold mb-2">❌ 실패</p>
+          <p className="text-sm text-[#9ca3af]">{error}</p>
+          <button
+            onClick={() => setStatus('idle')}
+            className="mt-3 px-4 py-2 text-sm bg-white/5 hover:bg-white/10 rounded-xl"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/app/projects/[id]/audit/page.tsx
+++ b/frontend/app/projects/[id]/audit/page.tsx
@@ -1,0 +1,130 @@
+// frontend/app/projects/[id]/audit/page.tsx
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { apiClient } from '@/lib/api'
+
+interface AuditLog {
+  id:         string
+  layer:      'platform' | 'aws_change' | 'validation_block'
+  action:     string
+  actor:      string
+  detail:     Record<string, any>
+  created_at: string
+}
+
+const LAYER_CONFIG = {
+  platform:         { label: '플랫폼 행위',     color: 'text-blue-400',   bg: 'bg-blue-400/10'   },
+  aws_change:       { label: 'AWS 변경',        color: 'text-yellow-400', bg: 'bg-yellow-400/10' },
+  validation_block: { label: 'Validation 차단', color: 'text-red-400',    bg: 'bg-red-400/10'    },
+}
+
+const ACTION_LABEL: Record<string, string> = {
+  craftops_deploy:            '배포 실행',
+  craftops_destroy:           '인프라 삭제',
+  project_delete:             '프로젝트 삭제',
+  failover_execute:           '페일오버 실행',
+  drift_approve:              'Drift 승인',
+  drift_reject:               'Drift 거부',
+  onboarding_complete:        '온보딩 완료',
+  validation_blocked_tfsec:   'tfsec 차단',
+  validation_blocked_checkov: 'checkov 차단',
+}
+
+export default function AuditLogPage() {
+  const { id: projectId } = useParams<{ id: string }>()
+  const router = useRouter()
+  const [logs, setLogs]       = useState<AuditLog[]>([])
+  const [total, setTotal]     = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [layer, setLayer]     = useState<string>('')
+
+  useEffect(() => {
+    setLoading(true)
+    const params = layer ? `?layer=${layer}` : ''
+    apiClient
+      .get(`/api/projects/${projectId}/audit-logs${params}`)
+      .then(res => {
+        setLogs(res.data.data.items)
+        setTotal(res.data.data.total)
+      })
+      .finally(() => setLoading(false))
+  }, [projectId, layer])
+
+  return (
+    <div className="px-6 py-8 max-w-4xl">
+      <button
+        onClick={() => router.push(`/projects/${projectId}`)}
+        className="text-[#9ca3af] hover:text-white text-sm mb-6 block"
+      >
+        ← 거버넌스 허브
+      </button>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold">Audit Log</h1>
+        <span className="text-sm text-[#9ca3af]">총 {total}건</span>
+      </div>
+
+      {/* 레이어 필터 */}
+      <div className="flex gap-2 mb-4">
+        {[
+          { value: '',                 label: '전체' },
+          { value: 'platform',         label: '플랫폼 행위' },
+          { value: 'aws_change',       label: 'AWS 변경' },
+          { value: 'validation_block', label: 'Validation 차단' },
+        ].map(f => (
+          <button
+            key={f.value}
+            onClick={() => setLayer(f.value)}
+            className={`px-3 py-1.5 text-xs rounded-xl transition-colors ${
+              layer === f.value
+                ? 'bg-white/15 text-white'
+                : 'bg-white/5 text-[#9ca3af] hover:bg-white/10'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <p className="text-[#9ca3af] text-sm">로딩 중...</p>
+      ) : logs.length === 0 ? (
+        <div className="bg-[#121214] border border-white/8 rounded-3xl p-8 text-center">
+          <p className="text-[#9ca3af] text-sm">기록이 없습니다.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {logs.map(log => {
+            const cfg = LAYER_CONFIG[log.layer]
+            return (
+              <div key={log.id} className="bg-[#121214] border border-white/8 rounded-2xl p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${cfg.bg} ${cfg.color}`}>
+                        {cfg.label}
+                      </span>
+                      <span className="text-sm font-medium">
+                        {ACTION_LABEL[log.action] || log.action}
+                      </span>
+                    </div>
+                    <p className="text-xs text-[#9ca3af] font-mono">{log.actor}</p>
+                    {log.detail && Object.keys(log.detail).length > 0 && (
+                      <pre className="text-xs text-[#9ca3af] mt-2 bg-black/20 p-2 rounded-lg overflow-x-auto">
+                        {JSON.stringify(log.detail, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                  <span className="text-xs text-[#9ca3af] whitespace-nowrap">
+                    {new Date(log.created_at).toLocaleString('ko-KR')}
+                  </span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/app/projects/[id]/drift/page.tsx
+++ b/frontend/app/projects/[id]/drift/page.tsx
@@ -1,0 +1,188 @@
+// frontend/app/projects/[id]/drift/page.tsx
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { apiClient } from '@/lib/api'
+
+interface DriftEvent {
+  drift_id:      string
+  resource_id:   string
+  resource_type: string
+  changed_by:    string
+  diff_summary:  string
+  severity:      'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW'
+  status:        'detected' | 'accepted' | 'guided'
+  detected_at:   string
+}
+
+const SEVERITY_CONFIG = {
+  CRITICAL: { color: 'text-red-400',    bg: 'bg-red-400/10',    emoji: '🔴' },
+  HIGH:     { color: 'text-yellow-400', bg: 'bg-yellow-400/10', emoji: '🟡' },
+  MEDIUM:   { color: 'text-orange-400', bg: 'bg-orange-400/10', emoji: '🟠' },
+  LOW:      { color: 'text-[#9ca3af]',  bg: 'bg-white/5',       emoji: '⚪' },
+}
+
+const STATUS_LABEL = {
+  detected: '미처리',
+  accepted: '승인됨',
+  guided:   '가이드 발송',
+}
+
+export default function DriftPage() {
+  const { id: projectId } = useParams<{ id: string }>()
+  const router   = useRouter()
+  const [events, setEvents]     = useState<DriftEvent[]>([])
+  const [loading, setLoading]   = useState(true)
+  const [actionId, setActionId] = useState<string | null>(null)
+  const [filter, setFilter]     = useState<string>('all')
+
+  const fetchEvents = useCallback(async () => {
+    try {
+      const res = await apiClient.get(`/api/projects/${projectId}/drift`)
+      setEvents(res.data.data)
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => { fetchEvents() }, [fetchEvents])
+
+  // WebSocket drift_detected 이벤트 수신 → 자동 갱신
+  useEffect(() => {
+    const API_URL = process.env.NEXT_PUBLIC_API_URL || ''
+    const wsUrl   = API_URL.replace('https://', 'wss://').replace('http://', 'ws://')
+    const token   = typeof window !== 'undefined' ? localStorage.getItem('access_token') : ''
+    const ws      = new WebSocket(`${wsUrl}/ws/events/${projectId}?token=${token}`)
+
+    ws.onmessage = (e) => {
+      const msg = JSON.parse(e.data)
+      if (msg.type === 'drift_detected') fetchEvents()
+    }
+
+    return () => ws.close()
+  }, [projectId, fetchEvents])
+
+  const handleApprove = async (driftId: string) => {
+    setActionId(driftId)
+    try {
+      await apiClient.post(`/api/drift/${driftId}/approve`)
+      await fetchEvents()
+    } finally { setActionId(null) }
+  }
+
+  const handleReject = async (driftId: string) => {
+    setActionId(driftId)
+    try {
+      await apiClient.post(`/api/drift/${driftId}/reject`)
+      await fetchEvents()
+    } finally { setActionId(null) }
+  }
+
+  const filtered = filter === 'all' ? events
+    : filter === 'detected' ? events.filter(e => e.status === 'detected')
+    : events.filter(e => e.severity === filter)
+
+  if (loading) return <div className="p-8 text-[#9ca3af]">로딩 중...</div>
+
+  return (
+    <div className="px-6 py-8 max-w-4xl">
+      <button
+        onClick={() => router.push(`/projects/${projectId}`)}
+        className="text-[#9ca3af] hover:text-white text-sm mb-6 block"
+      >
+        ← 거버넌스 허브
+      </button>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold">Configuration Drift</h1>
+        <span className="text-sm text-[#9ca3af]">총 {events.length}건</span>
+      </div>
+
+      {/* 필터 */}
+      <div className="flex gap-2 mb-4">
+        {[
+          { v: 'all',      l: '전체' },
+          { v: 'detected', l: '미처리' },
+          { v: 'CRITICAL', l: '🔴 CRITICAL' },
+          { v: 'HIGH',     l: '🟡 HIGH' },
+        ].map(f => (
+          <button
+            key={f.v}
+            onClick={() => setFilter(f.v)}
+            className={`px-3 py-1.5 text-xs rounded-xl transition-colors ${
+              filter === f.v ? 'bg-white/15 text-white' : 'bg-white/5 text-[#9ca3af] hover:bg-white/10'
+            }`}
+          >
+            {f.l}
+          </button>
+        ))}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="bg-[#121214] border border-white/8 rounded-3xl p-8 text-center">
+          <p className="text-emerald-400 font-semibold">✅ 감지된 Drift 없음</p>
+          <p className="text-sm text-[#9ca3af] mt-1">모든 리소스가 Baseline과 일치합니다.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map(event => {
+            const cfg = SEVERITY_CONFIG[event.severity]
+            return (
+              <div
+                key={event.drift_id}
+                className={`bg-[#121214] border border-white/8 rounded-3xl p-5 ${
+                  event.severity === 'CRITICAL' ? 'border-red-500/30' : ''
+                }`}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className={`text-xs font-bold ${cfg.color}`}>
+                        {cfg.emoji} {event.severity}
+                      </span>
+                      <span className="text-xs text-[#9ca3af]">
+                        {STATUS_LABEL[event.status]}
+                      </span>
+                    </div>
+                    <p className="text-sm font-medium font-mono">{event.resource_id}</p>
+                    <p className="text-xs text-[#9ca3af] mt-1">
+                      {event.resource_type.split('::').slice(1).join('::')}
+                    </p>
+                    <p className="text-xs text-[#9ca3af] mt-2">{event.diff_summary}</p>
+                    {event.changed_by && (
+                      <p className="text-xs text-[#9ca3af] mt-1">
+                        변경자: <span className="font-mono">{event.changed_by}</span>
+                      </p>
+                    )}
+                    <p className="text-xs text-[#9ca3af] mt-1">
+                      {new Date(event.detected_at).toLocaleString('ko-KR')}
+                    </p>
+                  </div>
+
+                  {event.status === 'detected' && (
+                    <div className="flex gap-2 flex-shrink-0">
+                      <button
+                        onClick={() => handleApprove(event.drift_id)}
+                        disabled={actionId === event.drift_id}
+                        className="px-3 py-1.5 text-xs bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 rounded-xl transition-colors disabled:opacity-50"
+                      >
+                        ✅ 승인
+                      </button>
+                      <button
+                        onClick={() => handleReject(event.drift_id)}
+                        disabled={actionId === event.drift_id}
+                        className="px-3 py-1.5 text-xs bg-red-500/10 text-red-400 hover:bg-red-500/20 rounded-xl transition-colors disabled:opacity-50"
+                      >
+                        ❌ 거부
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/app/projects/[id]/page.tsx
+++ b/frontend/app/projects/[id]/page.tsx
@@ -1,257 +1,1185 @@
 // frontend/app/projects/[id]/page.tsx
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { apiClient } from '@/lib/api'
-import { Project } from '@/types'
+import dynamic from 'next/dynamic'
 
-const STATUS_CONFIG: Record<string, { text: string; color: string }> = {
-  completed:         { text: '✅ 배포 완료',  color: 'text-emerald-400' },
-  deploying:         { text: '⏳ 배포 중',    color: 'text-blue-400' },
-  failed:            { text: '❌ 배포 실패',  color: 'text-red-400' },
-  partial_failed:    { text: '⚠️ 부분 실패', color: 'text-yellow-400' },
-  created:           { text: '🔧 준비 중',    color: 'text-[#9ca3af]' },
-  destroying:        { text: '🗑️ 삭제 중',   color: 'text-orange-400' },
-  destroy_completed: { text: '🗑️ 삭제 완료', color: 'text-[#9ca3af]' },
-  destroy_failed:    { text: '⚠️ 삭제 실패', color: 'text-red-400' },
+const ArchitectureDiagram = dynamic<{ mermaidCode: string }>(
+  () => import('@/components/ArchitectureDiagram'),
+  { ssr: false }
+)
+
+// ─── 타입 정의 ────────────────────────────────────────────────────
+interface DriftEvent {
+  drift_id:      string
+  resource_id:   string
+  resource_type: string
+  changed_by:    string
+  diff_summary:  string
+  severity:      'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW'
+  status:        'detected' | 'accepted' | 'guided'
+  detected_at:   string
 }
 
-const DR_STATUS_CONFIG: Record<string, { text: string; color: string }> = {
-  ready:     { text: '✅ 준비 완료',    color: 'text-emerald-400' },
-  syncing:   { text: '🔄 동기화 중',    color: 'text-blue-400' },
-  not_ready: { text: '⚠️ 동기화 필요', color: 'text-[#9ca3af]' },
+interface AuditLog {
+  id:         string
+  layer:      'platform' | 'aws_change' | 'validation_block'
+  action:     string
+  actor:      string
+  detail:     Record<string, unknown>
+  created_at: string
 }
 
-export default function ProjectDetailPage() {
-  const params    = useParams()
-  const projectId = params.id as string
-  const router    = useRouter()
+interface ProjectInfo {
+  project_id:     string
+  name:           string
+  prefix:         string
+  environment:    string
+  region:         string
+  status:         string
+  dr_status:      string
+  last_synced_at: string | null
+}
 
-  const [project, setProject]     = useState<Project | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError]         = useState<string | null>(null)
+// ─── 상수 ─────────────────────────────────────────────────────────
+const SEVERITY_TONE: Record<DriftEvent['severity'], 'red' | 'yellow' | 'orange' | 'mute'> = {
+  CRITICAL: 'red',
+  HIGH:     'yellow',
+  MEDIUM:   'orange',
+  LOW:      'mute',
+}
 
-  useEffect(() => {
-    apiClient
-      .get(`/api/projects/${projectId}`)
-      .then((res) => setProject(res.data.data))
-      .catch(() => setError('프로젝트 정보를 불러오지 못했습니다.'))
-      .finally(() => setIsLoading(false))
+const LAYER_STYLE = {
+  platform:         { label: '플랫폼',        tone: 'blue'   },
+  aws_change:       { label: 'AWS 변경',       tone: 'orange' },
+  validation_block: { label: 'Validation 차단', tone: 'red'   },
+} as const
+
+const ACTION_LABEL: Record<string, string> = {
+  craftops_deploy:            '배포 실행',
+  craftops_destroy:           '인프라 삭제',
+  project_delete:             '프로젝트 삭제',
+  failover_execute:           '페일오버 실행',
+  drift_approve:              'Drift 승인',
+  drift_reject:               'Drift 거부',
+  onboarding_complete:        '온보딩 완료',
+  validation_blocked_tfsec:   'tfsec 차단',
+  validation_blocked_checkov: 'checkov 차단',
+}
+
+const GRAFANA_URL = process.env.NEXT_PUBLIC_GRAFANA_URL || ''
+
+// ─── 메인 컴포넌트 ────────────────────────────────────────────────
+export default function GovernancePage() {
+  const { id: projectId } = useParams<{ id: string }>()
+  const router = useRouter()
+
+  const [project, setProject]      = useState<ProjectInfo | null>(null)
+  const [driftEvents, setDrift]    = useState<DriftEvent[]>([])
+  const [auditLogs, setAudit]      = useState<AuditLog[]>([])
+  const [diagram, setDiagram]      = useState<{ mermaid_code?: string; generated_at?: string } | null>(null)
+  const [totalResources, setTotal] = useState(0)
+  const [totalDriftAll, setTotalDriftAll] = useState(0)
+  const [actionId, setActionId]    = useState<string | null>(null)
+  const [regenerating, setRegen]   = useState(false)
+  const [loading, setLoading]      = useState(true)
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [projRes, driftRes, auditRes] = await Promise.all([
+        apiClient.get(`/api/projects/${projectId}`),
+        apiClient.get(`/api/projects/${projectId}/drift?limit=5`),
+        apiClient.get(`/api/projects/${projectId}/audit-logs?limit=5`),
+      ])
+      setProject(projRes.data.data)
+      setDrift(driftRes.data.data.slice(0, 5))
+      setTotalDriftAll(driftRes.data.data.length)
+      setAudit(auditRes.data.data.items?.slice(0, 5) || [])
+
+      apiClient.get(`/api/projects/${projectId}/resources`)
+        .then(res => setTotal(res.data.data?.total_resources || 0))
+        .catch(() => {})
+
+      apiClient.get(`/api/projects/${projectId}/documents`)
+        .then(res => setDiagram(res.data.data))
+        .catch(() => {})
+    } finally {
+      setLoading(false)
+    }
   }, [projectId])
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-screen text-[#9ca3af]">
-        로딩 중...
-      </div>
-    )
+  useEffect(() => { fetchAll() }, [fetchAll])
+
+  // WebSocket — drift_detected 실시간 수신
+  useEffect(() => {
+    const API_URL = process.env.NEXT_PUBLIC_API_URL || ''
+    const wsUrl   = API_URL.replace('https://', 'wss://').replace('http://', 'ws://')
+    const token   = typeof window !== 'undefined' ? localStorage.getItem('access_token') : ''
+    const ws      = new WebSocket(`${wsUrl}/ws/events/${projectId}?token=${token}`)
+
+    ws.onmessage = (e) => {
+      const msg = JSON.parse(e.data)
+      if (msg.type === 'drift_detected') fetchAll()
+    }
+
+    return () => ws.close()
+  }, [projectId, fetchAll])
+
+  const handleApprove = async (driftId: string) => {
+    setActionId(driftId)
+    try {
+      await apiClient.post(`/api/drift/${driftId}/approve`)
+      await fetchAll()
+    } finally { setActionId(null) }
   }
 
-  if (error || !project) {
-    return (
-      <div className="px-6 py-8 md:px-12 md:py-12">
-        <p className="text-red-400">{error ?? '프로젝트를 찾을 수 없습니다.'}</p>
-        <button
-          onClick={() => router.push('/dashboard')}
-          className="mt-3 text-sm text-[#9ca3af] hover:text-white transition-colors"
-        >
-          ← 대시보드로 돌아가기
-        </button>
-      </div>
-    )
+  const handleReject = async (driftId: string) => {
+    setActionId(driftId)
+    try {
+      await apiClient.post(`/api/drift/${driftId}/reject`)
+      await fetchAll()
+    } finally { setActionId(null) }
   }
 
-  const deployConf = STATUS_CONFIG[project.status]       ?? { text: project.status,    color: 'text-[#9ca3af]' }
-  const drConf     = DR_STATUS_CONFIG[project.dr_status] ?? { text: project.dr_status, color: 'text-[#9ca3af]' }
+  const handleRegenDiagram = async () => {
+    setRegen(true)
+    try {
+      await apiClient.post(`/api/projects/${projectId}/documents/regenerate`)
+      setTimeout(() => { fetchAll(); setRegen(false) }, 120_000)
+    } catch { setRegen(false) }
+  }
 
-  // destroy 진행 중 여부
-  const isDestroying = project.status === 'destroying'
+  if (loading) {
+    return (
+      <>
+        <style>{styles}</style>
+        <div className="gv-loading">
+          <span className="gv-spinner" />
+          <span>loading governance</span>
+        </div>
+      </>
+    )
+  }
+  if (!project) return null
+
+  const criticalCount = driftEvents.filter(e => e.severity === 'CRITICAL' && e.status === 'detected').length
+  const detectedCount = driftEvents.filter(e => e.status === 'detected').length
+  const drReady       = project.dr_status === 'ready'
 
   return (
-    <div className="px-6 py-8 md:px-12 md:py-12 max-w-5xl">
+    <>
+      <style>{styles}</style>
 
-      {/* 헤더 */}
-      <div className="mb-8">
-        <button
-          onClick={() => router.push('/dashboard')}
-          className="text-[#9ca3af] hover:text-white text-sm transition-colors mb-4 block"
-        >
-          ← 대시보드
-        </button>
-        <div className="flex items-start justify-between">
-          <div>
-            <h1 className="text-2xl font-bold">{project.name}</h1>
-            <p className="text-[#9ca3af] text-sm mt-1">
-              {project.prefix}-{project.environment} · {project.region}
-            </p>
+      {/* Top bar */}
+      <div className="gv-topbar">
+        <div className="gv-top-left">
+          <button className="gv-brand" onClick={() => router.push('/dashboard')}>
+            <span className="gv-mark" />
+            AutoOps
+          </button>
+          <span className="gv-crumb-sep" />
+          <div className="gv-crumb-proj">
+            <span className="gv-crumb-eyebrow">
+              <span className="gv-pip-static gv-pip-blue" />
+              Governance · Live Monitoring
+            </span>
+            <span className="gv-crumb-name">{project.name}</span>
           </div>
-          <span className="text-xs text-[#9ca3af] bg-white/5 px-3 py-1 rounded-full">
-            {project.environment}
-          </span>
         </div>
+        <button className="gv-back-link" onClick={() => router.push('/dashboard')}>← 대시보드</button>
       </div>
 
-      {/* destroying 중 배너 */}
-      {isDestroying && (
-        <div className="mb-6 bg-orange-500/5 border border-orange-500/20 rounded-2xl px-4 py-3 text-sm text-orange-400 flex items-center gap-2">
-          <span className="animate-spin">⏳</span>
-          AWS 리소스 삭제가 진행 중입니다. 잠시 후 새로고침해주세요.
-        </div>
-      )}
+      <div className="gv-page">
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-
-        {/* ── CraftOps 섹션 ── */}
-        <div className="bg-[#121214] border border-white/8 rounded-3xl p-6 space-y-4">
-          <div>
-            <p className="text-xs text-[#9ca3af] font-semibold mb-1">🏗️ CraftOps</p>
-            <p className="text-sm text-[#9ca3af]">인프라 설계 · 배포</p>
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex justify-between items-center text-sm">
-              <span className="text-[#9ca3af]">배포 상태</span>
-              <span className={`font-medium ${deployConf.color}`}>{deployConf.text}</span>
+        {/* ── Page header ── */}
+        <div className="gv-head">
+          <div className="gv-head-left">
+            <div className="gv-eyebrow">
+              <span className="gv-pip gv-pip-green" />
+              All systems monitored
+              <span className="gv-eyebrow-sep" />
+              <span className="gv-mono-sm">{project.prefix}-{project.environment}</span>
+              <span className="gv-eyebrow-sep" />
+              <span className="gv-mono-sm">{project.region}</span>
             </div>
-            <div className="flex justify-between items-center text-sm">
-              <span className="text-[#9ca3af]">마지막 배포</span>
-              <span className="text-sm">
-                {project.last_deployed_at
-                  ? new Date(project.last_deployed_at).toLocaleString('ko-KR')
-                  : '-'}
-              </span>
+            <div className="gv-title-row">
+              <h1 className="gv-title">{project.name}</h1>
+              <span className="gv-env-badge" data-env={project.environment}>{project.environment}</span>
+              {criticalCount > 0 && (
+                <span className="gv-crit-badge">
+                  <span className="gv-pip gv-pip-red" />
+                  CRITICAL × {criticalCount}
+                </span>
+              )}
             </div>
           </div>
-
-          <div className="space-y-2 pt-2 border-t border-white/8">
-            {/* created → 위저드로 */}
-            {project.status === 'created' && (
-              <button
-                onClick={() => router.push(`/projects/new?project_id=${projectId}`)}
-                className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-white/5 hover:bg-white/10 transition-colors"
-              >
-                🚀 배포 시작
-              </button>
-            )}
-
-            {/* deploying → 배포 로그 */}
-            {project.status === 'deploying' && (
-              <button
-                onClick={() => router.push(`/projects/${projectId}/deploy`)}
-                className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-blue-500/10 text-blue-400 hover:bg-blue-500/20 transition-colors"
-              >
-                ⏳ 배포 진행 중 — 로그 보기
-              </button>
-            )}
-
-            {/* completed → 재배포 or 리소스 삭제 */}
-            {project.status === 'completed' && (
-              <>
-                <button
-                  onClick={() => router.push(`/projects/${projectId}/validate`)}
-                  className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-white/5 hover:bg-white/10 transition-colors"
-                >
-                  🔄 재배포
-                </button>
-              </>
-            )}
-
-            {/* failed → 재배포 */}
-            {project.status === 'failed' && (
-              <button
-                onClick={() => router.push(`/projects/${projectId}/validate`)}
-                className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-white/5 hover:bg-white/10 transition-colors"
-              >
-                🔄 재배포
-              </button>
-            )}
-
-            {/* partial_failed → Partial Failure 대응 */}
-            {project.status === 'partial_failed' && (
-              <button
-                onClick={() => router.push(`/projects/${projectId}/partial-failure`)}
-                className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-yellow-500/10 hover:bg-yellow-500/20 text-yellow-400 transition-colors"
-              >
-                ⚠️ Partial Failure 대응
-              </button>
-            )}
-
-            {/* destroying → 진행 중 표시만 */}
-            {project.status === 'destroying' && (
-              <div className="w-full px-4 py-3 rounded-2xl text-sm font-medium bg-orange-500/10 text-orange-400">
-                🗑️ 리소스 삭제 진행 중...
-              </div>
-            )}
-
-            {/* destroy_failed → 재시도 안내 */}
-            {project.status === 'destroy_failed' && (
-              <div className="w-full px-4 py-3 rounded-2xl text-sm bg-red-500/10 text-red-400 space-y-1">
-                <p className="font-medium">⚠️ 삭제 실패</p>
-                <p className="text-xs text-red-400/70">대시보드에서 다시 삭제를 시도하세요.</p>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* ── MirrorOps 섹션 ── */}
-        <div className="bg-[#121214] border border-white/8 rounded-3xl p-6 space-y-4">
-          <div>
-            <p className="text-xs text-[#9ca3af] font-semibold mb-1">🪞 MirrorOps</p>
-            <p className="text-sm text-[#9ca3af]">재해복구 · DR 모니터링</p>
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex justify-between items-center text-sm">
-              <span className="text-[#9ca3af]">DR 상태</span>
-              <span className={`font-medium ${drConf.color}`}>{drConf.text}</span>
-            </div>
-            <div className="flex justify-between items-center text-sm">
-              <span className="text-[#9ca3af]">마지막 동기화</span>
-              <span className="text-sm">
-                {project.last_synced_at
-                  ? new Date(project.last_synced_at).toLocaleString('ko-KR')
-                  : '-'}
-              </span>
-            </div>
-          </div>
-
-          <div className="space-y-2 pt-2 border-t border-white/8">
-            <button
-              onClick={() => router.push(`/projects/${projectId}/mirror`)}
-              className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-white/5 hover:bg-white/10 transition-colors"
-            >
-              🪞 DR 대시보드
+          <div className="gv-head-actions">
+            <button className="gv-btn" onClick={() => router.push(`/projects/${projectId}/mirror`)}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <rect x="3" y="3" width="18" height="18" rx="2"/>
+                <path d="M12 3v18"/>
+              </svg>
+              MirrorOps DR
             </button>
             <button
-              onClick={() => router.push(`/projects/${projectId}/mirror/resources`)}
-              className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-white/5 hover:bg-white/10 transition-colors"
-            >
-              🗂️ 리소스 매핑 현황
-            </button>
-            <button
-              onClick={() => router.push(`/projects/${projectId}/mirror/package`)}
-              className="w-full text-left px-4 py-3 rounded-2xl text-sm font-medium bg-white/5 hover:bg-white/10 transition-colors"
-            >
-              📦 DR Package
-            </button>
-            <button
+              className="gv-btn gv-btn-danger"
+              disabled={!drReady}
               onClick={() => router.push(`/projects/${projectId}/failover`)}
-              className={`w-full text-left px-4 py-3 rounded-2xl text-sm font-bold transition-colors ${
-                project.dr_status === 'ready'
-                  ? 'bg-red-600 hover:bg-red-700 text-white'
-                  : 'bg-white/5 hover:bg-white/10 text-[#9ca3af]'
-              }`}
             >
-              🔴 페일오버 실행
-              {project.dr_status !== 'ready' && (
-                <span className="ml-2 text-xs font-normal">(DR 준비 필요)</span>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
+              </svg>
+              페일오버 실행
+            </button>
+          </div>
+        </div>
+
+        {/* ── KPI strip (Datadog style) ── */}
+        <div className="gv-kpi-strip">
+          <div className="gv-kpi">
+            <div className="gv-kpi-head">
+              <span className="gv-kpi-label">전체 리소스</span>
+              <span className="gv-kpi-tag">RESOURCES</span>
+            </div>
+            <div className="gv-kpi-value">
+              {totalResources}<small>개</small>
+            </div>
+            <div className="gv-kpi-foot">온보딩 스캔 기준</div>
+          </div>
+
+          <div className="gv-kpi" data-tone={detectedCount > 0 ? 'red' : 'green'}>
+            <div className="gv-kpi-head">
+              <span className="gv-kpi-label">Drift 감지</span>
+              <span className="gv-kpi-tag">
+                <span className="gv-pip gv-pip-tag" />
+                LIVE
+              </span>
+            </div>
+            <div className="gv-kpi-value">
+              {totalDriftAll}<small>건</small>
+            </div>
+            <div className="gv-kpi-foot">
+              {criticalCount > 0 ? `CRITICAL ${criticalCount}건 포함` : '이상 없음'}
+            </div>
+          </div>
+
+          <div className="gv-kpi" data-tone={drReady ? 'green' : 'mute'}>
+            <div className="gv-kpi-head">
+              <span className="gv-kpi-label">DR 상태</span>
+              <span className="gv-kpi-tag">MIRROROPS</span>
+            </div>
+            <div className="gv-kpi-value gv-kpi-value-text">
+              {project.dr_status === 'ready'   ? 'Ready'
+               : project.dr_status === 'syncing' ? 'Syncing'
+               : 'Not Ready'}
+            </div>
+            <div className="gv-kpi-foot">GCP us-central1</div>
+          </div>
+
+          <div className="gv-kpi">
+            <div className="gv-kpi-head">
+              <span className="gv-kpi-label">마지막 감사</span>
+              <span className="gv-kpi-tag">AUDIT</span>
+            </div>
+            <div className="gv-kpi-value gv-kpi-value-text">
+              {auditLogs[0]
+                ? new Date(auditLogs[0].created_at).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+                : '—'}
+            </div>
+            <div className="gv-kpi-foot">
+              {auditLogs[0] ? (ACTION_LABEL[auditLogs[0].action] || auditLogs[0].action) : '기록 없음'}
+            </div>
+          </div>
+
+          <div className="gv-kpi" data-tone={project.status === 'completed' ? 'green' : 'orange'}>
+            <div className="gv-kpi-head">
+              <span className="gv-kpi-label">배포 상태</span>
+              <span className="gv-kpi-tag">CRAFTOPS</span>
+            </div>
+            <div className="gv-kpi-value gv-kpi-value-text">
+              {project.status === 'completed'  ? '완료'
+               : project.status === 'deploying' ? '배포 중'
+               : project.status}
+            </div>
+            <div className="gv-kpi-foot">{project.prefix}-{project.environment}</div>
+          </div>
+        </div>
+
+        {/* ── Grafana panel ── */}
+        <div className="gv-panel">
+          <div className="gv-panel-head">
+            <div className="gv-panel-title">
+              <span className="gv-panel-ico" data-tone="blue">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                  <path d="M3 3v18h18"/>
+                  <path d="m19 9-5 5-4-4-3 3"/>
+                </svg>
+              </span>
+              <span>인프라 모니터링</span>
+              {GRAFANA_URL && (
+                <span className="gv-status-pill" data-tone="green">
+                  <span className="gv-pip gv-pip-green" />
+                  Grafana 연결됨
+                </span>
+              )}
+            </div>
+            {GRAFANA_URL && (
+              <button
+                className="gv-btn gv-btn-sm"
+                onClick={() => window.open(`${GRAFANA_URL}/d/autoops-infra?orgId=1`, '_blank')}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                  <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/>
+                  <polyline points="15 3 21 3 21 9"/>
+                  <line x1="10" y1="14" x2="21" y2="3"/>
+                </svg>
+                전체 화면
+              </button>
+            )}
+          </div>
+          {GRAFANA_URL ? (
+            <iframe
+              src={`${GRAFANA_URL}/d/autoops-infra/infra-health?orgId=1&theme=dark&kiosk`}
+              width="100%"
+              height="320"
+              style={{ border: 'none', display: 'block' }}
+              title="Grafana 인프라 헬스"
+            />
+          ) : (
+            <div className="gv-placeholder">
+              <div className="gv-placeholder-mark">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                  <path d="M3 3v18h18"/>
+                  <path d="m19 9-5 5-4-4-3 3"/>
+                </svg>
+              </div>
+              <div className="gv-placeholder-title">Grafana Deployment Pending</div>
+              <div className="gv-placeholder-sub">섹션 11 완료 후 메트릭 패널이 표시됩니다</div>
+            </div>
+          )}
+        </div>
+
+        {/* ── Drift + Audit (Datadog-style 2-col) ── */}
+        <div className="gv-two-col">
+
+          {/* Drift */}
+          <div className="gv-panel">
+            <div className="gv-panel-head">
+              <div className="gv-panel-title">
+                <span className="gv-panel-ico" data-tone="red">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                    <circle cx="12" cy="12" r="10"/>
+                    <path d="M12 8v4M12 16h.01"/>
+                  </svg>
+                </span>
+                <span>Configuration Drift</span>
+                {detectedCount > 0 && (
+                  <span className="gv-status-pill" data-tone="red">
+                    {detectedCount} 미처리
+                  </span>
+                )}
+                <span className="gv-live">
+                  <span className="gv-live-dot" />
+                  실시간
+                </span>
+              </div>
+              <button
+                className="gv-link-btn"
+                onClick={() => router.push(`/projects/${projectId}/drift`)}
+              >
+                전체 보기 →
+              </button>
+            </div>
+
+            {driftEvents.length === 0 ? (
+              <div className="gv-empty">
+                <span className="gv-empty-check">✓</span>
+                감지된 Drift 없음
+              </div>
+            ) : (
+              <div className="gv-list">
+                {driftEvents.map(event => (
+                  <div key={event.drift_id} className="gv-drift-row">
+                    <span className="gv-sev-pill" data-tone={SEVERITY_TONE[event.severity]}>
+                      {event.severity}
+                    </span>
+                    <div className="gv-drift-body">
+                      <div className="gv-drift-id">{event.resource_id}</div>
+                      <div className="gv-drift-diff">{event.diff_summary}</div>
+                    </div>
+                    {event.status === 'detected' ? (
+                      <div className="gv-drift-actions">
+                        <button
+                          className="gv-btn-tiny"
+                          data-tone="green"
+                          disabled={actionId === event.drift_id}
+                          onClick={() => handleApprove(event.drift_id)}
+                        >
+                          승인
+                        </button>
+                        <button
+                          className="gv-btn-tiny"
+                          data-tone="red"
+                          disabled={actionId === event.drift_id}
+                          onClick={() => handleReject(event.drift_id)}
+                        >
+                          거부
+                        </button>
+                      </div>
+                    ) : (
+                      <span className="gv-drift-resolved">
+                        {event.status === 'accepted' ? '승인됨' : '거부됨'}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {totalDriftAll > 5 && (
+              <div className="gv-panel-foot">
+                <button className="gv-link-btn" onClick={() => router.push(`/projects/${projectId}/drift`)}>
+                  +{totalDriftAll - 5}건 더 보기 →
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Audit */}
+          <div className="gv-panel">
+            <div className="gv-panel-head">
+              <div className="gv-panel-title">
+                <span className="gv-panel-ico" data-tone="blue">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
+                    <polyline points="14 2 14 8 20 8"/>
+                  </svg>
+                </span>
+                <span>Audit Log</span>
+              </div>
+              <button
+                className="gv-link-btn"
+                onClick={() => router.push(`/projects/${projectId}/audit`)}
+              >
+                전체 보기 →
+              </button>
+            </div>
+
+            {auditLogs.length === 0 ? (
+              <div className="gv-empty">기록 없음</div>
+            ) : (
+              <div className="gv-list">
+                {auditLogs.map(log => {
+                  const ls = LAYER_STYLE[log.layer]
+                  return (
+                    <div key={log.id} className="gv-audit-row">
+                      <span className="gv-audit-dot" data-tone={ls.tone} />
+                      <div className="gv-audit-body">
+                        <div className="gv-audit-line">
+                          <span className="gv-layer-chip" data-tone={ls.tone}>{ls.label}</span>
+                          <span className="gv-audit-action">{ACTION_LABEL[log.action] || log.action}</span>
+                        </div>
+                        <div className="gv-audit-meta">
+                          <span>{log.actor?.split('@')[0] || log.actor}</span>
+                          <span className="gv-dot-sep" />
+                          <span>
+                            {new Date(log.created_at).toLocaleString('ko-KR', {
+                              month: '2-digit', day: '2-digit',
+                              hour: '2-digit', minute: '2-digit',
+                            })}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* ── Architecture Diagram ── */}
+        <div className="gv-panel">
+          <div className="gv-panel-head">
+            <div className="gv-panel-title">
+              <span className="gv-panel-ico" data-tone="blue">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                  <circle cx="18" cy="5" r="3"/>
+                  <circle cx="6" cy="12" r="3"/>
+                  <circle cx="18" cy="19" r="3"/>
+                  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+                  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+                </svg>
+              </span>
+              <span>아키텍처 다이어그램</span>
+              {diagram?.generated_at && (
+                <span className="gv-panel-meta">
+                  {new Date(diagram.generated_at).toLocaleString('ko-KR', {
+                    month: '2-digit', day: '2-digit',
+                    hour: '2-digit', minute: '2-digit',
+                  })} 생성
+                </span>
+              )}
+            </div>
+            <button
+              className="gv-btn gv-btn-sm"
+              onClick={handleRegenDiagram}
+              disabled={regenerating}
+            >
+              {regenerating ? (
+                <>
+                  <span className="gv-spinner-tiny" />
+                  생성 중...
+                </>
+              ) : (
+                <>
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                    <path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/>
+                  </svg>
+                  재생성
+                </>
               )}
             </button>
           </div>
+          {diagram?.mermaid_code ? (
+            <div className="gv-diagram-wrap">
+              <ArchitectureDiagram mermaidCode={diagram.mermaid_code} />
+            </div>
+          ) : (
+            <div className="gv-placeholder">
+              <div className="gv-placeholder-mark" data-tone="blue">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                  <circle cx="18" cy="5" r="3"/>
+                  <circle cx="6" cy="12" r="3"/>
+                  <circle cx="18" cy="19" r="3"/>
+                  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+                  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+                </svg>
+              </div>
+              <div className="gv-placeholder-title">Bedrock AI 다이어그램 미생성</div>
+              <div className="gv-placeholder-sub">현재 인프라 구조를 자동 분석합니다</div>
+              <button
+                className="gv-btn-primary gv-mt"
+                onClick={handleRegenDiagram}
+                disabled={regenerating}
+              >
+                {regenerating ? (
+                  <>
+                    <span className="gv-spinner-sm" />
+                    생성 중...
+                  </>
+                ) : (
+                  <>
+                    <span>AI 다이어그램 생성</span>
+                    <span className="gv-arrow">→</span>
+                  </>
+                )}
+              </button>
+            </div>
+          )}
         </div>
-
       </div>
-    </div>
+    </>
   )
 }
+
+const styles = `
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+body { background: #0b0e17; color: #edf0f6; }
+body::before {
+  content: ""; position: fixed; inset: 0; z-index: -1;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 30%, transparent 80%);
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 30%, transparent 80%);
+  opacity: 0.55; pointer-events: none;
+}
+
+/* Topbar */
+.gv-topbar {
+  position: sticky; top: 0; z-index: 30;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 18px 36px;
+  background: rgba(11,14,23,0.85);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #edf0f6;
+}
+.gv-top-left { display: flex; align-items: center; gap: 16px; }
+.gv-brand {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 800; font-size: 16px; letter-spacing: -0.02em;
+  color: #edf0f6; background: none; border: none; cursor: pointer; padding: 0;
+}
+.gv-mark {
+  width: 26px; height: 26px;
+  border-radius: 7px;
+  background:
+    radial-gradient(80% 80% at 30% 25%, rgba(255,165,61,0.7), transparent 60%),
+    radial-gradient(80% 80% at 70% 80%, rgba(90,163,255,0.7), transparent 60%),
+    #11151f;
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 0 4px 24px rgba(90,163,255,0.18), inset 0 0 12px rgba(255,255,255,0.06);
+  position: relative; flex-shrink: 0;
+}
+.gv-mark::after {
+  content: ""; position: absolute; top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: 9px; height: 9px; border-radius: 2px;
+  background: #fff; box-shadow: 0 0 12px rgba(255,255,255,0.8);
+}
+.gv-crumb-sep {
+  width: 6px; height: 6px; transform: rotate(45deg);
+  border-top: 1px solid #7a8298;
+  border-right: 1px solid #7a8298;
+}
+.gv-crumb-proj { display: flex; flex-direction: column; gap: 2px; }
+.gv-crumb-eyebrow {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 500;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #5aa3ff;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.gv-crumb-name {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 15px;
+  color: #edf0f6; letter-spacing: -0.015em;
+}
+.gv-back-link {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px; color: #aeb4c5;
+  background: rgba(255,255,255,0.03);
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 14px; border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.13);
+  cursor: pointer;
+  transition: color 160ms, border-color 160ms, background 160ms;
+}
+.gv-back-link:hover { color: #edf0f6; border-color: rgba(255,255,255,0.20); background: rgba(255,255,255,0.06); }
+
+/* Page */
+.gv-page {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 36px 36px 80px;
+  color: #edf0f6;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  display: flex; flex-direction: column; gap: 16px;
+}
+
+/* Loading */
+.gv-loading {
+  min-height: 100vh;
+  display: flex; align-items: center; justify-content: center; gap: 12px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px; letter-spacing: 0.15em; text-transform: uppercase;
+  color: #7a8298;
+}
+.gv-spinner {
+  width: 14px; height: 14px; border-radius: 50%;
+  border: 2px solid rgba(255,255,255,0.1);
+  border-top-color: #5aa3ff;
+  animation: gv-spin 700ms linear infinite;
+}
+.gv-spinner-tiny {
+  width: 11px; height: 11px; border-radius: 50%;
+  border: 1.5px solid rgba(255,255,255,0.15);
+  border-top-color: currentColor;
+  animation: gv-spin 700ms linear infinite;
+  display: inline-block;
+}
+.gv-spinner-sm {
+  width: 14px; height: 14px; border-radius: 50%;
+  border: 2px solid rgba(10,13,20,0.2);
+  border-top-color: rgba(10,13,20,0.9);
+  animation: gv-spin 700ms linear infinite;
+  display: inline-block;
+}
+@keyframes gv-spin { to { transform: rotate(360deg); } }
+@keyframes gv-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.8); }
+}
+
+/* Pip helpers */
+.gv-pip {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  display: inline-block;
+  animation: gv-pulse 1.6s ease-in-out infinite;
+}
+.gv-pip-static { animation: none; }
+.gv-pip-green  { background: #6ee7a0; box-shadow: 0 0 8px #6ee7a0; }
+.gv-pip-blue   { background: #5aa3ff; box-shadow: 0 0 8px #5aa3ff; }
+.gv-pip-red    { background: #ff7676; box-shadow: 0 0 8px #ff7676; }
+.gv-pip-tag    { background: #5aa3ff; box-shadow: 0 0 6px #5aa3ff; width: 5px; height: 5px; }
+.gv-mono-sm {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; color: #7a8298;
+  letter-spacing: 0.04em;
+}
+
+/* Page head */
+.gv-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  gap: 24px; flex-wrap: wrap;
+  padding-bottom: 20px;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+.gv-head-left { flex: 1; min-width: 0; }
+.gv-eyebrow {
+  display: inline-flex; align-items: center; gap: 12px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: #aeb4c5;
+  margin-bottom: 14px;
+}
+.gv-eyebrow-sep {
+  width: 3px; height: 3px; border-radius: 50%;
+  background: #4b5267;
+}
+.gv-title-row {
+  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+}
+.gv-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700;
+  font-size: 32px;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  margin: 0;
+  color: #edf0f6;
+}
+.gv-env-badge {
+  display: inline-flex; align-items: center;
+  padding: 5px 12px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; font-weight: 500;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  border-radius: 100px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: rgba(255,255,255,0.025);
+  color: #aeb4c5;
+}
+.gv-env-badge[data-env="prod"], .gv-env-badge[data-env="production"]   { color: #ffa53d; border-color: rgba(255,165,61,0.3); background: rgba(255,165,61,0.06); }
+.gv-env-badge[data-env="stage"], .gv-env-badge[data-env="staging"]     { color: #f5d061; border-color: rgba(245,208,97,0.3); background: rgba(245,208,97,0.06); }
+.gv-env-badge[data-env="dev"], .gv-env-badge[data-env="development"]   { color: #5aa3ff; border-color: rgba(90,163,255,0.3); background: rgba(90,163,255,0.06); }
+
+.gv-crit-badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 5px 12px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  border-radius: 100px;
+  border: 1px solid rgba(255,118,118,0.35);
+  background: rgba(255,118,118,0.08);
+  color: #ff7676;
+}
+
+/* Buttons */
+.gv-head-actions { display: flex; gap: 10px; align-items: center; }
+.gv-btn {
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 10px 16px;
+  font-family: inherit;
+  font-size: 13px; font-weight: 600;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: rgba(255,255,255,0.04);
+  color: #edf0f6;
+  cursor: pointer;
+  transition: background 160ms, border-color 160ms, transform 160ms, box-shadow 160ms;
+}
+.gv-btn:hover:not(:disabled) { background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.20); }
+.gv-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.gv-btn-sm { padding: 7px 12px; font-size: 12px; gap: 6px; }
+.gv-btn-danger {
+  background: linear-gradient(180deg, rgba(255,118,118,0.18), rgba(255,118,118,0.10));
+  border-color: rgba(255,118,118,0.45);
+  color: #ff7676;
+  font-weight: 700;
+}
+.gv-btn-danger:hover:not(:disabled) {
+  background: linear-gradient(180deg, rgba(255,118,118,0.25), rgba(255,118,118,0.15));
+  border-color: rgba(255,118,118,0.6);
+  box-shadow: 0 0 30px -10px rgba(255,118,118,0.5);
+}
+.gv-btn-primary {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 11px 20px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 13.5px; font-weight: 600;
+  border-radius: 10px;
+  border: 1px solid #f3f4f8;
+  background: linear-gradient(180deg, #ffffff, #e8eaf0);
+  color: #0a0d14;
+  cursor: pointer;
+  transition: transform 180ms, box-shadow 180ms, filter 180ms;
+}
+.gv-btn-primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 30px -8px rgba(255,255,255,0.35), 0 0 30px -10px rgba(90,163,255,0.4);
+}
+.gv-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; filter: saturate(0.6); }
+.gv-arrow { transition: transform 200ms; display: inline-block; }
+.gv-btn-primary:hover:not(:disabled) .gv-arrow { transform: translateX(3px); }
+.gv-mt { margin-top: 16px; }
+
+.gv-link-btn {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  color: #5aa3ff;
+  letter-spacing: 0.05em;
+  background: none; border: none; padding: 0;
+  cursor: pointer;
+  transition: color 160ms;
+}
+.gv-link-btn:hover { color: #88bcff; }
+
+/* KPI strip (Datadog-style: dense, no big numbers cluster) */
+.gv-kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 12px;
+}
+.gv-kpi {
+  position: relative;
+  padding: 16px 18px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.012));
+  overflow: hidden;
+  transition: border-color 200ms;
+}
+.gv-kpi:hover { border-color: rgba(255,255,255,0.20); }
+.gv-kpi::before {
+  content: ""; position: absolute;
+  top: 0; left: 18px; right: 18px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--gv-acc, rgba(255,255,255,0.4)), transparent);
+}
+.gv-kpi[data-tone="red"]    { --gv-acc: #ff7676; }
+.gv-kpi[data-tone="green"]  { --gv-acc: #6ee7a0; }
+.gv-kpi[data-tone="blue"]   { --gv-acc: #5aa3ff; }
+.gv-kpi[data-tone="orange"] { --gv-acc: #ffa53d; }
+.gv-kpi[data-tone="yellow"] { --gv-acc: #f5d061; }
+
+.gv-kpi-head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 12px;
+}
+.gv-kpi-label {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; font-weight: 600;
+  letter-spacing: 0.06em;
+  color: #aeb4c5;
+}
+.gv-kpi-tag {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9.5px; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: #7a8298;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.10);
+}
+.gv-kpi-value {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700;
+  font-size: 28px;
+  letter-spacing: -0.025em;
+  line-height: 1;
+  color: var(--gv-acc, #edf0f6);
+}
+.gv-kpi-value small {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 12px;
+  color: #7a8298;
+  font-weight: 500;
+  margin-left: 4px;
+}
+.gv-kpi-value-text { font-size: 18px; padding-top: 6px; }
+.gv-kpi-foot {
+  margin-top: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  color: #7a8298;
+  letter-spacing: 0.02em;
+}
+
+/* Panel */
+.gv-panel {
+  position: relative;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.008));
+  overflow: hidden;
+}
+.gv-panel-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.012);
+  gap: 12px;
+}
+.gv-panel-title {
+  display: flex; align-items: center; gap: 10px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 13.5px;
+  color: #edf0f6;
+  letter-spacing: -0.005em;
+}
+.gv-panel-ico {
+  width: 26px; height: 26px;
+  border-radius: 7px;
+  display: grid; place-items: center;
+  flex-shrink: 0;
+}
+.gv-panel-ico[data-tone="blue"]   { background: rgba(90,163,255,0.10);  border: 1px solid rgba(90,163,255,0.25);  color: #5aa3ff; }
+.gv-panel-ico[data-tone="red"]    { background: rgba(255,118,118,0.10); border: 1px solid rgba(255,118,118,0.25); color: #ff7676; }
+.gv-panel-ico[data-tone="orange"] { background: rgba(255,165,61,0.10);  border: 1px solid rgba(255,165,61,0.25);  color: #ffa53d; }
+
+.gv-status-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px; font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  padding: 3px 9px;
+  border-radius: 100px;
+  border: 1px solid;
+}
+.gv-status-pill[data-tone="green"] { color: #6ee7a0; border-color: rgba(110,231,160,0.30); background: rgba(110,231,160,0.07); }
+.gv-status-pill[data-tone="red"]   { color: #ff7676; border-color: rgba(255,118,118,0.30); background: rgba(255,118,118,0.07); }
+
+.gv-live {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-left: auto;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px; color: #6ee7a0;
+  letter-spacing: 0.1em; text-transform: uppercase;
+}
+.gv-live-dot {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: #6ee7a0;
+  box-shadow: 0 0 6px #6ee7a0;
+  animation: gv-pulse 1.4s ease-in-out infinite;
+}
+.gv-panel-meta {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; color: #7a8298;
+  letter-spacing: 0.04em;
+}
+
+/* Placeholder (empty Grafana / diagram) */
+.gv-placeholder {
+  padding: 56px 24px;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  text-align: center;
+}
+.gv-placeholder-mark {
+  width: 48px; height: 48px;
+  margin: 0 auto 14px;
+  border-radius: 12px;
+  border: 1px dashed rgba(255,255,255,0.20);
+  display: grid; place-items: center;
+  color: #7a8298;
+}
+.gv-placeholder-mark[data-tone="blue"] {
+  border-color: rgba(90,163,255,0.30);
+  background: rgba(90,163,255,0.05);
+  color: #5aa3ff;
+}
+.gv-placeholder-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 600; font-size: 14px;
+  color: #edf0f6;
+  margin-bottom: 6px;
+  letter-spacing: -0.01em;
+}
+.gv-placeholder-sub {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px; color: #7a8298;
+  letter-spacing: 0.04em;
+}
+
+/* Two-col layout */
+.gv-two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+/* List body */
+.gv-list { display: flex; flex-direction: column; }
+
+/* Drift row */
+.gv-drift-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 18px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  transition: background 140ms;
+}
+.gv-drift-row:last-child { border-bottom: none; }
+.gv-drift-row:hover { background: rgba(255,255,255,0.025); }
+.gv-sev-pill {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9.5px; font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 5px;
+  letter-spacing: 0.08em;
+  flex-shrink: 0;
+  border: 1px solid;
+}
+.gv-sev-pill[data-tone="red"]    { color: #ff7676; border-color: rgba(255,118,118,0.30); background: rgba(255,118,118,0.10); }
+.gv-sev-pill[data-tone="yellow"] { color: #f5d061; border-color: rgba(245,208,97,0.30); background: rgba(245,208,97,0.10); }
+.gv-sev-pill[data-tone="orange"] { color: #ffa53d; border-color: rgba(255,165,61,0.30); background: rgba(255,165,61,0.10); }
+.gv-sev-pill[data-tone="mute"]   { color: #aeb4c5; border-color: rgba(255,255,255,0.13); background: rgba(255,255,255,0.04); }
+.gv-drift-body { flex: 1; min-width: 0; }
+.gv-drift-id {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px; font-weight: 500;
+  color: #edf0f6;
+  letter-spacing: 0.01em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.gv-drift-diff {
+  font-size: 12px;
+  color: #aeb4c5;
+  margin-top: 3px;
+  line-height: 1.4;
+}
+.gv-drift-actions { display: flex; gap: 6px; flex-shrink: 0; }
+.gv-btn-tiny {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  padding: 4px 11px;
+  border-radius: 6px;
+  border: 1px solid;
+  background: rgba(255,255,255,0.03);
+  cursor: pointer;
+  transition: all 140ms;
+  letter-spacing: 0.05em;
+}
+.gv-btn-tiny[data-tone="green"] { color: #6ee7a0; border-color: rgba(110,231,160,0.35); }
+.gv-btn-tiny[data-tone="green"]:hover:not(:disabled) { background: rgba(110,231,160,0.10); border-color: rgba(110,231,160,0.5); }
+.gv-btn-tiny[data-tone="red"]   { color: #ff7676; border-color: rgba(255,118,118,0.35); }
+.gv-btn-tiny[data-tone="red"]:hover:not(:disabled) { background: rgba(255,118,118,0.10); border-color: rgba(255,118,118,0.5); }
+.gv-btn-tiny:disabled { opacity: 0.4; cursor: not-allowed; }
+.gv-drift-resolved {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; color: #7a8298;
+  letter-spacing: 0.04em;
+}
+
+/* Empty */
+.gv-empty {
+  padding: 36px 18px;
+  text-align: center;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px;
+  color: #7a8298;
+  letter-spacing: 0.04em;
+  display: flex; align-items: center; justify-content: center; gap: 10px;
+}
+.gv-empty-check {
+  display: inline-grid; place-items: center;
+  width: 20px; height: 20px;
+  border-radius: 50%;
+  background: rgba(110,231,160,0.15);
+  border: 1px solid rgba(110,231,160,0.35);
+  color: #6ee7a0;
+  font-weight: 700;
+}
+
+.gv-panel-foot {
+  padding: 12px 18px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+  text-align: center;
+  background: rgba(255,255,255,0.012);
+}
+
+/* Audit row */
+.gv-audit-row {
+  display: flex; gap: 14px;
+  padding: 13px 18px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  transition: background 140ms;
+}
+.gv-audit-row:last-child { border-bottom: none; }
+.gv-audit-row:hover { background: rgba(255,255,255,0.025); }
+.gv-audit-dot {
+  flex-shrink: 0;
+  width: 8px; height: 8px; border-radius: 50%;
+  margin-top: 6px;
+}
+.gv-audit-dot[data-tone="blue"]   { background: #5aa3ff; box-shadow: 0 0 8px #5aa3ff; }
+.gv-audit-dot[data-tone="orange"] { background: #ffa53d; box-shadow: 0 0 8px #ffa53d; }
+.gv-audit-dot[data-tone="red"]    { background: #ff7676; box-shadow: 0 0 8px #ff7676; }
+.gv-audit-body { flex: 1; min-width: 0; }
+.gv-audit-line {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 4px;
+}
+.gv-layer-chip {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9.5px; font-weight: 600;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 4px;
+  border: 1px solid;
+}
+.gv-layer-chip[data-tone="blue"]   { color: #5aa3ff; border-color: rgba(90,163,255,0.30);  background: rgba(90,163,255,0.08); }
+.gv-layer-chip[data-tone="orange"] { color: #ffa53d; border-color: rgba(255,165,61,0.30);  background: rgba(255,165,61,0.08); }
+.gv-layer-chip[data-tone="red"]    { color: #ff7676; border-color: rgba(255,118,118,0.30); background: rgba(255,118,118,0.08); }
+.gv-audit-action {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: #edf0f6;
+}
+.gv-audit-meta {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  color: #7a8298;
+  letter-spacing: 0.04em;
+  display: flex; align-items: center; gap: 8px;
+}
+.gv-dot-sep {
+  width: 2px; height: 2px; border-radius: 50%;
+  background: #4b5267;
+}
+
+/* Diagram wrap */
+.gv-diagram-wrap {
+  padding: 20px 24px;
+  background: rgba(0,0,0,0.15);
+}
+
+@media (max-width: 1280px) {
+  .gv-kpi-strip { grid-template-columns: repeat(3, 1fr); }
+}
+@media (max-width: 900px) {
+  .gv-page { padding: 28px 20px 60px; }
+  .gv-topbar { padding: 14px 20px; }
+  .gv-top-left .gv-crumb-sep, .gv-top-left .gv-crumb-proj { display: none; }
+  .gv-title { font-size: 26px; }
+  .gv-two-col { grid-template-columns: 1fr; }
+  .gv-kpi-strip { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 520px) {
+  .gv-kpi-strip { grid-template-columns: 1fr; }
+}
+`

--- a/frontend/app/projects/[id]/page.tsx
+++ b/frontend/app/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { apiClient } from '@/lib/api'
 import dynamic from 'next/dynamic'
+import InfraMetrics from '@/components/InfraMetrics'
 
 const ArchitectureDiagram = dynamic<{ mermaidCode: string }>(
   () => import('@/components/ArchitectureDiagram'),
@@ -68,8 +69,6 @@ const ACTION_LABEL: Record<string, string> = {
   validation_blocked_tfsec:   'tfsec 차단',
   validation_blocked_checkov: 'checkov 차단',
 }
-
-const GRAFANA_URL = process.env.NEXT_PUBLIC_GRAFANA_URL || ''
 
 // ─── 메인 컴포넌트 ────────────────────────────────────────────────
 export default function GovernancePage() {
@@ -236,7 +235,7 @@ export default function GovernancePage() {
           </div>
         </div>
 
-        {/* ── KPI strip (Datadog style) ── */}
+        {/* ── KPI strip ── */}
         <div className="gv-kpi-strip">
           <div className="gv-kpi">
             <div className="gv-kpi-head">
@@ -307,61 +306,30 @@ export default function GovernancePage() {
           </div>
         </div>
 
-        {/* ── Grafana panel ── */}
+        {/* ── 인프라 모니터링 (CloudWatch) ── */}
         <div className="gv-panel">
           <div className="gv-panel-head">
             <div className="gv-panel-title">
               <span className="gv-panel-ico" data-tone="blue">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-                  <path d="M3 3v18h18"/>
-                  <path d="m19 9-5 5-4-4-3 3"/>
+                  <path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/>
                 </svg>
               </span>
               <span>인프라 모니터링</span>
-              {GRAFANA_URL && (
+              {project.status === 'completed' && (
                 <span className="gv-status-pill" data-tone="green">
                   <span className="gv-pip gv-pip-green" />
-                  Grafana 연결됨
+                  CloudWatch Live
                 </span>
               )}
             </div>
-            {GRAFANA_URL && (
-              <button
-                className="gv-btn gv-btn-sm"
-                onClick={() => window.open(`${GRAFANA_URL}/d/autoops-infra?orgId=1`, '_blank')}
-              >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-                  <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/>
-                  <polyline points="15 3 21 3 21 9"/>
-                  <line x1="10" y1="14" x2="21" y2="3"/>
-                </svg>
-                전체 화면
-              </button>
-            )}
           </div>
-          {GRAFANA_URL ? (
-            <iframe
-              src={`${GRAFANA_URL}/d/autoops-infra/infra-health?orgId=1&theme=dark&kiosk`}
-              width="100%"
-              height="320"
-              style={{ border: 'none', display: 'block' }}
-              title="Grafana 인프라 헬스"
-            />
-          ) : (
-            <div className="gv-placeholder">
-              <div className="gv-placeholder-mark">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
-                  <path d="M3 3v18h18"/>
-                  <path d="m19 9-5 5-4-4-3 3"/>
-                </svg>
-              </div>
-              <div className="gv-placeholder-title">Grafana Deployment Pending</div>
-              <div className="gv-placeholder-sub">섹션 11 완료 후 메트릭 패널이 표시됩니다</div>
-            </div>
-          )}
+          <div style={{ padding: '20px' }}>
+            <InfraMetrics projectId={projectId} />
+          </div>
         </div>
 
-        {/* ── Drift + Audit (Datadog-style 2-col) ── */}
+        {/* ── Drift + Audit (2-col) ── */}
         <div className="gv-two-col">
 
           {/* Drift */}
@@ -847,7 +815,7 @@ body::before {
 }
 .gv-link-btn:hover { color: #88bcff; }
 
-/* KPI strip (Datadog-style: dense, no big numbers cluster) */
+/* KPI strip */
 .gv-kpi-strip {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
@@ -874,6 +842,7 @@ body::before {
 .gv-kpi[data-tone="blue"]   { --gv-acc: #5aa3ff; }
 .gv-kpi[data-tone="orange"] { --gv-acc: #ffa53d; }
 .gv-kpi[data-tone="yellow"] { --gv-acc: #f5d061; }
+.gv-kpi[data-tone="mute"]   { --gv-acc: rgba(255,255,255,0.15); }
 
 .gv-kpi-head {
   display: flex; align-items: center; justify-content: space-between;
@@ -983,7 +952,7 @@ body::before {
   letter-spacing: 0.04em;
 }
 
-/* Placeholder (empty Grafana / diagram) */
+/* Placeholder */
 .gv-placeholder {
   padding: 56px 24px;
   display: flex; flex-direction: column;

--- a/frontend/app/projects/[id]/validate/page.tsx
+++ b/frontend/app/projects/[id]/validate/page.tsx
@@ -53,14 +53,25 @@ export default function ValidatePage() {
       })
       setResult(res.data.data)
     } catch (err: unknown) {
-      const errData = (
-        err as { response?: { data?: { error?: { code?: string; message?: string; details?: ErrorDetails } } } }
-      )?.response?.data?.error
-      setError({
-        code:    errData?.code    || 'UNKNOWN',
-        message: errData?.message || 'Validation에 실패했습니다.',
-        details: errData?.details,
-      })
+      const axiosErr = err as {
+        response?: { status?: number; data?: { error?: { code?: string; message?: string; details?: ErrorDetails } } }
+        code?: string
+      }
+
+      if (axiosErr?.response?.status === 504 || axiosErr?.code === 'ECONNABORTED') {
+        setError({
+          code:    'TIMEOUT',
+          message: '요청 시간이 초과됐습니다. 다시 시도해 주세요.\n(tfsec · checkov · infracost 분석에 시간이 걸릴 수 있습니다)',
+          details: undefined,
+        })
+      } else {
+        const errData = axiosErr?.response?.data?.error
+        setError({
+          code:    errData?.code    || 'UNKNOWN',
+          message: errData?.message || 'Validation에 실패했습니다.',
+          details: errData?.details,
+        })
+      }
     } finally {
       setIsValidating(false)
     }
@@ -270,12 +281,18 @@ export default function ValidatePage() {
             <div className="vp-alert-head">
               <span className="vp-alert-ico">!</span>
               <div>
-                <div className="vp-alert-title">검증 실패</div>
-                <div className="vp-alert-msg">{error.message}</div>
+                <div className="vp-alert-title">
+                  {error.code === 'TIMEOUT' ? '⏱ 응답 시간 초과' : '검증 실패'}
+                </div>
+                <div className="vp-alert-msg" style={{ whiteSpace: 'pre-line' }}>
+                  {error.message}
+                </div>
               </div>
             </div>
             <div className="vp-alert-actions">
-              <button className="vp-btn-secondary" onClick={handleValidate}>다시 시도</button>
+              <button className="vp-btn-secondary" onClick={() => { setError(null); handleValidate() }}>
+                다시 시도
+              </button>
             </div>
           </div>
         )}

--- a/frontend/components/ArchitectureDiagram.tsx
+++ b/frontend/components/ArchitectureDiagram.tsx
@@ -1,0 +1,52 @@
+// frontend/components/ArchitectureDiagram.tsx
+'use client'
+
+import { useEffect, useRef } from 'react'
+import mermaid from 'mermaid'
+
+interface Props {
+  mermaidCode: string
+}
+
+export default function ArchitectureDiagram({ mermaidCode }: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    mermaid.initialize({
+      startOnLoad:    false,
+      theme:          'dark',
+      themeVariables: {
+        background:     '#0b0e17',
+        primaryColor:   '#ffa53d',
+        secondaryColor: '#1a2035',
+        tertiaryColor:  '#151a27',
+        lineColor:      '#7a8298',
+        textColor:      '#edf0f6',
+      },
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!ref.current || !mermaidCode) return
+
+    ref.current.innerHTML = ''
+    const id  = `mermaid-${Date.now()}`
+    const div = document.createElement('div')
+    div.id          = id
+    div.className   = 'mermaid'
+    div.textContent = mermaidCode
+    ref.current.appendChild(div)
+
+    mermaid.run({ nodes: [div] }).catch(console.error)
+  }, [mermaidCode])
+
+  if (!mermaidCode) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '80px', color: 'var(--dx-ink-mute)', fontSize: '12px', fontFamily: 'var(--dx-mono)' }}>
+        다이어그램 데이터 없음
+      </div>
+    )
+  }
+
+  return <div ref={ref} style={{ width: '100%', overflowX: 'auto', padding: '8px 0' }} />
+}

--- a/frontend/components/InfraMetrics.tsx
+++ b/frontend/components/InfraMetrics.tsx
@@ -1,0 +1,413 @@
+// frontend/components/InfraMetrics.tsx
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { apiClient } from '@/lib/api'
+import {
+  LineChart, Line, AreaChart, Area,
+  XAxis, YAxis, CartesianGrid, Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+
+type Period = '1h' | '6h' | '24h' | '7d'
+
+interface DataPoint {
+  timestamp: string
+  value: number
+}
+
+interface MetricsData {
+  project_id: string
+  period: Period
+  region: string
+  resources: {
+    ecs_cluster?: string
+    ecs_service?: string
+    alb?: string
+    rds?: string
+  }
+  metrics: {
+    ecs?: { cpu: DataPoint[]; memory: DataPoint[] }
+    alb?: { request_count: DataPoint[]; response_time: DataPoint[]; error_5xx: DataPoint[] }
+    rds?: { cpu: DataPoint[]; connections: DataPoint[]; storage_free_gb: DataPoint[] }
+  }
+  message?: string
+}
+
+interface Props {
+  projectId: string
+}
+
+const PERIODS: { value: Period; label: string }[] = [
+  { value: '1h',  label: '1시간' },
+  { value: '6h',  label: '6시간' },
+  { value: '24h', label: '24시간' },
+  { value: '7d',  label: '7일' },
+]
+
+function formatTimestamp(ts: string, period: Period): string {
+  const d = new Date(ts)
+  if (period === '1h' || period === '6h') {
+    return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+  }
+  if (period === '24h') {
+    return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+  }
+  return d.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric', hour: '2-digit' })
+}
+
+function toChartData(series: DataPoint[], period: Period, key: string) {
+  return series.map(p => ({
+    time: formatTimestamp(p.timestamp, period),
+    [key]: p.value,
+  }))
+}
+
+function MetricPanel({
+  title,
+  subtitle,
+  children,
+  isEmpty,
+}: {
+  title: string
+  subtitle?: string
+  children: React.ReactNode
+  isEmpty?: boolean
+}) {
+  return (
+    <div style={{
+      background: '#13151f',
+      border: '1px solid rgba(255,255,255,0.08)',
+      borderRadius: '10px',
+      padding: '16px',
+    }}>
+      <div style={{ marginBottom: '12px' }}>
+        <span style={{ color: '#edf0f6', fontSize: '13px', fontWeight: 600 }}>{title}</span>
+        {subtitle && (
+          <span style={{ color: '#475569', fontSize: '11px', marginLeft: '6px' }}>{subtitle}</span>
+        )}
+      </div>
+      {isEmpty ? (
+        <div style={{
+          height: '150px',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: '#475569', fontSize: '12px',
+          fontFamily: "'JetBrains Mono', monospace",
+        }}>
+          데이터 없음
+        </div>
+      ) : children}
+    </div>
+  )
+}
+
+export default function InfraMetrics({ projectId }: Props) {
+  const [period, setPeriod]   = useState<Period>('1h')
+  const [data, setData]       = useState<MetricsData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError]     = useState<string | null>(null)
+
+  const fetchMetrics = useCallback(async (p: Period) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await apiClient.get(
+        `/api/projects/${projectId}/metrics?period=${p}`
+      )
+      setData(res.data)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : '조회 실패')
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => { fetchMetrics(period) }, [period, fetchMetrics])
+
+  const C = {
+    cpu:        '#6366f1',
+    memory:     '#22d3ee',
+    requests:   '#10b981',
+    respTime:   '#f59e0b',
+    error5xx:   '#ef4444',
+    connections:'#a78bfa',
+    storage:    '#34d399',
+  }
+
+  const tooltipStyle = {
+    backgroundColor: '#1e1e2e',
+    border: '1px solid rgba(255,255,255,0.1)',
+    borderRadius: '8px',
+    color: '#e2e8f0',
+    fontSize: '12px',
+  }
+
+  const fmt = (fn: (n: number) => [string, string]) => (v: any): [string, string] => {
+    const n = typeof v === 'number' ? v : 0
+    return fn(n)
+  }
+
+  const sectionLabel = (text: string) => (
+    <div style={{
+      color: '#64748b',
+      fontSize: '11px',
+      fontWeight: 600,
+      textTransform: 'uppercase' as const,
+      letterSpacing: '0.08em',
+      marginBottom: '10px',
+      fontFamily: "'JetBrains Mono', monospace",
+    }}>
+      {text}
+    </div>
+  )
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+
+      {/* 기간 선택 + 새로고침 */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{
+          color: '#64748b', fontSize: '12px',
+          fontFamily: "'JetBrains Mono', monospace",
+        }}>
+          {data?.resources?.ecs_cluster && (
+            <span>
+              cluster: <span style={{ color: '#94a3b8' }}>{data.resources.ecs_cluster}</span>
+            </span>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+          {PERIODS.map(({ value, label }) => (
+            <button
+              key={value}
+              onClick={() => setPeriod(value)}
+              style={{
+                padding: '5px 12px',
+                borderRadius: '7px',
+                border: period === value
+                  ? '1px solid rgba(99,102,241,0.6)'
+                  : '1px solid rgba(255,255,255,0.08)',
+                background: period === value
+                  ? 'rgba(99,102,241,0.12)'
+                  : 'transparent',
+                color: period === value ? '#818cf8' : '#475569',
+                fontSize: '12px',
+                cursor: 'pointer',
+                fontFamily: "'JetBrains Mono', monospace",
+                transition: 'all 150ms',
+              }}
+            >
+              {label}
+            </button>
+          ))}
+          <button
+            onClick={() => fetchMetrics(period)}
+            disabled={loading}
+            style={{
+              padding: '5px 12px',
+              borderRadius: '7px',
+              border: '1px solid rgba(255,255,255,0.08)',
+              background: 'transparent',
+              color: '#475569',
+              fontSize: '12px',
+              cursor: loading ? 'not-allowed' : 'pointer',
+              fontFamily: "'JetBrains Mono', monospace",
+            }}
+          >
+            {loading ? '...' : '↻'}
+          </button>
+        </div>
+      </div>
+
+      {/* 에러 */}
+      {error && (
+        <div style={{
+          padding: '10px 14px',
+          borderRadius: '8px',
+          background: 'rgba(239,68,68,0.08)',
+          border: '1px solid rgba(239,68,68,0.25)',
+          color: '#fca5a5',
+          fontSize: '12px',
+          fontFamily: "'JetBrains Mono', monospace",
+        }}>
+          {error}
+        </div>
+      )}
+
+      {/* 메시지 */}
+      {data?.message && (
+        <div style={{
+          padding: '10px 14px',
+          borderRadius: '8px',
+          background: 'rgba(99,102,241,0.06)',
+          border: '1px solid rgba(99,102,241,0.18)',
+          color: '#a5b4fc',
+          fontSize: '12px',
+          fontFamily: "'JetBrains Mono', monospace",
+        }}>
+          {data.message}
+        </div>
+      )}
+
+      {/* ── ECS ── */}
+      {data?.resources?.ecs_cluster && (
+        <div>
+          {sectionLabel(`ECS · ${data.resources.ecs_service || ''}`)}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+
+            <MetricPanel title="CPU 사용률" subtitle="%" isEmpty={!data.metrics.ecs?.cpu?.length}>
+              <ResponsiveContainer width="100%" height={150}>
+                <AreaChart data={toChartData(data.metrics.ecs!.cpu, period, 'v')}>
+                  <defs>
+                    <linearGradient id="gc1" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%"  stopColor={C.cpu} stopOpacity={0.25} />
+                      <stop offset="95%" stopColor={C.cpu} stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
+                  <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
+                  <YAxis domain={[0, 100]} tick={{ fill: '#334155', fontSize: 10 }} />
+                  <Tooltip contentStyle={tooltipStyle} formatter={fmt(n => [`${n.toFixed(1)}%`, 'CPU'])} />
+                  <Area type="monotone" dataKey="v" stroke={C.cpu} fill="url(#gc1)" strokeWidth={2} dot={false} />
+                </AreaChart>
+              </ResponsiveContainer>
+            </MetricPanel>
+
+            <MetricPanel title="Memory 사용률" subtitle="%" isEmpty={!data.metrics.ecs?.memory?.length}>
+              <ResponsiveContainer width="100%" height={150}>
+                <AreaChart data={toChartData(data.metrics.ecs!.memory, period, 'v')}>
+                  <defs>
+                    <linearGradient id="gc2" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%"  stopColor={C.memory} stopOpacity={0.25} />
+                      <stop offset="95%" stopColor={C.memory} stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
+                  <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
+                  <YAxis domain={[0, 100]} tick={{ fill: '#334155', fontSize: 10 }} />
+                  <Tooltip contentStyle={tooltipStyle} formatter={fmt(n => [`${n.toFixed(1)}%`, 'Memory'])} />
+                  <Area type="monotone" dataKey="v" stroke={C.memory} fill="url(#gc2)" strokeWidth={2} dot={false} />
+                </AreaChart>
+              </ResponsiveContainer>
+            </MetricPanel>
+          </div>
+        </div>
+      )}
+
+      {/* ── ALB ── */}
+      {data?.resources?.alb && (
+        <div>
+          {sectionLabel('ALB')}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '12px' }}>
+
+            <MetricPanel title="요청 수" subtitle="건/구간" isEmpty={!data.metrics.alb?.request_count?.length}>
+              <ResponsiveContainer width="100%" height={150}>
+                <LineChart data={toChartData(data.metrics.alb!.request_count, period, 'v')}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
+                  <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
+                  <YAxis tick={{ fill: '#334155', fontSize: 10 }} />
+                  <Tooltip contentStyle={tooltipStyle} formatter={fmt(n => [`${n}건`, '요청'])} />
+                  <Line type="monotone" dataKey="v" stroke={C.requests} strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </MetricPanel>
+
+            <MetricPanel title="응답 시간" subtitle="ms" isEmpty={!data.metrics.alb?.response_time?.length}>
+              <ResponsiveContainer width="100%" height={150}>
+                <LineChart data={toChartData(data.metrics.alb!.response_time, period, 'v')}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
+                  <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
+                  <YAxis tick={{ fill: '#334155', fontSize: 10 }} />
+                  <Tooltip contentStyle={tooltipStyle} formatter={fmt(n => [`${(n * 1000).toFixed(0)}ms`, '응답'])} />
+                  <Line type="monotone" dataKey="v" stroke={C.respTime} strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </MetricPanel>
+
+            <MetricPanel title="5xx 에러" subtitle="건/구간" isEmpty={!data.metrics.alb?.error_5xx?.length}>
+              <ResponsiveContainer width="100%" height={150}>
+                <LineChart data={toChartData(data.metrics.alb!.error_5xx, period, 'v')}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
+                  <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
+                  <YAxis tick={{ fill: '#334155', fontSize: 10 }} />
+                  <Tooltip contentStyle={tooltipStyle} formatter={fmt(n => [`${n}건`, '5xx'])} />
+                  <Line type="monotone" dataKey="v" stroke={C.error5xx} strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </MetricPanel>
+          </div>
+        </div>
+      )}
+
+      {/* ── RDS ── */}
+      {data?.resources?.rds && (
+        <div>
+          {sectionLabel(`RDS · ${data.resources.rds}`)}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '12px' }}>
+
+            <MetricPanel title="CPU 사용률" subtitle="%" isEmpty={!data.metrics.rds?.cpu?.length}>
+              <ResponsiveContainer width="100%" height={150}>
+                <AreaChart data={toChartData(data.metrics.rds!.cpu, period, 'v')}>
+                  <defs>
+                    <linearGradient id="gc3" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%"  stopColor={C.cpu} stopOpacity={0.25} />
+                      <stop offset="95%" stopColor={C.cpu} stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
+                  <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
+                  <YAxis domain={[0, 100]} tick={{ fill: '#334155', fontSize: 10 }} />
+                  <Tooltip contentStyle={tooltipStyle} formatter={fmt(n => [`${n.toFixed(1)}%`, 'CPU'])} />
+                  <Area type="monotone" dataKey="v" stroke={C.cpu} fill="url(#gc3)" strokeWidth={2} dot={false} />
+                </AreaChart>
+              </ResponsiveContainer>
+            </MetricPanel>
+
+            <MetricPanel title="DB 커넥션" subtitle="개" isEmpty={!data.metrics.rds?.connections?.length}>
+              <ResponsiveContainer width="100%" height={150}>
+                <LineChart data={toChartData(data.metrics.rds!.connections, period, 'v')}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
+                  <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
+                  <YAxis tick={{ fill: '#334155', fontSize: 10 }} />
+                  <Tooltip contentStyle={tooltipStyle} formatter={fmt(n => [`${n.toFixed(0)}개`, '커넥션'])} />
+                  <Line type="monotone" dataKey="v" stroke={C.connections} strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </MetricPanel>
+
+            <MetricPanel title="여유 스토리지" subtitle="GB" isEmpty={!data.metrics.rds?.storage_free_gb?.length}>
+              <ResponsiveContainer width="100%" height={150}>
+                <AreaChart data={toChartData(data.metrics.rds!.storage_free_gb, period, 'v')}>
+                  <defs>
+                    <linearGradient id="gc4" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%"  stopColor={C.storage} stopOpacity={0.25} />
+                      <stop offset="95%" stopColor={C.storage} stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
+                  <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
+                  <YAxis tick={{ fill: '#334155', fontSize: 10 }} />
+                  <Tooltip contentStyle={tooltipStyle} formatter={fmt(n => [`${n.toFixed(1)}GB`, '여유'])} />
+                  <Area type="monotone" dataKey="v" stroke={C.storage} fill="url(#gc4)" strokeWidth={2} dot={false} />
+                </AreaChart>
+              </ResponsiveContainer>
+            </MetricPanel>
+          </div>
+        </div>
+      )}
+
+      {/* 배포 전 안내 */}
+      {!loading && !error && !data?.resources?.ecs_cluster && !data?.resources?.alb && !data?.resources?.rds && (
+        <div style={{
+          padding: '40px 20px',
+          textAlign: 'center',
+          color: '#334155',
+          fontSize: '13px',
+          fontFamily: "'JetBrains Mono', monospace",
+        }}>
+          배포 완료 후 모니터링이 활성화됩니다
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
+        "mermaid": "^11.15.0",
         "next": "16.2.4",
         "radix-ui": "^1.4.3",
         "react": "19.2.4",
@@ -46,6 +47,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -424,6 +437,16 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.61.5",
@@ -884,6 +907,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@img/colour": {
@@ -1442,6 +1480,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -3593,11 +3639,238 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3649,6 +3922,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
@@ -4183,6 +4462,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -4966,6 +5254,14 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -5020,6 +5316,482 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.4",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.4.tgz",
+      "integrity": "sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5085,6 +5857,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5200,6 +5977,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5248,6 +6033,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -5507,6 +6300,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw=="
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -6593,6 +7391,11 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6786,6 +7589,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6812,6 +7624,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -7497,6 +8317,29 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7505,6 +8348,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -7531,6 +8379,11 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -7814,6 +8667,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7894,6 +8752,17 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7932,6 +8801,34 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromatch": {
@@ -8561,6 +9458,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8613,6 +9515,11 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8663,6 +9570,20 @@
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -9186,6 +10107,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -9242,6 +10179,11 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
@@ -9924,6 +10866,11 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9991,6 +10938,14 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -10093,6 +11048,14 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-morph": {
@@ -10473,6 +11436,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-hook-form": "^7.73.1",
+        "recharts": "^3.8.1",
         "shadcn": "^4.4.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
@@ -3250,6 +3251,40 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3271,6 +3306,16 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -3928,6 +3973,11 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "optional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
@@ -5879,6 +5929,11 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
+    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -6737,6 +6792,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -7572,6 +7632,15 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -9896,8 +9965,29 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -9980,6 +10070,45 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -10037,6 +10166,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -11463,6 +11597,27 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
+    "mermaid": "^11.15.0",
     "next": "16.2.4",
     "radix-ui": "^1.4.3",
     "react": "19.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.73.1",
+    "recharts": "^3.8.1",
     "shadcn": "^4.4.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/infra/build-frontend.sh
+++ b/infra/build-frontend.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# infra/build-frontend.sh
+
+# ECR 로그인
+aws ecr get-login-password --region us-west-2 | \
+  docker login --username AWS --password-stdin 611058323802.dkr.ecr.us-west-2.amazonaws.com
+
+# 프론트엔드 빌드 & 푸시
+docker buildx build \
+  --platform linux/amd64 \
+  --no-cache \
+  --push \
+  --build-arg NEXT_PUBLIC_API_URL=https://d1zl418y69bnx0.cloudfront.net \
+  --build-arg NEXT_PUBLIC_WS_URL=wss://d1zl418y69bnx0.cloudfront.net \
+  -t 611058323802.dkr.ecr.us-west-2.amazonaws.com/autoops-frontend:latest \
+  ~/project/AOps/msp-team01/frontend
+
+echo "✅ 프론트엔드 빌드 완료"

--- a/infra/start.sh
+++ b/infra/start.sh
@@ -37,4 +37,9 @@ aws ecs update-service \
   --region us-west-2 > /dev/null
 echo "✅ 프론트엔드 ECS Service 시작"
 
+aws ecs update-service --cluster autoops-cluster --service autoops-grafana-service    --desired-count 1 --region us-west-2 > /dev/null
+aws ecs update-service --cluster autoops-cluster --service autoops-prometheus-service --desired-count 1 --region us-west-2 > /dev/null
+aws ecs update-service --cluster autoops-cluster --service autoops-yace-service       --desired-count 1 --region us-west-2 > /dev/null
+echo "✅ Grafana + Prometheus + YACE 시작"
+
 echo "🚀 AutoOps 플랫폼 인프라 시작 완료"


### PR DESCRIPTION
[섹션 2] DB 스키마 확장
- governance 테이블 5개 추가 (onboarding_scans, resource_baselines, drift_events, audit_logs, project_documents)
- projects.source 컬럼 추가
- Alembic 마이그레이션 완료

[섹션 3] SQS + EventBridge
- autoops-drift-events SQS 큐 생성
- autoops-drift-detection EventBridge 룰 생성
- AutoOpsTaskRole DriftSQS 권한 추가

[섹션 4-6] 온보딩 + Drift Worker + Drift API
- onboarding.py 신규 (scan/status/confirm)
- drift_worker.py 신규 (감지 + 심각도 분류 + Slack 알림)
- drift.py 신규 (list/approve/reject)

[섹션 7] 프론트엔드 온보딩 + 대시보드
- onboarding/page.tsx 신규
- dashboard/page.tsx drift 배지 + 라우팅 수정

[섹션 8] Audit Log BE
- audit_logger.py 신규 (3레이어)
- audit.py API 신규
- craft.py / projects.py / mirror.py / onboarding.py audit log 연동

[섹션 9] 거버넌스 통합 허브
- projects/[id]/page.tsx 전면 재구현
- projects/[id]/drift/page.tsx 신규
- projects/[id]/audit/page.tsx 신규

[섹션 10] 리소스 그룹 API
- resources.py 신규 (GET /api/projects/{id}/resources)

[섹션 11] CloudWatch 인프라 모니터링 (v2 — Prometheus/Grafana 폐기)
- metrics.py 신규 (CloudWatch API 직접 조회)
- AutoOpsMonitoringPolicy IAM 권한 추가
- InfraMetrics.tsx 신규 (recharts ECS/ALB/RDS 차트)
- build-frontend.sh Grafana IP 블록 제거
- main.py prometheus_client 코드 전부 제거

[섹션 12] 아키텍처 다이어그램 + 백엔드 보완
- bedrock_client.py generate_architecture_diagram() 추가
  (모델: anthropic.claude-sonnet-4-20250514-v1:0)
- diagram.py 신규 (aws_resources 테이블 기반 조회)
- ArchitectureDiagram.tsx 신규 (mermaid@11)
- craft.py _run_detect_all 추가 (배포 완료 후 리소스 자동 감지)
- projects/[id]/page.tsx InfraMetrics 컴포넌트 임베드

[버그 수정]
- detector.py startswith 대소문자 버그 수정 (lower() 추가)
- metrics.py find_res RDS DBSubnetGroup 오감지 방지
- bedrock_client.py mermaid 파싱 실패 시 로그 추가
- validate/page.tsx 504 타임아웃 처리 + 재시도 버튼 추가
- main.py metrics alias 충돌 수정 (metrics_router)
- main.py AWSAccount import 경로 수정