### PR TITLE
fix(epic9): rds cloudwatch metrics + diagram model + resource count +…

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -37,6 +37,9 @@ class ConfirmRequest(BaseModel):
     email: str
     code: str
 
+class UpdateMeRequest(BaseModel):
+    slack_webhook_url: str = None
+
 
 @router.post("/login")
 def login(request: LoginRequest, db: Session = Depends(get_db)):
@@ -223,5 +226,24 @@ def get_me(
             "user_id":  current_user.user_id,
             "email":    current_user.email,
             "name":     current_user.name,
+        },
+    }
+
+@router.patch("/me")
+def update_me(
+    request: UpdateMeRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if request.slack_webhook_url is not None:
+        current_user.slack_webhook_url = request.slack_webhook_url
+        db.commit()
+    return {
+        "success": True,
+        "data": {
+            "user_id":           current_user.user_id,
+            "email":             current_user.email,
+            "name":              current_user.name,
+            "slack_webhook_url": current_user.slack_webhook_url,
         },
     }

--- a/backend/app/api/craft.py
+++ b/backend/app/api/craft.py
@@ -898,9 +898,10 @@ def _run_detect_all(project_id: str, role_arn: str, external_id: str, prefix: st
     from app.services.mirrorops.detector import ResourceDetector
     from app.models.aws_resource import AWSResource
     from app.models.project import Project
+    from app.models.governance import ResourceBaseline
+    import uuid
     db = SessionLocal()
     try:
-        # GCP 연동 프로젝트는 pipeline.run()에서 처리하므로 스킵
         project = db.query(Project).filter(
             Project.project_id == project_id
         ).first()
@@ -915,8 +916,29 @@ def _run_detect_all(project_id: str, role_arn: str, external_id: str, prefix: st
         db.commit()
 
         detector = ResourceDetector(role_arn=role_arn, region=region, external_id=external_id)
-        detector.detect_all(project_id=project_id, prefix=prefix, environment=environment, db=db)
+        detected = detector.detect_all(project_id=project_id, prefix=prefix, environment=environment, db=db)
         print(f"[CraftOps] 리소스 감지 완료: project_id={project_id}")
+
+        # ── Baseline 등록 (기존 삭제 후 재등록) ──────────────────────
+        db.query(ResourceBaseline).filter(
+            ResourceBaseline.project_id == project_id,
+            ResourceBaseline.source     == "craftops_deploy",
+        ).delete(synchronize_session=False)
+        db.commit()
+
+        for res in detected:
+            baseline = ResourceBaseline(
+                id              = str(uuid.uuid4()),
+                project_id      = project_id,
+                source          = "craftops_deploy",
+                resource_type   = res.resource_type,
+                resource_id_aws = res.resource_id_aws,
+                baseline_config = res.config_json,
+            )
+            db.add(baseline)
+        db.commit()
+        print(f"[CraftOps] Baseline 등록 완료: {len(detected)}개")
+
     except Exception as e:
         print(f"[CraftOps] 리소스 감지 실패: {e}")
     finally:

--- a/backend/app/api/metrics.py
+++ b/backend/app/api/metrics.py
@@ -261,7 +261,7 @@ async def get_project_metrics(
     ecs_cluster_name = ecs_cluster_res.resource_name if ecs_cluster_res else None
     ecs_service_name = ecs_service_res.resource_name if ecs_service_res else None
     alb_arn          = alb_res.resource_id_aws        if alb_res         else None
-    rds_identifier   = rds_res.resource_name          if rds_res         else None
+    rds_identifier   = rds_res.resource_name.lower() if rds_res         else None
     alb_dimension    = _extract_alb_dimension(alb_arn) if alb_arn        else None
 
     cw_resources = {

--- a/backend/app/services/mirrorops/bedrock_client.py
+++ b/backend/app/services/mirrorops/bedrock_client.py
@@ -199,7 +199,7 @@ AWS 설정:
         })
 
         response = self.client.invoke_model(
-            modelId     = "anthropic.claude-sonnet-4-20250514-v1:0",
+            modelId     = "us.anthropic.claude-sonnet-4-20250514-v1:0",
             body        = body,
             contentType = "application/json",
             accept      = "application/json",

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -161,13 +161,13 @@ export default function DashboardPage() {
   }, [projects, filter])
 
   // formatted "now"
-  const nowText = useMemo(() => {
-    const d = new Date()
+  const [nowText, setNowText] = useState('')
+  useEffect(() => {
     const fmt = new Intl.DateTimeFormat('ko-KR', {
       year: 'numeric', month: '2-digit', day: '2-digit',
       hour: '2-digit', minute: '2-digit', hour12: false,
-    }).format(d)
-    return `${fmt} KST`
+    }).format(new Date())
+    setNowText(`${fmt} KST`)
   }, [])
 
   return (

--- a/frontend/app/projects/[id]/page.tsx
+++ b/frontend/app/projects/[id]/page.tsx
@@ -84,6 +84,10 @@ export default function GovernancePage() {
   const [actionId, setActionId]    = useState<string | null>(null)
   const [regenerating, setRegen]   = useState(false)
   const [loading, setLoading]      = useState(true)
+  const [slackModal, setSlackModal]   = useState(false)
+  const [slackUrl, setSlackUrl]       = useState('')
+  const [slackSaving, setSlackSaving] = useState(false)
+  const parseUTC = (s: string) => new Date(s.endsWith('Z') ? s : s + 'Z')
 
   const fetchAll = useCallback(async () => {
     try {
@@ -96,10 +100,7 @@ export default function GovernancePage() {
       setDrift(driftRes.data.data.slice(0, 5))
       setTotalDriftAll(driftRes.data.data.length)
       setAudit(auditRes.data.data.items?.slice(0, 5) || [])
-
-      apiClient.get(`/api/projects/${projectId}/resources`)
-        .then(res => setTotal(res.data.data?.total_resources || 0))
-        .catch(() => {})
+      setTotal(projRes.data.data?.aws_resource_count || 0)
 
       apiClient.get(`/api/projects/${projectId}/documents`)
         .then(res => setDiagram(res.data.data))
@@ -148,6 +149,16 @@ export default function GovernancePage() {
       await apiClient.post(`/api/projects/${projectId}/documents/regenerate`)
       setTimeout(() => { fetchAll(); setRegen(false) }, 120_000)
     } catch { setRegen(false) }
+  }
+
+  const handleSlackSave = async () => {
+    setSlackSaving(true)
+    try {
+      await apiClient.patch('/api/auth/me', { slack_webhook_url: slackUrl })
+      setSlackModal(false)
+    } finally {
+      setSlackSaving(false)
+    }
   }
 
   if (loading) {
@@ -215,6 +226,19 @@ export default function GovernancePage() {
             </div>
           </div>
           <div className="gv-head-actions">
+            <button className="gv-btn" onClick={() => setSlackModal(true)}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path d="M14.5 10c-.83 0-1.5-.67-1.5-1.5v-5c0-.83.67-1.5 1.5-1.5s1.5.67 1.5 1.5v5c0 .83-.67 1.5-1.5 1.5z"/>
+                <path d="M20.5 10H19V8.5c0-.83.67-1.5 1.5-1.5s1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/>
+                <path d="M9.5 14c.83 0 1.5.67 1.5 1.5v5c0 .83-.67 1.5-1.5 1.5S8 21.33 8 20.5v-5c0-.83.67-1.5 1.5-1.5z"/>
+                <path d="M3.5 14H5v1.5c0 .83-.67 1.5-1.5 1.5S2 16.33 2 15.5 2.67 14 3.5 14z"/>
+                <path d="M14 14.5c0-.83.67-1.5 1.5-1.5h5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5h-5c-.83 0-1.5-.67-1.5-1.5z"/>
+                <path d="M15.5 19H14v1.5c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5-.67-1.5-1.5-1.5z"/>
+                <path d="M10 9.5C10 8.67 9.33 8 8.5 8H3.5C2.67 8 2 8.67 2 9.5S2.67 11 3.5 11h5c.83 0 1.5-.67 1.5-1.5z"/>
+                <path d="M8.5 5H10V3.5C10 2.67 9.33 2 8.5 2S7 2.67 7 3.5 7.67 5 8.5 5z"/>
+              </svg>
+              Slack 연동
+            </button>
             <button className="gv-btn" onClick={() => router.push(`/projects/${projectId}/mirror`)}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
                 <rect x="3" y="3" width="18" height="18" rx="2"/>
@@ -245,7 +269,7 @@ export default function GovernancePage() {
             <div className="gv-kpi-value">
               {totalResources}<small>개</small>
             </div>
-            <div className="gv-kpi-foot">온보딩 스캔 기준</div>
+            <div className="gv-kpi-foot">감지된 리소스 기준</div>
           </div>
 
           <div className="gv-kpi" data-tone={detectedCount > 0 ? 'red' : 'green'}>
@@ -284,7 +308,7 @@ export default function GovernancePage() {
             </div>
             <div className="gv-kpi-value gv-kpi-value-text">
               {auditLogs[0]
-                ? new Date(auditLogs[0].created_at).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+                ? parseUTC(auditLogs[0].created_at).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
                 : '—'}
             </div>
             <div className="gv-kpi-foot">
@@ -453,7 +477,7 @@ export default function GovernancePage() {
                           <span>{log.actor?.split('@')[0] || log.actor}</span>
                           <span className="gv-dot-sep" />
                           <span>
-                            {new Date(log.created_at).toLocaleString('ko-KR', {
+                            {parseUTC(log.created_at).toLocaleString('ko-KR', {
                               month: '2-digit', day: '2-digit',
                               hour: '2-digit', minute: '2-digit',
                             })}
@@ -484,7 +508,7 @@ export default function GovernancePage() {
               <span>아키텍처 다이어그램</span>
               {diagram?.generated_at && (
                 <span className="gv-panel-meta">
-                  {new Date(diagram.generated_at).toLocaleString('ko-KR', {
+                  {parseUTC(diagram.generated_at).toLocaleString('ko-KR', {
                     month: '2-digit', day: '2-digit',
                     hour: '2-digit', minute: '2-digit',
                   })} 생성
@@ -548,6 +572,55 @@ export default function GovernancePage() {
             </div>
           )}
         </div>
+
+        {/* ── Slack 연동 모달 ── */}
+        {slackModal && (
+          <div style={{
+            position: 'fixed', inset: 0, zIndex: 50,
+            background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(6px)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }} onClick={() => setSlackModal(false)}>
+            <div style={{
+              background: '#13151f', border: '1px solid rgba(255,255,255,0.13)',
+              borderRadius: '16px', padding: '28px', width: '460px', maxWidth: '90vw',
+            }} onClick={e => e.stopPropagation()}>
+              <div style={{ marginBottom: '20px' }}>
+                <div style={{ fontFamily: "'Plus Jakarta Sans',sans-serif", fontWeight: 700, fontSize: '16px', marginBottom: '6px' }}>
+                  Slack 알림 연동
+                </div>
+                <div style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: '12px', color: '#7a8298' }}>
+                  Drift 감지 시 해당 Webhook으로 알림이 발송됩니다
+                </div>
+              </div>
+              <input
+                type="text"
+                placeholder="https://hooks.slack.com/services/..."
+                value={slackUrl}
+                onChange={e => setSlackUrl(e.target.value)}
+                style={{
+                  width: '100%', padding: '10px 14px',
+                  background: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.13)',
+                  borderRadius: '8px', color: '#edf0f6',
+                  fontFamily: "'JetBrains Mono',monospace", fontSize: '12px',
+                  outline: 'none', boxSizing: 'border-box', marginBottom: '16px',
+                }}
+              />
+              <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                <button className="gv-btn" onClick={() => setSlackModal(false)}>취소</button>
+                <button
+                  className="gv-btn-primary"
+                  style={{ padding: '9px 18px', fontSize: '13px' }}
+                  disabled={!slackUrl || slackSaving}
+                  onClick={handleSlackSave}
+                >
+                  {slackSaving ? '저장 중...' : '저장'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
       </div>
     </>
   )

--- a/infra/start.sh
+++ b/infra/start.sh
@@ -37,9 +37,4 @@ aws ecs update-service \
   --region us-west-2 > /dev/null
 echo "✅ 프론트엔드 ECS Service 시작"
 
-aws ecs update-service --cluster autoops-cluster --service autoops-grafana-service    --desired-count 1 --region us-west-2 > /dev/null
-aws ecs update-service --cluster autoops-cluster --service autoops-prometheus-service --desired-count 1 --region us-west-2 > /dev/null
-aws ecs update-service --cluster autoops-cluster --service autoops-yace-service       --desired-count 1 --region us-west-2 > /dev/null
-echo "✅ Grafana + Prometheus + YACE 시작"
-
 echo "🚀 AutoOps 플랫폼 인프라 시작 완료"


### PR DESCRIPTION
[버그 수정]
- metrics.py: rds_identifier 소문자 변환 추가 (yca-prod-rds 대소문자 불일치 수정)
- bedrock_client.py: 다이어그램 모델 ID inference profile 형식으로 변경
  (anthropic.claude-sonnet-4-20250514-v1:0 → us.anthropic.claude-sonnet-4-20250514-v1:0)
- projects/[id]/page.tsx: parseUTC 함수 추가 — audit log/diagram 시간 UTC+9 변환

[기능 개선]
- projects.py get_project: aws_resource_count 필드 추가 (aws_resources 테이블 카운트)
- projects/[id]/page.tsx: totalResources → aws_resource_count 기반으로 변경
- projects/[id]/page.tsx: KPI 문구 "온보딩 스캔 기준" → "감지된 리소스 기준"
- craft.py _run_detect_all: resource_baselines 자동 등록 추가 (배포 완료 시 Drift 감지 준비)

[기타]
- auth.py: PATCH /api/auth/me 추가 (slack_webhook_url 업데이트)
- projects/[id]/page.tsx: Slack 연동 버튼 + 모달 추가
- dashboard/page.tsx: nowText hydration 에러 수정 (useMemo → useState+useEffect)
- validate/page.tsx: 504 타임아웃 처리 + 재시도 버튼 추가