### PR TITLE
fix(epic9): projects api error + bedrock model + rds metrics

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -134,6 +134,10 @@ def get_project(
         "rpo_minutes":     latest_package.rpo_minutes     if latest_package else None,
     } if latest_package else None
 
+    from app.models.aws_resource import AWSResource
+    result["aws_resource_count"] = db.query(AWSResource).filter(
+        AWSResource.project_id == project_id
+    ).count()
     return {"success": True, "data": result}
 
 

--- a/backend/app/services/mirrorops/bedrock_client.py
+++ b/backend/app/services/mirrorops/bedrock_client.py
@@ -199,7 +199,7 @@ AWS 설정:
         })
 
         response = self.client.invoke_model(
-            modelId     = "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            modelId     = self.MODEL_ID,
             body        = body,
             contentType = "application/json",
             accept      = "application/json",


### PR DESCRIPTION
[버그 수정]
- projects.py list_projects: 잘못 삽입된 aws_resource_count 코드 삭제
  (project_id 변수 없음 → API 에러 → aws_resource_count None 반환)
- bedrock_client.py: generate_architecture_diagram 모델 ID
  하드코딩 제거 → self.MODEL_ID 재사용
  (Legacy 모델 에러 반복 해결)
- metrics.py: rds_identifier .lower() 추가
  (YCA-prod-rds 대소문자 불일치 → CloudWatch 매칭 실패 수정)