### PR TITLE
feat: Failover ECS Task 분리 및 WebSocket 실시간 로그 연동

### DIFF
--- a/backend/app/api/gcp_connect.py
+++ b/backend/app/api/gcp_connect.py
@@ -175,20 +175,6 @@ def _validate_gcp_credentials(key_dict: dict, gcp_project_id: str) -> str:
                 },
             )
 
-        # 프로젝트 접근 권한 확인
-        check = subprocess.run(
-            ["gcloud", "projects", "describe", gcp_project_id],
-            capture_output=True, text=True, timeout=30,
-        )
-        if check.returncode != 0:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail={
-                    "code":    "GCP_AUTH_ERROR",
-                    "message": "GCP 프로젝트 접근 권한 없음. 서비스 계정 권한을 확인하세요.",
-                },
-            )
-
         return key_dict.get("client_email", "")
 
     finally:

--- a/backend/app/api/mirror.py
+++ b/backend/app/api/mirror.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status, Request
 from pydantic import BaseModel
 from typing import Optional
 from sqlalchemy.orm import Session
@@ -465,8 +465,6 @@ def _run_failover_simulation(
         db.close()
 
 
-# ── Actual 실행 ──────────────────────────────────────────────────────
-
 async def _run_failover_actual(
     project_id: str,
     failover_id: str,
@@ -474,188 +472,54 @@ async def _run_failover_actual(
     project:     "Project",
     role_arn:    str,
 ) -> None:
-    """
-    GCP actual 페일오버 실행. BackgroundTask로 동작한다.
-
-    흐름:
-    ① S3에서 main.tf 다운로드
-    ② GCP 인증 설정 (Secrets Manager)
-    ③ GCS State 버킷 자동 생성
-    ④ terraform init → apply (CloudWatch 로그 스트리밍)
-    ⑤ failover_history.status → completed + RTO 기록
-    """
     from app.core.config import settings
-    from app.services.mirrorops.gcp_auth import setup_gcp_auth
 
-    started_at = datetime.utcnow()
-    work_dir   = None
-    db         = SessionLocal()
-    log_group  = f"/autoops/failover/{failover_id}"
-
-    cw = boto3.client("logs", region_name="us-west-2")
-
-    def _log(msg: str):
-        print(f"[Failover {failover_id}] {msg}")
-        try:
-            cw.put_log_events(
-                logGroupName  = log_group,
-                logStreamName = "failover",
-                logEvents     = [{"timestamp": int(datetime.utcnow().timestamp() * 1000), "message": msg}],
-            )
-        except Exception:
-            pass
-
-    def _update_status(new_status: str, error_msg: str = "", rto_seconds: int = None, resources_created: int = None):
-        fh = db.query(FailoverHistory).filter(
-            FailoverHistory.failover_id == failover_id
-        ).first()
-        if fh:
-            fh.status       = new_status
-            fh.completed_at = datetime.utcnow()
-            if error_msg:
-                fh.error_message = error_msg
-            if rto_seconds is not None:
-                fh.actual_rto_seconds = rto_seconds
-            if resources_created is not None:
-                fh.gcp_resources_created = resources_created
-            db.commit()
+    ecs = boto3.client("ecs", region_name="us-west-2")
+    tf_key    = f"projects/{project_id}/latest/infrastructure/main.tf"
+    s3_path   = f"s3://autoops-dr-packages/{tf_key}"
 
     try:
-        # CloudWatch 로그 그룹 생성
-        try:
-            cw.create_log_group(logGroupName=log_group)
-            cw.create_log_stream(logGroupName=log_group, logStreamName="failover")
-        except cw.exceptions.ResourceAlreadyExistsException:
-            pass
-
-        # ① S3에서 main.tf 다운로드
-        _log("S3에서 main.tf 다운로드 중...")
-        s3       = boto3.client("s3", region_name="us-west-2")
-        work_dir = tempfile.mkdtemp(prefix=f"autoops-failover-{project_id[:8]}-")
-        tf_key   = f"projects/{project_id}/latest/infrastructure/main.tf"
-
-        s3.download_file("autoops-dr-packages", tf_key, str(Path(work_dir) / "main.tf"))
-        _log("main.tf 다운로드 완료")
-
-        # gcp_project_id 결정 — 연동된 프로젝트 우선
-        gcp_project_id = project.gcp_project_id or settings.gcp_project_id
-
-        # ② GCP 인증
-        _log("GCP 인증 설정 중...")
-        setup_gcp_auth(project=project)
-        _log(f"GCP 인증 완료 (프로젝트: {gcp_project_id})")
-
-        # ③ GCS State 버킷 생성
-        bucket_name = f"autoops-dr-state-{project_id}"
-        _log(f"GCS State 버킷 확인: {bucket_name}")
-        try:
-            from google.cloud import storage as gcs_storage
-            gcs = gcs_storage.Client()
-            if not gcs.bucket(bucket_name).exists():
-                bucket = gcs.create_bucket(bucket_name, location="us-west1")
-                bucket.versioning_enabled = True
-                bucket.patch()
-                _log(f"GCS 버킷 생성 완료: {bucket_name}")
-            else:
-                _log(f"GCS 버킷 이미 존재: {bucket_name}")
-        except Exception as e:
-            _log(f"⚠️ GCS 버킷 처리 중 오류 (계속 진행): {e}")
-
-        # ④ terraform init
-        _log("terraform init 실행 중...")
-        env = {**os.environ, "TF_IN_AUTOMATION": "1"}
-
-        init_result = subprocess.run(
-            ["terraform", "init", "-no-color", "-reconfigure"],
-            cwd=work_dir, capture_output=True, text=True, timeout=120, env=env,
+        ecs.run_task(
+            cluster        = "autoops-cluster",
+            taskDefinition = "autoops-failover-runner",
+            launchType     = "FARGATE",
+            networkConfiguration={
+                "awsvpcConfiguration": {
+                    "subnets":        ["subnet-0d215b0dbeeb14fcd", "subnet-009137f901eda3457"],
+                    "securityGroups": ["sg-03765069875b4e4c2"],
+                    "assignPublicIp": "DISABLED",
+                }
+            },
+            overrides={
+                "containerOverrides": [{
+                    "name": "failover-runner",
+                    "environment": [
+                        {"name": "FAILOVER_ID",       "value": failover_id},
+                        {"name": "PROJECT_ID",        "value": project_id},
+                        {"name": "HCL_S3_PATH",       "value": s3_path},
+                        {"name": "GCP_SECRET_ARN",    "value": project.gcp_secret_arn or ""},
+                        {"name": "GCP_PROJECT_ID",    "value": project.gcp_project_id or ""},
+                        {"name": "ACTION",            "value": "apply"},
+                        {"name": "BACKEND_API_URL",   "value": settings.backend_api_url},
+                        {"name": "INTERNAL_SECRET",   "value": settings.internal_secret},
+                    ],
+                }]
+            },
         )
-        for line in init_result.stdout.splitlines():
-            if line.strip():
-                _log(line)
-        if init_result.returncode != 0:
-            raise RuntimeError(f"terraform init 실패:\n{init_result.stderr}")
-        _log("terraform init 완료")
-
-        # ⑤ terraform apply
-        _log("terraform apply 실행 중 (GCP 리소스 생성 시작)...")
-        _log("Cloud SQL 생성에 약 10~15분 소요됩니다.")
-
-        import re as _re
-        resources_created = 0
-
-        apply_proc = subprocess.Popen(
-            ["terraform", "apply", "-auto-approve", "-no-color", "-json"],
-            cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            text=True, env=env,
-        )
-
-        for line in apply_proc.stdout:
-            line = line.rstrip()
-            if not line:
-                continue
-            try:
-                event = json.loads(line)
-                msg   = event.get("@message", "")
-                if msg:
-                    _log(msg)
-                    if "Apply complete!" in msg:
-                        match = _re.search(r'(\d+) added', msg)
-                        if match:
-                            resources_created = int(match.group(1))
-            except json.JSONDecodeError:
-                _log(line)
-
-        apply_proc.wait(timeout=1200)
-        if apply_proc.returncode != 0:
-            raise RuntimeError(f"terraform apply 실패 (exit code {apply_proc.returncode})")
-
-        _log("✅ terraform apply 완료 — GCP 리소스 생성 성공")
-
-        # ── S3 parquet → Cloud SQL 데이터 복원 추가 ─────────────────────
-        _log("Cloud SQL 데이터 복원 시작...")
-        await _import_snapshot_to_cloud_sql(
-            project_id  = project_id,
-            package     = package,
-            bucket_name = bucket_name,
-            gcp_project = gcp_project_id,
-            log_fn      = _log,
-        )
-        _log("✅ Cloud SQL 데이터 복원 완료")
-
-
-        # ⑥ RTO 계산 및 DB 업데이트
-        rto_seconds = int((datetime.utcnow() - started_at).total_seconds())
-        _log(f"실제 RTO: {rto_seconds // 60}분 {rto_seconds % 60}초")
-        _update_status("completed", rto_seconds=rto_seconds, resources_created=resources_created)
-
-        from app.services.governance.audit_logger import log_platform_action
-        from app.core.database import SessionLocal
-        _audit_db = SessionLocal()
-        try:
-            log_platform_action(
-                db         = _audit_db,
-                action     = "failover_execute",
-                user_id    = project.user_id,
-                project_id = project_id,
-                detail     = {
-                    "failover_id": failover_id,
-                    "rto_seconds": rto_seconds,
-                    "mode":        "actual",
-                },
-            )
-            _audit_db.commit()
-        finally:
-            _audit_db.close()
-
+        print(f"[Failover {failover_id}] ECS Task 시작됨")
     except Exception as e:
-        err_msg = str(e)
-        _log(f"❌ 페일오버 실패: {err_msg}")
-        _update_status("failed", error_msg=err_msg[:1000])
-
-    finally:
-        if work_dir and os.path.exists(work_dir):
-            shutil.rmtree(work_dir, ignore_errors=True)
-        db.close()
+        db = SessionLocal()
+        try:
+            fh = db.query(FailoverHistory).filter(
+                FailoverHistory.failover_id == failover_id
+            ).first()
+            if fh:
+                fh.status        = "failed"
+                fh.error_message = str(e)[:1000]
+                fh.completed_at  = datetime.utcnow()
+                db.commit()
+        finally:
+            db.close()
 
 
 # ── terraform_code PATCH ─────────────────────────────────────────────
@@ -880,7 +744,7 @@ def destroy_gcp_resources(
             detail={"code": "BAD_REQUEST", "message": "simulation 모드는 삭제할 GCP 리소스가 없습니다."},
         )
 
-    if fh.status not in ("completed", "failed"):
+    if fh.status not in ("completed", "failed", "running", "destroy_failed", "destroying"):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
@@ -911,131 +775,61 @@ async def _run_failover_destroy(
     project_id:  str,
     failover_id: str,
 ) -> None:
-    """
-    terraform destroy로 GCP 리소스 삭제.
-
-    흐름:
-    ① S3에서 main.tf 다운로드
-    ② GCP 인증
-    ③ terraform init → destroy
-    ④ GCS import 파일 정리
-    ⑤ failover_history.status → destroyed
-    """
-    from app.services.mirrorops.gcp_auth import setup_gcp_auth
     from app.core.config import settings
-
-    db       = SessionLocal()
-    work_dir = None
-    # project 조회 (gcp_secret_arn 사용을 위해)
     from app.models.project import Project as ProjectModel
+
+    db      = SessionLocal()
     project = db.query(ProjectModel).filter(
         ProjectModel.project_id == project_id
     ).first()
-    cw       = boto3.client("logs", region_name="us-west-2")
-    log_group = f"/autoops/failover/{failover_id}"
+    db.close()
 
-    def _log(msg: str):
-        print(f"[Destroy{failover_id}]{msg}")
-        try:
-            cw.put_log_events(
-                logGroupName  = log_group,
-                logStreamName = "failover",
-                logEvents     = [{"timestamp": int(datetime.utcnow().timestamp() * 1000), "message": msg}],
-            )
-        except Exception:
-            pass
-
-    def _update_status(new_status: str, error_msg: str = "", rto_seconds: int = None, resources_created: int = None):
-        fh = db.query(FailoverHistory).filter(
-            FailoverHistory.failover_id == failover_id
-        ).first()
-        if fh:
-            fh.status       = new_status
-            fh.completed_at = datetime.utcnow()
-            if error_msg:
-                fh.error_message = error_msg
-            if rto_seconds is not None:
-                fh.actual_rto_seconds    = rto_seconds
-            if resources_created is not None:
-                fh.gcp_resources_created = resources_created
-            db.commit()
+    ecs     = boto3.client("ecs", region_name="us-west-2")
+    tf_key  = f"projects/{project_id}/latest/infrastructure/main.tf"
+    s3_path = f"s3://autoops-dr-packages/{tf_key}"
 
     try:
-        # ① S3에서 main.tf 다운로드
-        _log("S3에서 main.tf 다운로드 중...")
-        s3       = boto3.client("s3", region_name="us-west-2")
-        work_dir = tempfile.mkdtemp(prefix=f"autoops-destroy-{project_id[:8]}-")
-        tf_key   = f"projects/{project_id}/latest/infrastructure/main.tf"
-        s3.download_file("autoops-dr-packages", tf_key, str(Path(work_dir) / "main.tf"))
-        _log("main.tf 다운로드 완료")
-
-        # ② GCP 인증
-        _log("GCP 인증 설정 중...")
-        setup_gcp_auth(project=project)
-        _log("GCP 인증 완료")
-
-        env = {**os.environ, "TF_IN_AUTOMATION": "1"}
-
-        # ③ terraform init
-        _log("terraform init 실행 중...")
-        init_result = subprocess.run(
-            ["terraform", "init", "-no-color", "-reconfigure"],
-            cwd=work_dir, capture_output=True, text=True, timeout=120, env=env,
+        ecs.run_task(
+            cluster        = "autoops-cluster",
+            taskDefinition = "autoops-failover-runner",
+            launchType     = "FARGATE",
+            networkConfiguration={
+                "awsvpcConfiguration": {
+                    "subnets":        ["subnet-0d215b0dbeeb14fcd", "subnet-009137f901eda3457"],
+                    "securityGroups": ["sg-03765069875b4e4c2"],
+                    "assignPublicIp": "DISABLED",
+                }
+            },
+            overrides={
+                "containerOverrides": [{
+                    "name": "failover-runner",
+                    "environment": [
+                        {"name": "FAILOVER_ID",       "value": failover_id},
+                        {"name": "PROJECT_ID",        "value": project_id},
+                        {"name": "HCL_S3_PATH",       "value": s3_path},
+                        {"name": "GCP_SECRET_ARN",    "value": project.gcp_secret_arn or "" if project else ""},
+                        {"name": "GCP_PROJECT_ID",    "value": project.gcp_project_id or "" if project else ""},
+                        {"name": "ACTION",            "value": "destroy"},
+                        {"name": "BACKEND_API_URL",   "value": settings.backend_api_url},
+                        {"name": "INTERNAL_SECRET",   "value": settings.internal_secret},
+                    ],
+                }]
+            },
         )
-        if init_result.returncode != 0:
-            raise RuntimeError(f"terraform init 실패:\n{init_result.stderr}")
-        _log("terraform init 완료")
-
-        # ③ terraform destroy
-        _log("terraform destroy 실행 중 (GCP 리소스 삭제 시작)...")
-        destroy_proc = subprocess.Popen(
-            ["terraform", "destroy", "-auto-approve", "-no-color", "-json"],
-            cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            text=True, env=env,
-        )
-        for line in destroy_proc.stdout:
-            line = line.rstrip()
-            if not line:
-                continue
-            try:
-                event = json.loads(line)
-                msg   = event.get("@message", "")
-                if msg:
-                    _log(msg)
-            except json.JSONDecodeError:
-                _log(line)
-
-        destroy_proc.wait(timeout=600)  # 최대 10분
-        if destroy_proc.returncode != 0:
-            raise RuntimeError(f"terraform destroy 실패 (exit code{destroy_proc.returncode})")
-        _log("✅ terraform destroy 완료 — GCP 리소스 삭제 성공")
-
-        # ④ GCS import 파일 정리
-        bucket_name = f"autoops-dr-state-{project_id}"
-        try:
-            from google.cloud import storage as gcs_storage
-            gcs    = gcs_storage.Client()
-            bucket = gcs.bucket(bucket_name)
-            blobs  = list(bucket.list_blobs(prefix="import/"))
-            if blobs:
-                bucket.delete_blobs(blobs)
-                _log(f"GCS import 파일 정리 완료:{len(blobs)}개")
-        except Exception as e:
-            _log(f"⚠️ GCS 정리 중 오류 (무시):{e}")
-
-        # ⑤ 상태 업데이트
-        _update_status("destroyed")
-        _log("✅ GCP 리소스 삭제 완료")
-
+        print(f"[Destroy {failover_id}] ECS Task 시작됨")
     except Exception as e:
-        err_msg = str(e)
-        _log(f"❌ GCP 리소스 삭제 실패:{err_msg}")
-        _update_status("destroy_failed", error_msg=err_msg[:1000])
-
-    finally:
-        if work_dir and os.path.exists(work_dir):
-            shutil.rmtree(work_dir, ignore_errors=True)
-        db.close()
+        db = SessionLocal()
+        try:
+            fh = db.query(FailoverHistory).filter(
+                FailoverHistory.failover_id == failover_id
+            ).first()
+            if fh:
+                fh.status        = "destroy_failed"
+                fh.error_message = str(e)[:1000]
+                fh.completed_at  = datetime.utcnow()
+                db.commit()
+        finally:
+            db.close()
 
 # ── GET /api/mirror/{project_id}/failover-history ──────────────────
 
@@ -1068,3 +862,48 @@ def get_failover_history(
             for fh in history
         ],
     }
+
+# ── Internal Failover Complete (ECS Task → Backend) ─────────────────
+
+class FailoverCompleteBody(BaseModel):
+    action: str   # "apply" | "destroy"
+    status: str   # "success" | "failed"
+    error:  Optional[str] = None
+    resources_created: Optional[int] = None 
+
+@router.post("/{project_id}/failover/{failover_id}/internal-complete")
+def internal_failover_complete(
+    failover_id: str,
+    body: FailoverCompleteBody,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    from app.core.config import settings
+    secret = request.headers.get("X-Internal-Secret", "")
+    if secret != settings.internal_secret:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    fh = db.query(FailoverHistory).filter(
+        FailoverHistory.failover_id == failover_id
+    ).first()
+    if not fh:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    if body.action == "destroy":
+        fh.status = "destroyed" if body.status == "success" else "destroy_failed"
+    else:
+        fh.status = "completed" if body.status == "success" else "failed"
+
+    if body.error:
+        fh.error_message = body.error[:1000]
+
+    if body.action != "destroy" and body.status == "success":
+        if fh.started_at:
+            fh.actual_rto_seconds = int((datetime.utcnow() - fh.started_at).total_seconds())
+
+    if body.resources_created is not None:
+        fh.gcp_resources_created = body.resources_created
+    
+    fh.completed_at = datetime.utcnow()
+    db.commit()
+    return {"success": True}

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -287,55 +287,12 @@ async def _stream_failover_logs(
     project_id: str,
     failover_id: str,
 ) -> None:
-    log_group  = f"/autoops/failover/{failover_id}"
-    next_token = None
+    log_group  = "/autoops/failover-runner"
+    start_time = None  # fh.started_at 기준으로 설정
 
     try:
         while True:
-            # ── CloudWatch 로그 즉시 폴링 (초기 대기 없음) ────────────
-            try:
-                streams = cw.describe_log_streams(
-                    logGroupName = log_group,
-                    orderBy      = "LastEventTime",
-                    descending   = True,
-                    limit        = 1,
-                )
-                log_streams = streams.get("logStreams", [])
-
-                if log_streams:
-                    kwargs = {
-                        "logGroupName":  log_group,
-                        "logStreamName": log_streams[0]["logStreamName"],
-                        "startFromHead": True,
-                        "limit":         100,
-                    }
-                    if next_token:
-                        kwargs["nextToken"] = next_token
-
-                    resp       = cw.get_log_events(**kwargs)
-                    events     = resp.get("events", [])
-                    next_token = resp.get("nextForwardToken")
-
-                    for event in events:
-                        msg = event.get("message", "").strip()
-                        if not msg:
-                            continue
-                        await websocket.send_json({
-                            "event_type": "failover_progress",
-                            "project_id": project_id,
-                            "timestamp":  datetime.now(timezone.utc).isoformat(),
-                            "data": {
-                                "failover_id":      failover_id,
-                                "current_resource": msg,
-                                "elapsed_seconds":  0,
-                            },
-                        })
-
-            except Exception:
-                # 로그 그룹 미생성, 일시 오류 등 — 무시하고 계속 폴링
-                pass
-
-            # ── DB 완료 여부 체크 ──────────────────────────────────
+            # DB에서 상태 + 시작 시각 조회
             db: Session = SessionLocal()
             try:
                 from app.models.failover_history import FailoverHistory
@@ -346,8 +303,38 @@ async def _stream_failover_logs(
                 rto_seconds    = fh.actual_rto_seconds    if fh else None
                 gcp_created    = fh.gcp_resources_created if fh else None
                 error_msg      = fh.error_message         if fh else None
+                if start_time is None and fh and fh.started_at:
+                    import calendar
+                    start_time = int(calendar.timegm(fh.started_at.timetuple())) * 1000
             finally:
                 db.close()
+
+            # 로그 폴링
+            if start_time:
+                try:
+                    resp = cw.filter_log_events(
+                        logGroupName  = log_group,
+                        filterPattern = '"[Failover Runner]"',
+                        startTime     = start_time,
+                        limit         = 100,
+                    )
+                    events = resp.get("events", [])
+                    for event in events:
+                        msg = event.get("message", "").strip()
+                        if msg:
+                            start_time = event["timestamp"] + 1  # 중복 방지
+                            await websocket.send_json({
+                                "event_type": "failover_progress",
+                                "project_id": project_id,
+                                "timestamp":  datetime.now(timezone.utc).isoformat(),
+                                "data": {
+                                    "failover_id":      failover_id,
+                                    "current_resource": msg,
+                                    "elapsed_seconds":  0,
+                                },
+                            })
+                except Exception:
+                    pass
 
             if current_status == "completed":
                 await websocket.send_json({

--- a/backend/app/services/mirrorops/gcp_auth.py
+++ b/backend/app/services/mirrorops/gcp_auth.py
@@ -1,3 +1,5 @@
+# backend/app/services/mirrorops/gcp_auth.py
+
 import boto3
 import json
 import os
@@ -6,30 +8,41 @@ import tempfile
 
 def load_gcp_credentials() -> str:
     """
-    AWS Secrets Manager에서 GCP SA Key를 로드하고
-    임시 파일로 저장한 후 경로를 반환한다. (§5-4)
-
-    ECS Task Role이 secretsmanager:GetSecretValue 권한을 보유하므로
-    추가 자격증명 없이 조회 가능하다.
+    AWS Secrets Manager에서 공유 GCP SA Key를 로드하고
+    임시 파일로 저장한 후 경로를 반환한다.
+    개발/테스트 환경에서 GCP 미연동 프로젝트의 폴백으로 사용된다.
     """
-    client = boto3.client("secretsmanager", region_name="us-west-2")
-    secret  = client.get_secret_value(SecretId="autoops/gcp-sa-key")
+    client   = boto3.client("secretsmanager", region_name="us-west-2")
+    secret   = client.get_secret_value(SecretId="autoops/gcp-sa-key")
     key_data = json.loads(secret["SecretString"])
 
-    # 컨테이너 수명 동안만 존재하는 임시 파일로 저장
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".json", delete=False
-    )
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
     json.dump(key_data, tmp)
     tmp.close()
-
     return tmp.name
 
 
-def setup_gcp_auth() -> None:
+def setup_gcp_auth(project=None) -> None:
     """
     GOOGLE_APPLICATION_CREDENTIALS 환경변수를 설정한다.
-    이후 GCP SDK / terraform GCP provider가 자동으로 인증한다.
+
+    project가 있고 gcp_secret_arn이 설정된 경우:
+        → 해당 프로젝트의 SA 키 사용 (사용자 GCP 프로젝트)
+    없거나 미연동인 경우:
+        → 공유 autoops/gcp-sa-key 사용 (개발/테스트용)
     """
-    key_path = load_gcp_credentials()
+    if project and getattr(project, "gcp_secret_arn", None):
+        # 프로젝트별 SA 키 사용
+        client   = boto3.client("secretsmanager", region_name="us-west-2")
+        secret   = client.get_secret_value(SecretId=project.gcp_secret_arn)
+        key_data = json.loads(secret["SecretString"])
+
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+        json.dump(key_data, tmp)
+        tmp.close()
+        key_path = tmp.name
+    else:
+        # 폴백: 공유 SA 키 (개발/테스트 환경)
+        key_path = load_gcp_credentials()
+
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = key_path

--- a/backend/app/services/mirrorops/mapper.py
+++ b/backend/app/services/mirrorops/mapper.py
@@ -96,6 +96,7 @@ RULE_BASED_MAP: dict[str, dict] = {
         "mapping":    lambda cfg: {
             "database_version": f"POSTGRES_{cfg.get('EngineVersion', '15').split('.')[0]}",
             "region":           "us-west1",
+            "deletion_protection": False, 
             "settings": {
                 "tier":              "db-f1-micro",
                 "availability_type": "REGIONAL" if cfg.get("MultiAZ") else "ZONAL",

--- a/backend/app/services/mirrorops/pipeline.py
+++ b/backend/app/services/mirrorops/pipeline.py
@@ -22,13 +22,9 @@ class MirrorOpsPipelineService:
         self,
         project_id: str,
         deployment_id: str,
-        trigger_type: str,       # "deployment_completed" | "infra_changed" | "manual"
+        trigger_type: str,
         db: Session,
     ) -> str:
-        """
-        파이프라인을 실행하고 sync_id를 반환한다.
-        Phase 1이 완료되면 즉시 반환한다 (Phase 2는 비동기).
-        """
         # 프로젝트 및 AWS 계정 조회
         project = db.query(Project).filter(
             Project.project_id == project_id
@@ -37,8 +33,8 @@ class MirrorOpsPipelineService:
             AWSAccount.account_id == project.account_id
         ).first()
 
-        # GCP 인증 설정 — project별 SA 키 사용
-        gcp_project_id = project.gcp_project_id or settings.gcp_project_id
+        # GCP 인증 설정 — project별 SA 키 사용 (폴백 없음)
+        gcp_project_id = project.gcp_project_id
         setup_gcp_auth(project=project)
 
         # sync_history 레코드 생성
@@ -58,7 +54,6 @@ class MirrorOpsPipelineService:
         db.commit()
 
         try:
-            # 기존 GCPMapping, AWSResource 삭제 (UUID 불일치 방지)
             from app.models.gcp_mapping import GCPMapping as GCPMappingModel
             from app.models.aws_resource import AWSResource as AWSResourceModel
 
@@ -70,10 +65,8 @@ class MirrorOpsPipelineService:
             ).delete()
             db.commit()
 
-            # ① 리소스 감지 (FR-B-003)
-            assumed_session = boto3.Session(
-                region_name=project.region,
-            )
+            # ① 리소스 감지
+            assumed_session = boto3.Session(region_name=project.region)
             detector = ResourceDetector(
                 role_arn    = account.role_arn,
                 region      = project.region,
@@ -88,7 +81,7 @@ class MirrorOpsPipelineService:
             sync.aws_resources_detected = len(aws_resources)
             db.commit()
 
-            # ② 매핑 엔진 (FR-B-004, FR-B-005)
+            # ② 매핑 엔진
             mapper   = MappingEngine()
             mappings = mapper.map_all(
                 aws_resources = aws_resources,
@@ -99,7 +92,6 @@ class MirrorOpsPipelineService:
             sync.gcp_resources_mapped = len(mappings)
             db.commit()
 
-            # ── [추가] 변경 감지 — 이전 동기화와 리소스 수 비교 ──────────────
             from app.models.sync_history import DRPackage as DRPackageModel
 
             previous_sync = db.query(SyncHistory).filter(
@@ -108,17 +100,16 @@ class MirrorOpsPipelineService:
                 SyncHistory.sync_id    != sync.sync_id,
             ).order_by(SyncHistory.started_at.desc()).first()
 
-            has_changes = True  # 기본값: 변경 있음으로 간주
+            has_changes = True
 
             if previous_sync:
                 prev_count = previous_sync.aws_resources_detected or 0
                 curr_count = len(aws_resources)
                 if prev_count == curr_count and curr_count > 0:
-                    has_changes = False  # 리소스 수 동일 → 변경 없음으로 간주
+                    has_changes = False
 
-            # ③ GCP Terraform HCL 생성 + DR Package — 변경 있을 때만 실행
+            # ③ GCP Terraform HCL 생성 + DR Package
             if has_changes:
-                # 기존 is_latest 패키지 False로 변경
                 db.query(DRPackageModel).filter(
                     DRPackageModel.project_id == project_id,
                     DRPackageModel.is_latest  == True,
@@ -151,17 +142,14 @@ class MirrorOpsPipelineService:
                     db          = db,
                 )
             else:
-                # 변경 없음 → DR Package 재생성 스킵
                 print(f"[MirrorOps] 변경 없음 — DR Package 재생성 스킵 (project_id={project_id})")
 
-                # [추가] 변경 없음: 최신 패키지가 ready면 dr_status 복원
                 latest_pkg = db.query(DRPackageModel).filter(
                     DRPackageModel.project_id == project_id,
                     DRPackageModel.is_latest  == True,
                 ).first()
                 if latest_pkg and latest_pkg.status == "ready":
                     project.dr_status = "ready"
-                    # [추가] 스냅샷 Export 완료 시 체크리스트도 동기화
                     if latest_pkg.snapshot_status == "ready" and latest_pkg.checklist:
                         updated = []
                         for item in latest_pkg.checklist:
@@ -172,7 +160,6 @@ class MirrorOpsPipelineService:
                         latest_pkg.checklist = updated
                 db.commit()
 
-            # [추가] Phase 1 완료 → sync 상태 업데이트
             sync.status       = "completed"
             sync.completed_at = datetime.utcnow()
             db.commit()

--- a/backend/app/services/mirrorops/sqs_worker.py
+++ b/backend/app/services/mirrorops/sqs_worker.py
@@ -20,7 +20,6 @@ async def start_sqs_worker():
 
     while True:
         try:
-            # 동기 boto3 호출을 별도 스레드로 분리
             loop = asyncio.get_event_loop()
             resp = await loop.run_in_executor(
                 None,
@@ -37,20 +36,16 @@ async def start_sqs_worker():
                 receipt_handle = msg["ReceiptHandle"]
                 body = json.loads(msg["Body"])
 
-                # EventBridge 이벤트 파싱
                 detail_type = body.get("detail-type", "")
                 detail      = body.get("detail", {})
 
                 try:
                     if detail_type == "InfraDeploymentCompleted":
-                        # §7-8 CraftOps → MirrorOps 트리거
                         await _handle_deployment_completed(detail)
 
                     elif detail_type == "RDS DB Snapshot Event":
-                        # Phase 2 트리거
                         await _handle_rds_snapshot_completed(detail)
 
-                    # 처리 완료 → 큐에서 삭제
                     sqs.delete_message(
                         QueueUrl      = queue_url,
                         ReceiptHandle = receipt_handle,
@@ -58,7 +53,6 @@ async def start_sqs_worker():
 
                 except Exception as e:
                     print(f"[MirrorOps Worker] 메시지 처리 실패:{e}")
-                    # 실패 시 VisibilityTimeout 후 재처리
 
         except Exception as e:
             print(f"[MirrorOps Worker] SQS 수신 오류:{e}")
@@ -68,6 +62,18 @@ async def start_sqs_worker():
 async def _handle_deployment_completed(detail: dict):
     db = SessionLocal()
     try:
+        from app.models.project import Project
+
+        # GCP 미연동 시 DR 패키지 자동 생성 스킵
+        # GCP 연동 후 사용자가 직접 MirrorOps 페이지에서 수동 실행
+        project = db.query(Project).filter(
+            Project.project_id == detail["project_id"]
+        ).first()
+
+        if not project or not project.gcp_project_id:
+            print(f"[MirrorOps Worker] GCP 미연동 — DR 패키지 자동 생성 스킵 (project_id={detail['project_id']})")
+            return
+
         pipeline = MirrorOpsPipelineService()
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(
@@ -91,9 +97,8 @@ async def _handle_rds_snapshot_completed(detail: dict):
         snapshot_arn = detail.get("SourceArn", "")
 
         if "autoops" not in snapshot_id:
-            return  # AutoOps가 생성한 스냅샷이 아니면 무시
+            return
 
-        # snapshot_id에서 project_id 추출 (형식: autoops-{project_id_8자리}-{timestamp})
         parts = snapshot_id.split("-")
         if len(parts) < 2:
             return
@@ -101,7 +106,6 @@ async def _handle_rds_snapshot_completed(detail: dict):
         from app.models.sync_history import DRPackage
         from app.models.project import Project
 
-        # snapshot_ref.json에서 package_id 조회
         package = db.query(DRPackage).filter(
             DRPackage.snapshot_status == "pending",
         ).order_by(DRPackage.created_at.desc()).first()

--- a/failover-runner/Dockerfile
+++ b/failover-runner/Dockerfile
@@ -1,0 +1,21 @@
+FROM hashicorp/terraform:1.14.8
+
+RUN apk add --no-cache \
+    python3 \
+    py3-pip \
+    curl \
+    bash \
+    jq \
+    aws-cli
+
+# gcloud CLI 설치
+RUN curl -sSL https://sdk.cloud.google.com > /tmp/install.sh && \
+    bash /tmp/install.sh --disable-prompts --install-dir=/usr/local && \
+    ln -s /usr/local/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
+
+WORKDIR /workspace
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/failover-runner/entrypoint.sh
+++ b/failover-runner/entrypoint.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -e
+
+echo "[Failover Runner] 시작: FAILOVER_ID=${FAILOVER_ID}, ACTION=${ACTION}"
+
+# ── CloudWatch 로그 그룹/스트림 생성 ────────────────────────────────
+LOG_GROUP="/autoops/failover/${FAILOVER_ID}"
+LOG_STREAM="failover"
+
+aws logs create-log-group --log-group-name "${LOG_GROUP}" --region us-west-2 2>/dev/null || true
+aws logs create-log-stream --log-group-name "${LOG_GROUP}" --log-stream-name "${LOG_STREAM}" --region us-west-2 2>/dev/null || true
+
+_log() {
+    local msg="$1"
+    local ts=$(date +%s%3N)
+    echo "[Failover Runner] ${msg}"
+    aws logs put-log-events \
+        --log-group-name "${LOG_GROUP}" \
+        --log-stream-name "${LOG_STREAM}" \
+        --log-events "[{\"timestamp\":${ts},\"message\":\"${msg}\"}]" \
+        --region us-west-2 2>/dev/null || true
+}
+
+# ── S3에서 main.tf 다운로드 ─────────────────────────────────────────
+mkdir -p /workspace/tf
+_log "S3에서 main.tf 다운로드 중..."
+aws s3 cp "${HCL_S3_PATH}" /workspace/tf/main.tf
+_log "main.tf 다운로드 완료"
+
+cd /workspace/tf
+
+# ── GCP 인증 ────────────────────────────────────────────────────────
+_log "GCP SA 키 로드 중..."
+SA_KEY=$(aws secretsmanager get-secret-value \
+  --secret-id "${GCP_SECRET_ARN}" \
+  --region us-west-2 \
+  --query SecretString \
+  --output text)
+
+echo "${SA_KEY}" > /tmp/gcp-sa-key.json
+gcloud auth activate-service-account \
+  --key-file=/tmp/gcp-sa-key.json \
+  --project="${GCP_PROJECT_ID}"
+export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-sa-key.json
+_log "GCP 인증 완료 (프로젝트: ${GCP_PROJECT_ID})"
+
+# ── GCS State 버킷 생성 ─────────────────────────────────────────────
+BUCKET_NAME="autoops-dr-state-${PROJECT_ID}"
+_log "GCS State 버킷 확인: ${BUCKET_NAME}"
+if gcloud storage buckets describe "gs://${BUCKET_NAME}" --project="${GCP_PROJECT_ID}" 2>/dev/null; then
+    _log "GCS 버킷 이미 존재: ${BUCKET_NAME}"
+else
+    gcloud storage buckets create "gs://${BUCKET_NAME}" --location=us-west1 --project="${GCP_PROJECT_ID}" && _log "GCS 버킷 생성 완료: ${BUCKET_NAME}"
+fi
+
+# ── terraform init ──────────────────────────────────────────────────
+_log "terraform init 실행 중..."
+terraform init -no-color -reconfigure 2>&1 | while read line; do
+    _log "${line}"
+done
+_log "terraform init 완료"
+
+# ── terraform apply 또는 destroy ────────────────────────────────────
+if [ "${ACTION}" = "destroy" ]; then
+    _log "terraform destroy 실행 중 (GCP 리소스 삭제 시작)..."
+    terraform destroy -auto-approve -no-color -json 2>&1 | while read line; do
+        msg=$(echo "${line}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('@message',''))" 2>/dev/null || echo "${line}")
+        [ -n "${msg}" ] && _log "${msg}"
+    done
+    TF_EXIT=${PIPESTATUS[0]}
+else
+    _log "terraform apply 실행 중 (GCP 리소스 생성 시작)..."
+    _log "Cloud SQL 생성에 약 10~15분 소요됩니다."
+    echo "0" > /tmp/tf_resources_added
+    terraform apply -auto-approve -no-color -json 2>&1 | while read line; do
+        msg=$(echo "${line}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('@message',''))" 2>/dev/null || echo "${line}")
+        echo "${line}" | python3 -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    if d.get('type')=='change_summary':
+        count=d.get('changes',{}).get('add',0)
+        if count: open('/tmp/tf_resources_added','w').write(str(count))
+except: pass
+" 2>/dev/null || true
+        [ -n "${msg}" ] && _log "${msg}"
+    done
+    TF_EXIT=${PIPESTATUS[0]}
+    RESOURCES_ADDED=$(cat /tmp/tf_resources_added 2>/dev/null || echo "0")
+fi
+
+# ── 완료 상태 백엔드로 전송 ─────────────────────────────────────────
+if [ "${TF_EXIT}" -eq 0 ]; then
+    _log "✅ terraform ${ACTION} 완료"
+    curl -s -X POST "${BACKEND_API_URL}/api/mirror/${PROJECT_ID}/failover/${FAILOVER_ID}/internal-complete" \
+      -H "Content-Type: application/json" \
+      -H "X-Internal-Secret: ${INTERNAL_SECRET}" \
+      -d "{\"action\":\"${ACTION}\",\"status\":\"success\",\"resources_created\":${RESOURCES_ADDED}}"
+else
+    _log "❌ terraform ${ACTION} 실패 (exit code: ${TF_EXIT})"
+    curl -s -X POST "${BACKEND_API_URL}/api/mirror/${PROJECT_ID}/failover/${FAILOVER_ID}/internal-complete" \
+      -H "Content-Type: application/json" \
+      -H "X-Internal-Secret: ${INTERNAL_SECRET}" \
+      -d "{\"action\":\"${ACTION}\",\"status\":\"failed\",\"error\":\"terraform ${ACTION} 실패 (exit code ${TF_EXIT})\"}"
+    exit ${TF_EXIT}
+fi
+
+echo "[Failover Runner] 완료"

--- a/frontend/app/projects/[id]/gcp-connect/page.tsx
+++ b/frontend/app/projects/[id]/gcp-connect/page.tsx
@@ -1,0 +1,1046 @@
+// frontend/app/projects/[id]/gcp-connect/page.tsx
+'use client'
+
+import { useState, useRef, DragEvent, ChangeEvent } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { apiClient } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+type ConnectStatus = 'idle' | 'validating' | 'success' | 'error'
+
+interface ConnectResult {
+  gcp_project_id: string
+  sa_email: string
+  connected_at: string
+}
+
+const REQUIRED_ROLES = [
+  'Cloud Run 관리자',
+  'Compute 관리자',
+  'Cloud SQL 관리자',
+  '저장소 관리자',
+  'Artifact Registry 관리자',
+  '서비스 계정 관리자',
+]
+
+export default function GcpConnectPage() {
+  const params    = useParams()
+  const router    = useRouter()
+  const projectId = params.id as string
+
+  const [gcpProjectId, setGcpProjectId] = useState('')
+  const [keyData, setKeyData]           = useState<Record<string, unknown> | null>(null)
+  const [keyFileName, setKeyFileName]   = useState('')
+  const [status, setStatus]             = useState<ConnectStatus>('idle')
+  const [error, setError]               = useState('')
+  const [result, setResult]             = useState<ConnectResult | null>(null)
+  const [isDragging, setIsDragging]     = useState(false)
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // ── JSON 키 파싱 ─────────────────────────────────────────────
+  const parseKeyFile = (file: File) => {
+    setError('')
+    if (!file.name.endsWith('.json') && file.type !== 'application/json') {
+      setError('JSON 형식의 서비스 계정 키 파일만 업로드할 수 있습니다.')
+      setKeyData(null)
+      setKeyFileName('')
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      try {
+        const parsed = JSON.parse(e.target?.result as string)
+        if (!parsed.client_email || !parsed.private_key) {
+          setError('유효한 서비스 계정 키가 아닙니다. client_email / private_key 필드가 필요합니다.')
+          setKeyData(null)
+          setKeyFileName('')
+          return
+        }
+        setKeyData(parsed)
+        setKeyFileName(file.name)
+        if (!gcpProjectId && typeof parsed.project_id === 'string') {
+          setGcpProjectId(parsed.project_id)
+        }
+      } catch {
+        setError('JSON 파싱에 실패했습니다. 파일이 손상되지 않았는지 확인하세요.')
+        setKeyData(null)
+        setKeyFileName('')
+      }
+    }
+    reader.onerror = () => {
+      setError('파일을 읽는 중 오류가 발생했습니다.')
+    }
+    reader.readAsText(file)
+  }
+
+  // ── 드래그 앤 드롭 ───────────────────────────────────────────
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragging(true)
+  }
+
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragging(false)
+  }
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragging(false)
+    const file = e.dataTransfer.files?.[0]
+    if (file) parseKeyFile(file)
+  }
+
+  const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) parseKeyFile(file)
+  }
+
+  // ── 연동 실행 ────────────────────────────────────────────────
+  const handleConnect = async () => {
+    if (!gcpProjectId || !keyData) return
+    setStatus('validating')
+    setError('')
+
+    try {
+      const res = await apiClient.post(`/api/projects/${projectId}/gcp/connect`, {
+        gcp_project_id: gcpProjectId,
+        service_account_key: keyData,
+      })
+      setResult(res.data.data)
+      setStatus('success')
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { error?: { message?: string } } } })
+          ?.response?.data?.error?.message ?? 'GCP 연동에 실패했습니다. 권한과 프로젝트 ID를 확인하세요.'
+      setError(msg)
+      setStatus('error')
+    }
+  }
+
+  const handleRetry = () => {
+    setStatus('idle')
+    setError('')
+  }
+
+  const canConnect = Boolean(gcpProjectId && keyData) && status !== 'validating'
+
+  // ── 성공 화면 ────────────────────────────────────────────────
+  if (status === 'success' && result) {
+    return (
+      <>
+        <style>{styles}</style>
+        <div className="gc-page">
+          <div className="gc-success">
+            <div className="gc-success-ico">
+              <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+            <div className="gc-success-eyebrow">
+              <span className="gc-pip gc-pip-green" />
+              Connection Established
+            </div>
+            <h1 className="gc-success-title">GCP 연동 완료</h1>
+            <p className="gc-success-sub">
+              이제 MirrorOps Sync와 Failover 기능을 사용할 수 있습니다.
+            </p>
+
+            <div className="gc-success-detail">
+              <div className="gc-detail-row">
+                <span className="gc-detail-k">프로젝트</span>
+                <span className="gc-detail-v gc-mono">{result.gcp_project_id}</span>
+              </div>
+              <div className="gc-detail-row">
+                <span className="gc-detail-k">서비스 계정</span>
+                <span className="gc-detail-v gc-mono">{result.sa_email}</span>
+              </div>
+              <div className="gc-detail-row">
+                <span className="gc-detail-k">Artifact Registry</span>
+                <span className="gc-detail-v">
+                  <span className="gc-mono">autoops-repo</span>
+                  <span className="gc-detail-region">us-west1</span>
+                  <span className="gc-detail-auto">자동 생성됨</span>
+                </span>
+              </div>
+            </div>
+
+            <button
+              className="gc-btn-primary gc-btn-go"
+              onClick={() => router.push(`/projects/${projectId}/mirror`)}
+            >
+              <span>MirrorOps로 이동</span>
+              <span className="gc-go-arrow">→</span>
+            </button>
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <style>{styles}</style>
+
+      <div className="gc-page">
+
+        {/* ── Header (성공 후 숨김 — 위 분기에서 처리됨) ───────── */}
+        <header className="gc-header">
+          <button
+            onClick={() => router.push(`/projects/${projectId}/mirror`)}
+            className="gc-back"
+          >
+            <span className="gc-back-arrow">←</span>
+            프로젝트로
+          </button>
+          <div className="gc-eyebrow">
+            <span className="gc-pip" />
+            AutoOps · GCP Integration
+          </div>
+          <h1 className="gc-title">
+            <span className="gc-title-glyph">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+              </svg>
+            </span>
+            GCP 계정 연동
+          </h1>
+          <p className="gc-desc">
+            본인 GCP 서비스 계정 JSON 키를 업로드해 AutoOps와 연결하세요. 연동 후
+            MirrorOps의 DR 동기화와 페일오버 기능이 활성화됩니다.
+          </p>
+        </header>
+
+        {/* ── 안내 섹션 ─────────────────────────── */}
+        <section className="gc-card">
+          <div className="gc-card-eyebrow">
+            <span className="gc-pip gc-pip-blue" />
+            Step 01 · GCP 프로젝트
+          </div>
+
+          <div className="gc-field">
+            <label className="gc-field-label">GCP 프로젝트 ID</label>
+            <Input
+              value={gcpProjectId}
+              onChange={(e) => setGcpProjectId(e.target.value)}
+              placeholder="my-gcp-project-id"
+              className="gc-input gc-mono"
+            />
+          </div>
+
+          <p className="gc-hint">
+            GCP 콘솔에서 서비스 계정을 생성하고 JSON 키를 다운로드하세요.
+          </p>
+
+          {/* 필요 권한 */}
+          <div className="gc-roles">
+            <div className="gc-roles-label">필요 권한</div>
+            <div className="gc-roles-list">
+              {REQUIRED_ROLES.map((role) => (
+                <span key={role} className="gc-role">
+                  <span className="gc-role-dot" />
+                  {role}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* GCP 콘솔 단계별 가이드 */}
+          <div className="gc-guide">
+            <div className="gc-guide-bar">
+              <span className="gc-pip gc-pip-blue" />
+              GCP 콘솔 · 서비스 계정 만들기
+            </div>
+
+            <ol className="gc-steps">
+              <li className="gc-step">
+                <span className="gc-step-num">1</span>
+                <div className="gc-step-body">
+                  <p className="gc-step-text">
+                    <a href="https://console.cloud.google.com" target="_blank" rel="noopener noreferrer" className="gc-step-link">console.cloud.google.com</a>
+                    {' '}접속 → 상단에서 프로젝트 선택
+                  </p>
+                </div>
+              </li>
+
+              <li className="gc-step">
+                <span className="gc-step-num">2</span>
+                <div className="gc-step-body">
+                  <p className="gc-step-text">
+                    좌측 메뉴 → <span className="gc-kbd">IAM 및 관리자</span> → <span className="gc-kbd">서비스 계정</span> → <span className="gc-kbd">서비스 계정 만들기</span>
+                  </p>
+                  <div className="gc-step-note">
+                    <span className="gc-note-k">서비스 계정 이름</span>
+                    <span className="gc-note-v gc-mono">autoops-dr</span>
+                  </div>
+                </div>
+              </li>
+
+              <li className="gc-step">
+                <span className="gc-step-num">3</span>
+                <div className="gc-step-body">
+                  <p className="gc-step-text">
+                    <span className="gc-kbd">역할 선택</span>에서 아래 6개 역할 추가
+                  </p>
+                  <div className="gc-step-roles">
+                    <div className="gc-step-role">
+                      <span className="gc-role-dot" />
+                      <span className="gc-role-name">Cloud Run 관리자</span>
+                      <span className="gc-role-why">ECS Service → Cloud Run 배포</span>
+                    </div>
+                    <div className="gc-step-role">
+                      <span className="gc-role-dot" />
+                      <span className="gc-role-name">Compute 관리자</span>
+                      <span className="gc-role-why">VPC · 서브넷 · 방화벽 · NAT 생성</span>
+                    </div>
+                    <div className="gc-step-role">
+                      <span className="gc-role-dot" />
+                      <span className="gc-role-name">Cloud SQL 관리자</span>
+                      <span className="gc-role-why">RDS → Cloud SQL 생성</span>
+                    </div>
+                    <div className="gc-step-role">
+                      <span className="gc-role-dot" />
+                      <span className="gc-role-name">저장소 관리자</span>
+                      <span className="gc-role-why">GCS 버킷 (Terraform State)</span>
+                    </div>
+                    <div className="gc-step-role">
+                      <span className="gc-role-dot" />
+                      <span className="gc-role-name">Artifact Registry 관리자</span>
+                      <span className="gc-role-why">autoops-repo 생성</span>
+                    </div>
+                    <div className="gc-step-role">
+                      <span className="gc-role-dot" />
+                      <span className="gc-role-name">서비스 계정 관리자</span>
+                      <span className="gc-role-why">IAM Role → Service Account 생성</span>
+                    </div>
+                  </div>
+                </div>
+              </li>
+
+              <li className="gc-step">
+                <span className="gc-step-num">4</span>
+                <div className="gc-step-body">
+                  <p className="gc-step-text">
+                    서비스 계정 목록에서 <span className="gc-mono gc-inline-mono">autoops-dr</span> 클릭 → <span className="gc-kbd">키</span> 탭 →
+                    {' '}<span className="gc-kbd">키 추가</span> → <span className="gc-kbd">새 키 만들기</span> → <span className="gc-kbd">JSON</span> → <span className="gc-kbd">만들기</span>
+                  </p>
+                  <div className="gc-step-result">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                      <polyline points="7 10 12 15 17 10"/>
+                      <line x1="12" y1="15" x2="12" y2="3"/>
+                    </svg>
+                    JSON 파일이 자동으로 다운로드됩니다
+                  </div>
+                </div>
+              </li>
+            </ol>
+          </div>
+        </section>
+
+        {/* ── JSON 키 업로드 ────────────────────── */}
+        <section className="gc-card">
+          <div className="gc-card-eyebrow">
+            <span className="gc-pip gc-pip-blue" />
+            Step 02 · 서비스 계정 키
+          </div>
+
+          <div
+            className={`gc-drop ${isDragging ? 'gc-drop-active' : ''} ${keyData ? 'gc-drop-done' : ''}`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              onChange={handleFileSelect}
+              className="gc-file-input"
+            />
+
+            {keyData ? (
+              <div className="gc-drop-success">
+                <div className="gc-drop-check">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12"/>
+                  </svg>
+                </div>
+                <div className="gc-drop-file">
+                  <div className="gc-drop-fname gc-mono">{keyFileName}</div>
+                  <div className="gc-drop-fmeta">
+                    {typeof keyData.client_email === 'string' ? keyData.client_email : '서비스 계정 키 확인됨'}
+                  </div>
+                </div>
+                <span className="gc-drop-replace">교체하려면 클릭</span>
+              </div>
+            ) : (
+              <div className="gc-drop-empty">
+                <div className="gc-drop-ico">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                    <polyline points="17 8 12 3 7 8"/>
+                    <line x1="12" y1="3" x2="12" y2="15"/>
+                  </svg>
+                </div>
+                <div className="gc-drop-main">
+                  JSON 키 파일을 드래그하거나 <span className="gc-drop-browse">클릭하여 선택</span>
+                </div>
+                <div className="gc-drop-sub gc-mono">service-account-key.json</div>
+              </div>
+            )}
+          </div>
+
+          {error && status !== 'error' && (
+            <div className="gc-inline-error">
+              <span className="gc-err-dot" />
+              {error}
+            </div>
+          )}
+        </section>
+
+        {/* ── 에러 화면 ─────────────────────────── */}
+        {status === 'error' && (
+          <section className="gc-error-card">
+            <div className="gc-error-head">
+              <span className="gc-err-dot" />
+              GCP 연동 실패
+            </div>
+            <p className="gc-error-msg">{error}</p>
+            <Button
+              variant="outline"
+              className="gc-btn-retry"
+              onClick={handleRetry}
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="23 4 23 10 17 10"/>
+                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+              </svg>
+              다시 시도
+            </Button>
+          </section>
+        )}
+
+        {/* ── 연동 버튼 ─────────────────────────── */}
+        {status !== 'error' && (
+          <button
+            className={`gc-btn-primary gc-connect ${!canConnect ? 'gc-disabled' : ''}`}
+            onClick={handleConnect}
+            disabled={!canConnect}
+          >
+            {status === 'validating' ? (
+              <>
+                <span className="gc-spinner" />
+                <span>GCP 프로젝트 접근 권한 확인 중...</span>
+              </>
+            ) : (
+              <>
+                <span className="gc-connect-glyph">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+                  </svg>
+                </span>
+                <span>GCP 연동 시작</span>
+              </>
+            )}
+          </button>
+        )}
+
+      </div>
+    </>
+  )
+}
+
+// ─── styles ─────────────────────────────────────────────────────
+const styles = `
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+body { background: #0b0e17; color: #edf0f6; }
+body::before {
+  content: ""; position: fixed; inset: 0; z-index: -1;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 30%, transparent 80%);
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 30%, transparent 80%);
+  opacity: 0.55; pointer-events: none;
+}
+
+.gc-page {
+  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+  color: #edf0f6;
+  max-width: 580px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+  display: flex; flex-direction: column; gap: 18px;
+}
+
+.gc-mono {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  letter-spacing: 0.01em;
+}
+
+/* ── Header ─────────────────────────────────── */
+.gc-header { display: flex; flex-direction: column; gap: 6px; margin-bottom: 4px; }
+.gc-back {
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: 8px;
+  background: none; border: none;
+  color: #aeb4c5;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 13px; font-weight: 500;
+  cursor: pointer;
+  padding: 6px 0;
+  margin-bottom: 8px;
+  transition: color 160ms;
+}
+.gc-back:hover { color: #edf0f6; }
+.gc-back:hover .gc-back-arrow { transform: translateX(-3px); }
+.gc-back-arrow { transition: transform 200ms; display: inline-block; }
+
+.gc-eyebrow {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: #5aa3ff;
+  padding: 5px 11px;
+  border: 1px solid rgba(90,163,255,0.3);
+  border-radius: 100px;
+  background: rgba(90,163,255,0.06);
+  align-self: flex-start;
+}
+.gc-pip {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #5aa3ff; box-shadow: 0 0 8px #5aa3ff;
+  animation: gc-pulse 1.6s ease-in-out infinite;
+}
+.gc-pip-blue { background: #5aa3ff; box-shadow: 0 0 8px #5aa3ff; }
+.gc-pip-green { background: #22c55e; box-shadow: 0 0 8px #22c55e; }
+@keyframes gc-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.85); }
+}
+
+.gc-title {
+  display: flex; align-items: center; gap: 12px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 32px;
+  letter-spacing: -0.03em; line-height: 1.15;
+  margin: 6px 0 8px;
+  color: #edf0f6;
+}
+.gc-title-glyph {
+  width: 40px; height: 40px;
+  border-radius: 10px;
+  display: grid; place-items: center;
+  border: 1px solid rgba(90,163,255,0.32);
+  background: rgba(90,163,255,0.10);
+  color: #5aa3ff;
+  flex-shrink: 0;
+}
+.gc-desc {
+  font-size: 14.5px; color: #aeb4c5;
+  line-height: 1.6; margin: 0;
+}
+
+/* ── Card ───────────────────────────────────── */
+.gc-card {
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.005));
+  padding: 24px 26px;
+  display: flex; flex-direction: column; gap: 16px;
+}
+.gc-card-eyebrow {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: #5aa3ff;
+}
+
+/* ── Field ──────────────────────────────────── */
+.gc-field { display: flex; flex-direction: column; gap: 8px; }
+.gc-field-label {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: #aeb4c5;
+}
+.gc-input {
+  width: 100% !important;
+  background: rgba(0,0,0,0.4) !important;
+  border: 1px solid rgba(255,255,255,0.13) !important;
+  color: #edf0f6 !important;
+  padding: 11px 14px !important;
+  border-radius: 10px !important;
+  font-size: 13px !important;
+}
+.gc-input::placeholder { color: #7a8298 !important; }
+.gc-input:focus {
+  outline: none !important;
+  border-color: rgba(90,163,255,0.6) !important;
+  box-shadow: 0 0 0 3px rgba(90,163,255,0.14) !important;
+}
+
+.gc-hint {
+  font-size: 13px; color: #aeb4c5;
+  line-height: 1.55; margin: 0;
+}
+
+/* ── Roles ──────────────────────────────────── */
+.gc-roles { display: flex; flex-direction: column; gap: 10px; }
+.gc-roles-label {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: #aeb4c5;
+}
+.gc-roles-list { display: flex; flex-wrap: wrap; gap: 8px; }
+.gc-role {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: rgba(255,255,255,0.02);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px; color: #edf0f6;
+  letter-spacing: 0.01em;
+}
+.gc-role-dot {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: #ffa53d; box-shadow: 0 0 6px rgba(255,165,61,0.6);
+}
+
+/* ── Console guide (단계별) ─────────────────── */
+.gc-guide {
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(0,0,0,0.28);
+  overflow: hidden;
+}
+.gc-guide-bar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 11px 16px;
+  background: rgba(90,163,255,0.05);
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: #5aa3ff;
+}
+.gc-steps {
+  list-style: none;
+  margin: 0; padding: 8px 18px;
+  counter-reset: gc-step;
+}
+.gc-step {
+  position: relative;
+  display: flex; gap: 14px;
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.gc-step:last-child { border-bottom: none; }
+.gc-step:not(:last-child)::after {
+  content: ""; position: absolute;
+  left: 12px; top: 40px; bottom: 2px; width: 1px;
+  background: linear-gradient(180deg, rgba(90,163,255,0.3), transparent);
+}
+.gc-step-num {
+  flex-shrink: 0;
+  width: 25px; height: 25px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  border: 1px solid rgba(90,163,255,0.4);
+  background: rgba(90,163,255,0.12);
+  color: #5aa3ff;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px; font-weight: 600;
+  z-index: 1;
+}
+.gc-step-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 10px; padding-top: 2px; }
+.gc-step-text {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 13.5px; line-height: 1.6;
+  color: #edf0f6;
+  margin: 0;
+}
+.gc-step-link { color: #5aa3ff; text-decoration: none; border-bottom: 1px solid rgba(90,163,255,0.4); }
+.gc-step-link:hover { border-bottom-color: #5aa3ff; }
+.gc-kbd {
+  display: inline-block;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px; font-weight: 500;
+  color: #edf0f6;
+  padding: 1px 7px;
+  border: 1px solid rgba(255,255,255,0.16);
+  border-radius: 6px;
+  background: rgba(255,255,255,0.04);
+  white-space: nowrap;
+}
+.gc-inline-mono {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12.5px; color: #ffa53d;
+}
+.gc-step-note {
+  display: inline-flex; align-items: center; gap: 10px;
+  align-self: flex-start;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,165,61,0.28);
+  background: rgba(255,165,61,0.06);
+}
+.gc-note-k {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px; font-weight: 600;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: #ffa53d;
+}
+.gc-note-v {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px; font-weight: 600;
+  color: #edf0f6;
+}
+.gc-step-roles {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 6px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.02);
+}
+.gc-step-role {
+  display: grid;
+  grid-template-columns: 9px minmax(0, auto) 1fr;
+  align-items: baseline;
+  gap: 4px 11px;
+  padding: 9px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+.gc-step-role:last-child { border-bottom: none; }
+.gc-step-role .gc-role-dot { align-self: center; }
+.gc-role-name {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12.5px; font-weight: 600;
+  color: #edf0f6;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+.gc-role-why {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 12px; font-weight: 500;
+  color: #aeb4c5;
+  letter-spacing: -0.005em;
+  line-height: 1.45;
+}
+.gc-step-result {
+  display: inline-flex; align-items: center; gap: 8px;
+  align-self: flex-start;
+  padding: 8px 13px;
+  border-radius: 8px;
+  border: 1px solid rgba(34,197,94,0.32);
+  background: rgba(34,197,94,0.08);
+  color: #22c55e;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px; font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+/* ── Drop zone ──────────────────────────────── */
+.gc-drop {
+  position: relative;
+  border-radius: 14px;
+  border: 1.5px dashed rgba(255,255,255,0.2);
+  background: rgba(255,255,255,0.012);
+  padding: 28px 24px;
+  cursor: pointer;
+  transition: all 200ms;
+}
+.gc-drop:hover { border-color: rgba(90,163,255,0.5); background: rgba(90,163,255,0.04); }
+.gc-drop-active {
+  border-color: #5aa3ff;
+  background: rgba(90,163,255,0.10);
+  box-shadow: 0 0 0 4px rgba(90,163,255,0.10), 0 0 30px rgba(90,163,255,0.12);
+}
+.gc-drop-done {
+  border-style: solid;
+  border-color: rgba(34,197,94,0.5);
+  background: rgba(34,197,94,0.05);
+  cursor: pointer;
+}
+.gc-file-input { display: none; }
+
+.gc-drop-empty {
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  text-align: center;
+}
+.gc-drop-ico {
+  width: 48px; height: 48px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.13);
+  background: rgba(255,255,255,0.03);
+  color: #5aa3ff;
+  display: grid; place-items: center;
+  margin-bottom: 4px;
+}
+.gc-drop-main {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px; font-weight: 500;
+  color: #edf0f6;
+}
+.gc-drop-browse { color: #5aa3ff; font-weight: 600; }
+.gc-drop-sub {
+  font-size: 11px; color: #7a8298;
+  letter-spacing: 0.04em;
+}
+
+.gc-drop-success {
+  display: flex; align-items: center; gap: 14px;
+}
+.gc-drop-check {
+  width: 38px; height: 38px;
+  border-radius: 10px;
+  background: rgba(34,197,94,0.16);
+  border: 1px solid rgba(34,197,94,0.4);
+  color: #22c55e;
+  display: grid; place-items: center;
+  flex-shrink: 0;
+}
+.gc-drop-file { flex: 1; min-width: 0; }
+.gc-drop-fname {
+  font-size: 13.5px; font-weight: 600;
+  color: #edf0f6;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.gc-drop-fmeta {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; color: #7a8298;
+  letter-spacing: 0.01em;
+  margin-top: 2px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.gc-drop-replace {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px; color: #5aa3ff;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+@media (max-width: 480px) {
+  .gc-drop-replace { display: none; }
+}
+
+/* ── Inline error ───────────────────────────── */
+.gc-inline-error {
+  display: flex; align-items: center; gap: 10px;
+  padding: 11px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(239,68,68,0.3);
+  background: rgba(239,68,68,0.06);
+  font-size: 12.5px; color: #ef4444;
+  line-height: 1.5;
+}
+.gc-err-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #ef4444; box-shadow: 0 0 8px #ef4444;
+  flex-shrink: 0;
+}
+
+/* ── Error card ─────────────────────────────── */
+.gc-error-card {
+  border-radius: 16px;
+  border: 1px solid rgba(239,68,68,0.32);
+  background: linear-gradient(180deg, rgba(239,68,68,0.06), rgba(239,68,68,0.015));
+  padding: 22px 26px;
+  display: flex; flex-direction: column; gap: 14px;
+  align-items: flex-start;
+}
+.gc-error-head {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; font-weight: 600;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: #ef4444;
+}
+.gc-error-msg {
+  font-size: 14px; color: #edf0f6;
+  line-height: 1.55; margin: 0;
+}
+.gc-btn-retry {
+  display: inline-flex !important; align-items: center !important; gap: 8px !important;
+  padding: 10px 16px !important;
+  border-radius: 10px !important;
+  font-family: 'Plus Jakarta Sans', sans-serif !important;
+  font-size: 13px !important; font-weight: 600 !important;
+  border: 1px solid rgba(239,68,68,0.4) !important;
+  background: rgba(239,68,68,0.08) !important;
+  color: #ef4444 !important;
+  cursor: pointer;
+  transition: all 160ms;
+}
+.gc-btn-retry:hover { background: rgba(239,68,68,0.16) !important; border-color: rgba(239,68,68,0.6) !important; }
+
+/* ── Primary / connect button ───────────────── */
+.gc-btn-primary {
+  display: flex; align-items: center; justify-content: center; gap: 12px;
+  width: 100%;
+  padding: 15px 24px;
+  border-radius: 12px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 15px; font-weight: 700;
+  letter-spacing: -0.01em;
+  border: 1px solid rgba(90,163,255,0.5);
+  background: linear-gradient(180deg, #5aa3ff, #3d83df);
+  color: #0b0e17;
+  cursor: pointer;
+  transition: all 200ms;
+  box-shadow: 0 0 24px rgba(90,163,255,0.2);
+}
+.gc-btn-primary:hover { filter: brightness(1.08); transform: translateY(-1px); box-shadow: 0 8px 32px -6px rgba(90,163,255,0.45); }
+.gc-connect-glyph { display: inline-flex; }
+.gc-disabled {
+  background: rgba(255,255,255,0.04);
+  border-color: rgba(255,255,255,0.1);
+  color: #7a8298;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+.gc-disabled:hover { filter: none; transform: none; box-shadow: none; }
+
+.gc-spinner {
+  width: 16px; height: 16px; border-radius: 50%;
+  border: 2px solid rgba(11,14,23,0.25);
+  border-top-color: #0b0e17;
+  animation: gc-spin 700ms linear infinite;
+}
+.gc-disabled .gc-spinner { border-color: rgba(174,180,197,0.2); border-top-color: #aeb4c5; }
+@keyframes gc-spin { to { transform: rotate(360deg); } }
+
+/* validating 상태는 비활성처럼 보이되 스피너는 명확히 */
+.gc-connect:disabled:not(.gc-disabled) {
+  background: linear-gradient(180deg, rgba(90,163,255,0.5), rgba(61,131,223,0.5));
+  color: #0b0e17;
+  cursor: wait;
+}
+
+/* ── Success screen ─────────────────────────── */
+.gc-success {
+  border-radius: 18px;
+  border: 1px solid rgba(34,197,94,0.32);
+  background:
+    radial-gradient(ellipse 120% 80% at 50% 0%, rgba(34,197,94,0.10), transparent 70%),
+    linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.005));
+  padding: 40px 36px;
+  display: flex; flex-direction: column; align-items: center;
+  text-align: center;
+  box-shadow: 0 0 60px -20px rgba(34,197,94,0.3);
+}
+.gc-success-ico {
+  width: 64px; height: 64px;
+  border-radius: 50%;
+  background: rgba(34,197,94,0.16);
+  border: 1px solid rgba(34,197,94,0.45);
+  color: #22c55e;
+  display: grid; place-items: center;
+  margin-bottom: 20px;
+  box-shadow: 0 0 0 6px rgba(34,197,94,0.08), 0 0 30px rgba(34,197,94,0.25);
+}
+.gc-success-eyebrow {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: #22c55e;
+  margin-bottom: 12px;
+}
+.gc-success-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 28px;
+  letter-spacing: -0.03em;
+  color: #edf0f6;
+  margin: 0 0 8px;
+}
+.gc-success-sub {
+  font-size: 14px; color: #aeb4c5;
+  line-height: 1.6; margin: 0 0 28px;
+  max-width: 380px;
+}
+
+.gc-success-detail {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(0,0,0,0.3);
+  padding: 4px 18px;
+  margin-bottom: 28px;
+  text-align: left;
+}
+.gc-detail-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  padding: 13px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.gc-detail-row:last-child { border-bottom: none; }
+.gc-detail-k {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px; font-weight: 600;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: #7a8298;
+  flex-shrink: 0;
+}
+.gc-detail-v {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 13px; color: #edf0f6;
+  text-align: right;
+  word-break: break-all;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+.gc-detail-region {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px; font-weight: 600;
+  letter-spacing: 0.08em;
+  color: #5aa3ff;
+  padding: 2px 8px;
+  border: 1px solid rgba(90,163,255,0.32);
+  background: rgba(90,163,255,0.08);
+  border-radius: 100px;
+}
+.gc-detail-auto {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px; font-weight: 600;
+  letter-spacing: 0.08em;
+  color: #22c55e;
+  padding: 2px 8px;
+  border: 1px solid rgba(34,197,94,0.4);
+  background: rgba(34,197,94,0.10);
+  border-radius: 100px;
+}
+
+.gc-btn-go {
+  background: linear-gradient(180deg, #22c55e, #16a34a);
+  border-color: rgba(34,197,94,0.5);
+  color: #04140a;
+  box-shadow: 0 0 28px rgba(34,197,94,0.25);
+  max-width: 320px;
+}
+.gc-btn-go:hover { box-shadow: 0 8px 36px -6px rgba(34,197,94,0.5); }
+.gc-go-arrow { transition: transform 200ms; display: inline-block; }
+.gc-btn-go:hover .gc-go-arrow { transform: translateX(4px); }
+
+/* ── Responsive ─────────────────────────────── */
+@media (max-width: 560px) {
+  .gc-page { padding: 32px 18px 80px; }
+  .gc-title { font-size: 26px; }
+  .gc-success { padding: 32px 22px; }
+  .gc-detail-row { flex-direction: column; align-items: flex-start; gap: 4px; }
+  .gc-detail-v { justify-content: flex-start; text-align: left; }
+}
+`

--- a/frontend/app/projects/[id]/mirror/page.tsx
+++ b/frontend/app/projects/[id]/mirror/page.tsx
@@ -58,6 +58,10 @@ export default function MirrorDashboardPage() {
   const [syncError, setSyncError]         = useState<string | null>(null)
   const [isSyncing, setIsSyncing]         = useState(false)
 
+  // ── GCP 연동 상태 ────────────────────────────────────────────────
+  const [isConnected, setIsConnected]       = useState<boolean | null>(null)
+  const [showNotConnected, setShowNotConnected] = useState(false)
+
   // ── GCP 리소스 관리 상태 ─────────────────────────────────────────
   const [latestFailover, setLatestFailover]   = useState<FailoverRecord | null>(null)
   const [destroyStatus, setDestroyStatus] = useState<'idle' | 'confirming' | 'destroying' | 'destroyed' | 'failed'>('idle')
@@ -68,6 +72,14 @@ export default function MirrorDashboardPage() {
       .get(`/api/projects/${projectId}`)
       .then((res) => setProject(res.data.data))
       .catch(() => {})
+  }, [projectId])
+
+  // GCP 연동 상태 조회 — 페이지 진입 시 is_connected 확인
+  useEffect(() => {
+    apiClient
+      .get(`/api/projects/${projectId}/gcp/status`)
+      .then((res) => setIsConnected(Boolean(res.data?.data?.is_connected)))
+      .catch(() => setIsConnected(false))
   }, [projectId])
 
   // 페일오버 이력 조회 — 페이지 진입 시 GCP 리소스 상태 복원
@@ -158,6 +170,15 @@ export default function MirrorDashboardPage() {
       await apiClient.post(`/api/mirror/${projectId}/sync`)
       refetch()
     } catch (err: unknown) {
+      // GCP_NOT_CONNECTED (400) → 연동 안내 배너 표시 (추가)
+      const code =
+        (err as { response?: { data?: { error?: { code?: string } } } })
+          ?.response?.data?.error?.code
+      const httpStatus = (err as { response?: { status?: number } })?.response?.status
+      if (code === 'GCP_NOT_CONNECTED' || httpStatus === 400) {
+        setIsConnected(false)
+        setShowNotConnected(true)
+      }
       const msg =
         (err as { response?: { data?: { error?: { message?: string } } } })
           ?.response?.data?.error?.message ?? '동기화 요청에 실패했습니다.'
@@ -213,6 +234,8 @@ export default function MirrorDashboardPage() {
   const showGcpManagement = latestFailover &&
     ['completed', 'failed', 'destroying', 'destroyed', 'destroy_failed'].includes(latestFailover.status)
 
+  const goToConnect = () => router.push(`/projects/${projectId}/gcp-connect`)
+
   return (
     <>
       <style>{styles}</style>
@@ -232,26 +255,62 @@ export default function MirrorDashboardPage() {
               {awsRegion} 리전 기준 실시간 인프라 동기화 현황입니다.
             </p>
           </div>
-          <button
-            className="mr-btn mr-btn-secondary"
-            onClick={handleManualSync}
-            disabled={isSyncing || project?.status !== 'completed'}
-          >
-            {isSyncing ? (
-              <>
-                <span className="mr-spinner-sm" />
-                <span>동기화 중...</span>
-              </>
-            ) : (
-              <>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-                  <path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/>
-                </svg>
-                <span>수동 동기화</span>
-              </>
+
+          {/* Sync 버튼 — GCP 연동 상태에 따라 활성/비활성 */}
+          <div className="mr-sync-wrap">
+            <button
+              className="mr-btn mr-btn-secondary"
+              onClick={handleManualSync}
+              disabled={isSyncing || project?.status !== 'completed' || isConnected === false || drStatus?.dr_status === 'syncing'}
+            >
+              {isSyncing ? (
+                <>
+                  <span className="mr-spinner-sm" />
+                  <span>동기화 중...</span>
+                </>
+              ) : (
+                <>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                    <path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/>
+                  </svg>
+                  <span>{isConnected === null ? '로딩 중...' : isConnected ? 'DR 패키지 생성' : 'GCP 연동 필요'}</span>
+                </>
+              )}
+            </button>
+
+            {isConnected === false && (
+              <div className="mr-sync-hint">
+                <span className="mr-sync-hint-text">GCP 연동 후 DR 패키지를 생성할 수 있습니다.</span>
+                <button className="mr-sync-link" onClick={goToConnect}>
+                  GCP 연동하기 <span className="mr-arrow">→</span>
+                </button>
+              </div>
             )}
-          </button>
+          </div>
         </div>
+
+        {/* GCP_NOT_CONNECTED 인라인 에러 배너 */}
+        {showNotConnected && (
+          <div className="mr-gcp-banner">
+            <span className="mr-gcp-banner-ico">⚠️</span>
+            <div className="mr-gcp-banner-body">
+              <div className="mr-gcp-banner-title">GCP 계정 연동이 필요합니다.</div>
+              <div className="mr-gcp-banner-desc">
+                MirrorOps Sync와 Failover를 사용하려면 GCP 계정을 먼저 연동해야 합니다.
+              </div>
+              <button className="mr-gcp-banner-cta" onClick={goToConnect}>
+                GCP 연동하기 <span className="mr-arrow">→</span>
+              </button>
+            </div>
+            <button
+              className="mr-gcp-banner-close"
+              onClick={() => setShowNotConnected(false)}
+              aria-label="닫기"
+            >
+              ✕
+            </button>
+          </div>
+        )}
 
         {/* Sync error */}
         {syncError && (
@@ -804,6 +863,28 @@ body::before {
 }
 .mr-sub { font-size: 14.5px; color: #aeb4c5; margin: 0; line-height: 1.55; }
 
+/* Sync 버튼 + 안내 (추가) */
+.mr-sync-wrap { display: flex; flex-direction: column; align-items: flex-end; gap: 10px; }
+.mr-sync-hint {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 6px;
+  text-align: right; max-width: 240px;
+}
+.mr-sync-hint-text {
+  font-size: 12px; color: #7a8298; line-height: 1.5;
+}
+.mr-sync-link {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: none; border: none; cursor: pointer;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 12.5px; font-weight: 600;
+  color: #5aa3ff;
+  padding: 0;
+  transition: color 160ms;
+}
+.mr-sync-link:hover { color: #8cc0ff; }
+.mr-sync-link:hover .mr-arrow { transform: translateX(3px); }
+.mr-sync-link .mr-arrow { transition: transform 200ms; }
+
 .mr-btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 9px;
   padding: 11px 18px;
@@ -858,6 +939,56 @@ body::before {
   font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-weight: 700; font-size: 11px;
 }
+
+/* GCP_NOT_CONNECTED 배너 (추가) */
+.mr-gcp-banner {
+  display: flex; gap: 14px; align-items: flex-start;
+  padding: 16px 18px; border-radius: 12px;
+  border: 1px solid rgba(250,204,21,0.3);
+  background: rgba(250,204,21,0.1);
+  margin-bottom: 20px;
+  position: relative;
+}
+.mr-gcp-banner-ico {
+  flex-shrink: 0; font-size: 18px; line-height: 1.4;
+}
+.mr-gcp-banner-body { flex: 1; min-width: 0; }
+.mr-gcp-banner-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700; font-size: 14.5px;
+  color: #facc15; letter-spacing: -0.01em;
+  margin-bottom: 4px;
+}
+.mr-gcp-banner-desc {
+  font-size: 13px; color: #d6c98a; line-height: 1.55;
+  margin-bottom: 12px;
+}
+.mr-gcp-banner-cta {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 9px 16px; border-radius: 9px;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 13px; font-weight: 600;
+  border: 1px solid rgba(250,204,21,0.45);
+  background: rgba(250,204,21,0.14);
+  color: #facc15;
+  cursor: pointer;
+  transition: background 160ms, border-color 160ms;
+}
+.mr-gcp-banner-cta:hover { background: rgba(250,204,21,0.22); border-color: rgba(250,204,21,0.65); }
+.mr-gcp-banner-cta:hover .mr-arrow { transform: translateX(3px); }
+.mr-gcp-banner-cta .mr-arrow { transition: transform 200ms; }
+.mr-gcp-banner-close {
+  flex-shrink: 0;
+  width: 26px; height: 26px;
+  border-radius: 7px;
+  border: 1px solid rgba(250,204,21,0.22);
+  background: transparent;
+  color: rgba(250,204,21,0.7);
+  cursor: pointer; font-size: 12px;
+  display: grid; place-items: center;
+  transition: color 160ms, background 160ms, border-color 160ms;
+}
+.mr-gcp-banner-close:hover { color: #facc15; background: rgba(250,204,21,0.12); border-color: rgba(250,204,21,0.4); }
 
 .mr-split {
   display: grid; grid-template-columns: 1fr 1fr;
@@ -1081,5 +1212,7 @@ body::before {
   .mr-kpi-cell { align-items: flex-start; }
   .mr-action-row { flex-direction: column; }
   .mr-gcp-info { grid-template-columns: repeat(2, 1fr); }
+  .mr-sync-wrap { align-items: flex-start; }
+  .mr-sync-hint { align-items: flex-start; text-align: left; }
 }
 `

--- a/frontend/app/projects/[id]/page.tsx
+++ b/frontend/app/projects/[id]/page.tsx
@@ -98,7 +98,7 @@ export default function GovernancePage() {
       ])
       setProject(projRes.data.data)
       setDrift(driftRes.data.data.slice(0, 5))
-      setTotalDriftAll(driftRes.data.data.length)
+      setTotalDriftAll(driftRes.data.data.filter((d: any) => d.status === 'detected').length)
       setAudit(auditRes.data.data.items?.slice(0, 5) || [])
       setTotal(projRes.data.data?.aws_resource_count || 0)
 
@@ -298,7 +298,7 @@ export default function GovernancePage() {
                : project.dr_status === 'syncing' ? 'Syncing'
                : 'Not Ready'}
             </div>
-            <div className="gv-kpi-foot">GCP us-central1</div>
+            <div className="gv-kpi-foot">GCP us-west1</div>
           </div>
 
           <div className="gv-kpi">

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
- failover-runner/Dockerfile: 신규 생성 (terraform + gcloud + aws-cli)
- failover-runner/entrypoint.sh: 신규 생성 (apply/destroy 실행 + internal-complete 호출 + resources_created 파싱)
- mirror.py: _run_failover_actual/_run_failover_destroy ECS Task 호출로 변경
- mirror.py: ECS run_task logConfiguration 오버라이드 제거
- mirror.py: internal_failover_complete RTO 계산 및 resources_created 저장 추가
- mirror.py: FailoverCompleteBody resources_created 필드 추가
- websocket.py: _stream_failover_logs CloudWatch filter_log_events 방식으로 수정
- mapping_engine.py: deletion_protection = false 추가
- frontend/app/projects/[id]/page.tsx: GCP 리전 us-central1 → us-west1 수정"