### PR TITLE
feat(epic8): add OIDC-based CD pipelines

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,78 @@
+name: Deploy Backend
+
+"on":
+  push:
+    branches: [main, develop]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy-backend.yml'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REGISTRY: 611058323802.dkr.ecr.us-west-2.amazonaws.com
+  ECR_REPOSITORY: autoops-backend
+  ECS_CLUSTER: autoops-cluster
+  ECS_SERVICE: autoops-backend-service
+  ROLE_ARN: arn:aws:iam::611058323802:role/autoops-github-actions-role
+
+jobs:
+  deploy:
+    name: Build & Deploy Backend
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, Tag, Push
+        run: |
+          IMAGE_URI=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          docker buildx build \
+            --platform linux/amd64 \
+            -t $IMAGE_URI:${{ github.sha }} \
+            -t $IMAGE_URI:latest \
+            --push \
+            ./backend/
+          echo "✅ ECR 푸시 완료"
+
+      - name: Force ECS Redeployment
+        run: |
+          aws ecs update-service \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service ${{ env.ECS_SERVICE }} \
+            --force-new-deployment \
+            --region ${{ env.AWS_REGION }} > /dev/null
+
+          echo "⏳ ECS 재배포 시작..."
+
+      - name: Wait for Service Stable
+        run: |
+          aws ecs wait services-stable \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --services ${{ env.ECS_SERVICE }} \
+            --region ${{ env.AWS_REGION }}
+          echo "✅ ECS 서비스 안정화 완료"
+
+      - name: Health Check
+        run: |
+          sleep 5
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            https://d1zl418y69bnx0.cloudfront.net/health)
+          if [ "$STATUS" != "200" ]; then
+            echo "❌ 헬스체크 실패: HTTP $STATUS"
+            exit 1
+          fi
+          echo "✅ 백엔드 배포 완료 (HTTP $STATUS)"

--- a/.github/workflows/deploy-failover-runner.yml
+++ b/.github/workflows/deploy-failover-runner.yml
@@ -1,0 +1,47 @@
+name: Deploy Failover Runner
+
+"on":
+  push:
+    branches: [main, develop]
+    paths:
+      - 'failover-runner/**'
+      - '.github/workflows/deploy-failover-runner.yml'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REGISTRY: 611058323802.dkr.ecr.us-west-2.amazonaws.com
+  ECR_REPOSITORY: autoops-failover-runner
+  ROLE_ARN: arn:aws:iam::611058323802:role/autoops-github-actions-role
+
+jobs:
+  deploy:
+    name: Build & Push Failover Runner
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, Tag, Push
+        run: |
+          IMAGE_URI=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          docker buildx build \
+            --platform linux/amd64 \
+            -t $IMAGE_URI:${{ github.sha }} \
+            -t $IMAGE_URI:latest \
+            --push \
+            ./failover-runner/
+          echo "✅ failover-runner ECR 푸시 완료"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,70 @@
+name: Deploy Frontend
+
+"on":
+  push:
+    branches: [main, develop]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/deploy-frontend.yml'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REGISTRY: 611058323802.dkr.ecr.us-west-2.amazonaws.com
+  ECR_REPOSITORY: autoops-frontend
+  ECS_CLUSTER: autoops-cluster
+  ECS_SERVICE: autoops-frontend-service
+  ROLE_ARN: arn:aws:iam::611058323802:role/autoops-github-actions-role
+  CF_DOMAIN: d1zl418y69bnx0.cloudfront.net
+
+jobs:
+  deploy:
+    name: Build & Deploy Frontend
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, Tag, Push
+        run: |
+          IMAGE_URI=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          docker buildx build \
+            --platform linux/amd64 \
+            --build-arg NEXT_PUBLIC_API_URL=https://${{ env.CF_DOMAIN }} \
+            --build-arg NEXT_PUBLIC_WS_URL=wss://${{ env.CF_DOMAIN }} \
+            -t $IMAGE_URI:${{ github.sha }} \
+            -t $IMAGE_URI:latest \
+            --push \
+            ./frontend/
+          echo "✅ ECR 푸시 완료 (CF: ${{ env.CF_DOMAIN }})"
+
+      - name: Force ECS Redeployment
+        run: |
+          aws ecs update-service \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service ${{ env.ECS_SERVICE }} \
+            --force-new-deployment \
+            --region ${{ env.AWS_REGION }} > /dev/null
+
+          echo "⏳ ECS 재배포 시작..."
+
+      - name: Wait for Service Stable
+        run: |
+          aws ecs wait services-stable \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --services ${{ env.ECS_SERVICE }} \
+            --region ${{ env.AWS_REGION }}
+          echo "✅ 프론트엔드 배포 완료"


### PR DESCRIPTION
##  OIDC 방식 사용: Access Key / MFA 불필요
- deploy-backend: ECR push → ECS force-redeploy → health check
- deploy-frontend: NEXT_PUBLIC_* build-arg 주입 → ECR → ECS redeploy
- deploy-failover-runner: ECR push only (ephemeral ECS Task)
- health check: CloudFront 경유 (ALB SG 직접 접근 차단)"