### PR TITLE
fix:cloudwatch 모니터링 대소문자 식별자 매칭 실패 수정

### DIFF
--- a/backend/app/services/craftops/hcl_template.py
+++ b/backend/app/services/craftops/hcl_template.py
@@ -82,8 +82,8 @@ def generate_hcl(config_snapshot: dict, include_backend: bool = True) -> str:
     rds_version       = rds_preset.get("engine_version", "15")
     allocated_storage = int(data_tier.get("allocated_storage", 20))
 
-    p        = f"{prefix}-{environment}"
-    p_lower  = f"{prefix}-{environment}".lower()
+    p       = f"{prefix}-{environment}".lower()  # 전체 소문자 통일
+    p_lower = p  # 하위 호환성 유지
     # cpu_units는 숫자 타입으로 처리 (문자열 아님)
     cpu_units = int(vcpu * 1024)
 


### PR DESCRIPTION
- hcl_template.py: p = f"{prefix}-{environment}".lower() 통일
  (기존 {p}/{p_lower} 혼재 → 전체 소문자 강제)
  (ECS/ALB/SG 등 리소스명 대소문자 불일치 → CloudWatch 매칭 실패 근본 해결)
- p_lower = p 하위 호환성 유지 (RDS/Secrets 기존 코드 영향 없음)