### PR TITLE
fix: Cross-Account 배포 방식 전환 및 Free Tier RDS 설정 수정

### DIFF
--- a/backend/app/api/craft.py
+++ b/backend/app/api/craft.py
@@ -450,7 +450,12 @@ def deploy(
         )
 
     try:
-        deploy_hcl = HCLGenerator().generate_for_deploy(deployment.config_snapshot)
+        snapshot_with_role = {
+            **deployment.config_snapshot,
+            "role_arn": account.role_arn,
+            "external_id": str(current_user.user_id),
+        }
+        deploy_hcl = HCLGenerator().generate_for_deploy(snapshot_with_role)
         hcl_s3_path = upload_hcl_to_s3(
             project_id=request.project_id,
             deployment_id=deployment.deployment_id,
@@ -555,13 +560,6 @@ def deployment_complete_callback(
             },
         )
         db.commit()
-
-        from app.api.diagram import _generate_diagram_task
-        background_tasks.add_task(
-            _generate_diagram_task,
-            project_id = body.project_id,
-            source     = "craftops_deploy",
-        )
 
         # §7-8 EventBridge 발행
         account = db.query(AWSAccount).filter(
@@ -717,7 +715,12 @@ def deployment_action(
         db.commit()
 
         # [FIX] hcl_s3_path 정의 추가
-        deploy_hcl = HCLGenerator().generate_for_deploy(deployment.config_snapshot)
+        snapshot_with_role = {
+            **deployment.config_snapshot,
+            "role_arn": account.role_arn,
+            "external_id": str(project.user_id),
+        }
+        deploy_hcl = HCLGenerator().generate_for_deploy(snapshot_with_role)
         hcl_s3_path = upload_hcl_to_s3(
             project_id=project_id,
             deployment_id=deployment_id,
@@ -748,7 +751,12 @@ def deployment_action(
         db.commit()
 
         # [FIX] hcl_s3_path 정의 추가
-        deploy_hcl = HCLGenerator().generate_for_deploy(deployment.config_snapshot)
+        snapshot_with_role = {
+            **deployment.config_snapshot,
+            "role_arn": account.role_arn,
+            "external_id": str(project.user_id),
+        }
+        deploy_hcl = HCLGenerator().generate_for_deploy(snapshot_with_role)
         hcl_s3_path = upload_hcl_to_s3(
             project_id=project_id,
             deployment_id=deployment_id,
@@ -938,6 +946,10 @@ def _run_detect_all(project_id: str, role_arn: str, external_id: str, prefix: st
             db.add(baseline)
         db.commit()
         print(f"[CraftOps] Baseline 등록 완료: {len(detected)}개")
+
+        # aws_resources 저장 완료 후 다이어그램 생성
+        from app.api.diagram import _generate_diagram_task
+        _generate_diagram_task(project_id=project_id, source="craftops_deploy")
 
     except Exception as e:
         print(f"[CraftOps] 리소스 감지 실패: {e}")

--- a/backend/app/services/craftops/dag_engine.py
+++ b/backend/app/services/craftops/dag_engine.py
@@ -380,7 +380,7 @@ class DAGEngine:
         env_presets: dict[str, dict] = {
             "production": {
                 "multi_az":              True,
-                "backup_retention_days": 30,
+                "backup_retention_days": 1,
                 "storage_encrypted":     True,
                 "instance_class":        "db.t3.medium",  # Gemini 없을 때 기본값
             },

--- a/backend/app/services/craftops/hcl_generator.py
+++ b/backend/app/services/craftops/hcl_generator.py
@@ -1,4 +1,3 @@
-# backend/app/services/craftops/hcl_generator.py
 import os
 import shutil
 import tempfile
@@ -7,29 +6,13 @@ from app.services.craftops.hcl_template import generate_hcl as template_generate
 
 
 class HCLGenerator:
-    """
-    config_snapshot을 받아 Terraform HCL 코드를 생성하고
-    terraform CLI 명령어 실행을 위한 임시 디렉토리를 관리한다.
-
-    v2: Gemini API 호출 제거 → Python 템플릿 기반 HCL 생성으로 전환
-    v3: validate용(include_backend=False) / deploy용(include_backend=True) 분리
-        - validate용: backend 블록 없음 → plan.add 정상 출력
-        - deploy용:   backend 블록 포함 → S3 state 정상 저장
-    v4: config_snapshot 필수 키 검증 추가
-        random provider 추가 (RDS 패스워드 random_id 사용)
-    """
-
     REQUIRED_KEYS = {"project_id", "prefix", "environment", "region"}
 
     def __init__(self):
         pass
 
     def generate(self, config_snapshot: dict) -> tuple[str, str]:
-        """
-        validate용 HCL 생성 (backend 블록 없음 → plan.add 정상 출력).
-        validator.py에서 호출.
-        반환: (hcl_code, work_dir)
-        """
+        """validate용 HCL (backend 블록 없음)"""
         self._validate_snapshot(config_snapshot)
         hcl_code   = template_generate_hcl(config_snapshot, include_backend=False)
         project_id = config_snapshot.get("project_id", "unknown")
@@ -39,49 +22,41 @@ class HCLGenerator:
 
     def generate_for_deploy(self, config_snapshot: dict) -> str:
         """
-        deploy용 HCL 생성 (backend 블록 포함 → S3 state 저장).
-        craft.py의 deploy 엔드포인트에서 호출.
-        반환: hcl_code (S3 업로드용)
+        deploy용 HCL (backend + assume_role 포함).
+        config_snapshot에 role_arn, external_id 필수.
         """
         self._validate_snapshot(config_snapshot)
-        return template_generate_hcl(config_snapshot, include_backend=True)
+        hcl_code = template_generate_hcl(config_snapshot, include_backend=True)
+
+        # provider 블록에 assume_role 주입
+        # hcl_template.py의 provider "aws" 블록을 assume_role 포함 버전으로 교체
+        role_arn    = config_snapshot.get("role_arn", "")
+        external_id = config_snapshot.get("external_id", "")
+        region      = config_snapshot.get("region", "us-west-2")
+
+        if role_arn and external_id:
+            old_provider = f'provider "aws" {{\n  region = "{region}"\n}}'
+            new_provider = (
+                f'provider "aws" {{\n'
+                f'  region = "{region}"\n\n'
+                f'  assume_role {{\n'
+                f'    role_arn     = "{role_arn}"\n'
+                f'    external_id  = "{external_id}"\n'
+                f'  }}\n'
+                f'}}'
+            )
+            hcl_code = hcl_code.replace(old_provider, new_provider)
+
+        return hcl_code
 
     def write_to_dir(self, hcl_code: str, work_dir: str) -> None:
-        """HCL 코드를 작업 디렉토리의 main.tf에 저장(덮어쓰기)한다."""
         (Path(work_dir) / "main.tf").write_text(hcl_code, encoding="utf-8")
 
     def cleanup(self, work_dir: str) -> None:
-        """Validation 완료 후 임시 디렉토리를 정리한다."""
         if work_dir and os.path.exists(work_dir):
             shutil.rmtree(work_dir, ignore_errors=True)
 
-    # ── Private 헬퍼 ────────────────────────────────────────────────
-
     def _validate_snapshot(self, config_snapshot: dict) -> None:
-        """
-        config_snapshot 필수 키 존재 여부를 검증한다.
-        누락된 키가 있으면 ValueError를 발생시킨다.
-        """
         missing = self.REQUIRED_KEYS - set(config_snapshot.keys())
         if missing:
-            raise ValueError(
-                f"config_snapshot 필수 키 누락: {sorted(missing)}"
-            )
-
-    def _write_providers(self, work_dir: str) -> None:
-        """
-        random provider 설정 파일을 작업 디렉토리에 생성한다.
-        hcl_template.py의 random_id 리소스(RDS 패스워드)가 이 provider를 필요로 한다.
-        """
-        providers_hcl = """terraform {
-  required_providers {
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.0"
-    }
-  }
-}
-"""
-        (Path(work_dir) / "providers.tf").write_text(
-            providers_hcl, encoding="utf-8"
-        )
+            raise ValueError(f"config_snapshot 필수 키 누락: {sorted(missing)}")

--- a/terraform-runner/entrypoint.sh
+++ b/terraform-runner/entrypoint.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-# terraform-runner/entrypoint.sh
-# set -e 제거 — 오류 발생 시 콜백 전송 후 종료하기 위해
-
-# ── 환경변수 (ECS Task 실행 시 주입) ───────────────────────────────
-# PROJECT_ID       : AutoOps 프로젝트 ID
-# DEPLOYMENT_ID    : 배포 ID
-# HCL_S3_PATH      : main.tf가 저장된 S3 경로
-# ROLE_ARN         : 사용자 AWS 계정 Cross-Account IAM Role ARN
-# REGION           : 사용자 인프라 배포 리전
-# ACTION           : apply | destroy
-# EXTERNAL_ID      : AssumeRole ExternalId (user_id)
-# BACKEND_API_URL  : 백엔드 ALB URL (콜백용)
-# INTERNAL_SECRET  : 내부 API 시크릿
-# AWS_DEFAULT_REGION=us-west-2 (AutoOps 플랫폼 리전)
 
 echo "[AutoOps Runner] 시작: DEPLOYMENT_ID=${DEPLOYMENT_ID}, ACTION=${ACTION}"
 
@@ -52,33 +38,28 @@ echo "[AutoOps Runner] main.tf 다운로드 완료: ${HCL_S3_PATH}"
 
 cd /workspace/tf
 
-# ── Cross-Account Role Assume ───────────────────────────────────────
-CREDS=$(aws sts assume-role \
+# ── Cross-Account Role Assume 검증 (자격증명 교체 없음) ─────────────
+# provider 블록의 assume_role이 terraform apply 시점에 처리
+# backend(S3/DynamoDB)는 AutoOpsTaskRole 자격증명 그대로 사용
+aws sts assume-role \
   --role-arn "${ROLE_ARN}" \
-  --role-session-name "autoops-deploy-${DEPLOYMENT_ID}" \
+  --role-session-name "autoops-verify-${DEPLOYMENT_ID}" \
   --external-id "${EXTERNAL_ID}" \
-  --duration-seconds 3600 \
-  --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-  --output text)
-
+  --duration-seconds 900 \
+  > /dev/null
 if [ $? -ne 0 ]; then
-  echo "[AutoOps Runner] Cross-Account Role Assume 실패"
+  echo "[AutoOps Runner] Cross-Account Role Assume 검증 실패"
   send_callback "failed" "IAM Role Assume 실패: ${ROLE_ARN}"
   exit 1
 fi
-
-export AWS_ACCESS_KEY_ID=$(echo $CREDS | awk '{print $1}')
-export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | awk '{print $2}')
-export AWS_SESSION_TOKEN=$(echo $CREDS | awk '{print $3}')
-export AWS_DEFAULT_REGION="${REGION}"
-
 echo "[AutoOps Runner] Cross-Account Role Assume 완료"
 
 # ── terraform init ──────────────────────────────────────────────────
+# 이 시점 자격증명 = AutoOpsTaskRole (플랫폼 계정)
+# → S3/DynamoDB backend 접근 정상
 terraform init -input=false
 if [ $? -ne 0 ]; then
   echo "[AutoOps Runner] terraform init 실패"
-  # apply 실패 → partial_failed / destroy 실패 → destroy_failed
   if [ "${ACTION}" = "destroy" ]; then
     send_callback "destroy_failed" "terraform init 실패 (destroy)"
   else
@@ -89,6 +70,8 @@ fi
 echo "[AutoOps Runner] terraform init 완료"
 
 # ── terraform apply 또는 destroy ────────────────────────────────────
+# provider 블록의 assume_role이 사용자 계정으로 전환
+# → 리소스 생성/삭제는 사용자 계정에서 실행
 if [ "${ACTION}" = "destroy" ]; then
   terraform destroy -auto-approve -input=false
   TF_EXIT=$?


### PR DESCRIPTION
[Cross-Account AssumeRole 방식 전환]
- entrypoint.sh: AssumeRole 후 환경변수 교체 제거
  (backend S3/DynamoDB는 AutoOpsTaskRole 자격증명 유지)
- hcl_generator.py: generate_for_deploy에 provider assume_role 블록 주입
- craft.py: generate_for_deploy 호출 시 role_arn, external_id 전달 (453, 713, 744번 줄)

[Free Tier 대응]
- dag_engine.py: staging backup_retention_days 7 → 1 (Free Tier 제한 대응)"