### PR TITLE
fix:ASAP

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     unzip \
     wget \
-    skopeo \ 
+    skopeo \
     && rm -rf /var/lib/apt/lists/*
 
 # Terraform 설치
@@ -17,20 +17,26 @@ RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/1.14.8/terraf
     && mv terraform /usr/local/bin/ \
     && rm terraform.zip
 
-# tfsec 설치
-RUN curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
+# tfsec 설치 (버전 고정)
+RUN curl -sL https://github.com/aquasecurity/tfsec/releases/download/v1.28.11/tfsec-linux-amd64 \
+    -o /usr/local/bin/tfsec \
+    && chmod +x /usr/local/bin/tfsec
 
-# Infracost 설치
-RUN curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
+# Infracost 설치 (버전 고정)
+RUN curl -sL https://github.com/infracost/infracost/releases/download/v0.10.39/infracost-linux-amd64.tar.gz \
+    -o /tmp/infracost.tar.gz \
+    && tar -xzf /tmp/infracost.tar.gz -C /tmp \
+    && mv /tmp/infracost-linux-amd64 /usr/local/bin/infracost \
+    && rm /tmp/infracost.tar.gz
 
-# gcloud 설치 추가 (infracost 설치 다음에)
+# gcloud 설치
 RUN curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
 ENV PATH $PATH:/root/google-cloud-sdk/bin
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# checkov 설치 (requirements.txt에 없는 경우 별도 설치)
+# checkov 설치
 RUN pip install checkov
 
 COPY . .

--- a/backend/app/api/accounts.py
+++ b/backend/app/api/accounts.py
@@ -1,11 +1,11 @@
 # backend/app/api/accounts.py
 import boto3
+import json as _json
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from app.core.auth import get_current_user
-from app.core.config import settings
 from app.core.database import get_db
 from app.models.aws_account import AWSAccount
 from app.models.user import User
@@ -18,33 +18,308 @@ class ConnectAccountRequest(BaseModel):
     account_alias: str | None = None
 
 
+def _setup_config_and_drift(temp_creds: dict, aws_account_id: str):
+    """
+    사용자 계정에 AWS Config 설정 + 플랫폼 리소스 정책 업데이트.
+    계정 연동 시 1회 실행. 이미 설정된 경우 스킵.
+
+    CF 스택(autoops-role.yaml)에서 처리하는 것:
+      - AutoOpsDriftEventRole
+      - EventBridge Rules (Drift 감지 + RDS 스냅샷 완료)
+      - KMS Key (alias/autoops-rds-export)
+
+    accounts.py에서 처리하는 것:
+      - AWS Config (S3, ConfigRole, Recorder, Delivery, Recording)
+      - 플랫폼 SQS 정책 업데이트 (Drift + MirrorOps)
+      - 플랫폼 DR S3 버킷 정책 업데이트
+    """
+    region             = "us-west-2"
+    platform_account_id = "611058323802"
+    bucket_name        = f"autoops-config-{aws_account_id}"
+    sqs_arn            = f"arn:aws:sqs:{region}:{platform_account_id}:autoops-drift-events"
+    mirrorops_sqs_arn  = f"arn:aws:sqs:{region}:{platform_account_id}:autoops-mirrorops-trigger"
+    queue_url          = f"https://sqs.{region}.amazonaws.com/{platform_account_id}/autoops-drift-events"
+    mirrorops_queue_url = f"https://sqs.{region}.amazonaws.com/{platform_account_id}/autoops-mirrorops-trigger"
+
+    def _client(service):
+        return boto3.client(
+            service,
+            region_name=region,
+            aws_access_key_id=temp_creds["AccessKeyId"],
+            aws_secret_access_key=temp_creds["SecretAccessKey"],
+            aws_session_token=temp_creds["SessionToken"],
+        )
+
+    try:
+        # ── 1. S3 버킷 생성 (Config 전송용) ─────────────────────────
+        s3 = _client("s3")
+        try:
+            s3.create_bucket(
+                Bucket=bucket_name,
+                CreateBucketConfiguration={"LocationConstraint": region},
+            )
+            s3.put_bucket_policy(
+                Bucket=bucket_name,
+                Policy=f'''{{
+                    "Version": "2012-10-17",
+                    "Statement": [{{
+                        "Effect": "Allow",
+                        "Principal": {{"Service": "config.amazonaws.com"}},
+                        "Action": ["s3:GetBucketAcl", "s3:PutObject"],
+                        "Resource": [
+                            "arn:aws:s3:::{bucket_name}",
+                            "arn:aws:s3:::{bucket_name}/*"
+                        ]
+                    }}]
+                }}''',
+            )
+            print(f"[Config] S3 버킷 생성: {bucket_name}")
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "BucketAlreadyOwnedByYou":
+                print(f"[Config] S3 버킷 이미 존재: {bucket_name}")
+            else:
+                raise
+
+        # ── 2. ConfigRole 생성 ───────────────────────────────────────
+        iam = _client("iam")
+        try:
+            iam.create_role(
+                RoleName="AutoOpsConfigRole",
+                AssumeRolePolicyDocument='''{
+                    "Version": "2012-10-17",
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Principal": {"Service": "config.amazonaws.com"},
+                        "Action": "sts:AssumeRole"
+                    }]
+                }''',
+            )
+            iam.attach_role_policy(
+                RoleName="AutoOpsConfigRole",
+                PolicyArn="arn:aws:iam::aws:policy/ReadOnlyAccess",
+            )
+            print("[Config] ConfigRole 생성 완료")
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "EntityAlreadyExists":
+                print("[Config] ConfigRole 이미 존재")
+            else:
+                raise
+
+        config_role_arn = iam.get_role(RoleName="AutoOpsConfigRole")["Role"]["Arn"]
+
+        # ── 3. ConfigRecorder 생성 ───────────────────────────────────
+        config = _client("config")
+        try:
+            existing = config.describe_configuration_recorders()
+            if not existing.get("ConfigurationRecorders"):
+                config.put_configuration_recorder(
+                    ConfigurationRecorder={
+                        "name": "autoops-config-recorder",
+                        "roleARN": config_role_arn,
+                        "recordingGroup": {
+                            "allSupported": True,
+                            "includeGlobalResourceTypes": True,
+                        },
+                    }
+                )
+                print("[Config] ConfigRecorder 생성 완료")
+            else:
+                print("[Config] ConfigRecorder 이미 존재")
+        except ClientError as e:
+            raise
+
+        # ── 4. DeliveryChannel 생성 ──────────────────────────────────
+        try:
+            existing = config.describe_delivery_channels()
+            if not existing.get("DeliveryChannels"):
+                config.put_delivery_channel(
+                    DeliveryChannel={
+                        "name": "autoops-config-delivery",
+                        "s3BucketName": bucket_name,
+                    }
+                )
+                print("[Config] DeliveryChannel 생성 완료")
+            else:
+                print("[Config] DeliveryChannel 이미 존재")
+        except ClientError as e:
+            raise
+
+        # ── 5. Config Recording 시작 ─────────────────────────────────
+        try:
+            status_resp = config.describe_configuration_recorder_status()
+            recorders = status_resp.get("ConfigurationRecordersStatus", [])
+            if not recorders or not recorders[0].get("recording"):
+                config.start_configuration_recorder(
+                    ConfigurationRecorderName="autoops-config-recorder"
+                )
+                print("[Config] Config Recording 시작")
+            else:
+                print("[Config] Config Recording 이미 실행 중")
+        except ClientError as e:
+            raise
+
+        # ── 6. AutoOpsRole IAM 안전망 (CF 스택 미사용 계정 대응) ────
+        try:
+            iam.put_role_policy(
+                RoleName="AutoOpsRole",
+                PolicyName="AutoOpsIAMWritePolicy",
+                PolicyDocument='''{
+                    "Version": "2012-10-17",
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Action": [
+                            "iam:ListRoles",
+                            "iam:GetRole",
+                            "iam:ListRolePolicies",
+                            "iam:ListAttachedRolePolicies"
+                        ],
+                        "Resource": "*"
+                    }]
+                }''',
+            )
+            print("[Config] AutoOpsRole IAM 안전망 추가 완료")
+        except ClientError as e:
+            print(f"[Config] AutoOpsRole IAM 안전망 추가 실패 (무시): {e}")
+
+        # ── 7. AutoOpsDriftEventRole ARN 조회 ────────────────────────
+        # CF 스택에서 생성됨. 플랫폼 SQS 정책 업데이트에 필요.
+        try:
+            drift_role_arn = iam.get_role(
+                RoleName="AutoOpsDriftEventRole"
+            )["Role"]["Arn"]
+        except ClientError:
+            drift_role_arn = f"arn:aws:iam::{aws_account_id}:role/AutoOpsDriftEventRole"
+
+        # ── 8. 플랫폼 Drift SQS 정책 업데이트 ──────────────────────
+        try:
+            platform_sqs = boto3.client("sqs", region_name=region)
+            existing_policy_str = platform_sqs.get_queue_attributes(
+                QueueUrl=queue_url,
+                AttributeNames=["Policy"],
+            ).get("Attributes", {}).get("Policy", "")
+
+            policy = _json.loads(existing_policy_str) if existing_policy_str else {
+                "Version": "2012-10-17",
+                "Statement": [],
+            }
+
+            new_sid = f"AllowCrossAccount_{aws_account_id}"
+            existing_sids = [s.get("Sid", "") for s in policy["Statement"]]
+
+            if new_sid not in existing_sids:
+                policy["Statement"].append({
+                    "Sid": new_sid,
+                    "Effect": "Allow",
+                    "Principal": {"AWS": drift_role_arn},
+                    "Action": "sqs:SendMessage",
+                    "Resource": sqs_arn,
+                })
+                platform_sqs.set_queue_attributes(
+                    QueueUrl=queue_url,
+                    Attributes={"Policy": _json.dumps(policy)},
+                )
+                print(f"[Config] Drift SQS 정책 업데이트 완료: {drift_role_arn}")
+            else:
+                print(f"[Config] Drift SQS 정책 이미 존재: {new_sid}")
+        except Exception as e:
+            print(f"[Config] Drift SQS 정책 업데이트 실패 (무시): {e}")
+
+        # ── 9. 플랫폼 MirrorOps SQS 정책 업데이트 ───────────────────
+        try:
+            existing_policy_str = platform_sqs.get_queue_attributes(
+                QueueUrl=mirrorops_queue_url,
+                AttributeNames=["Policy"],
+            ).get("Attributes", {}).get("Policy", "")
+
+            policy = _json.loads(existing_policy_str) if existing_policy_str else {
+                "Version": "2012-10-17",
+                "Statement": [],
+            }
+
+            new_sid = f"AllowCrossAccountMirrorOps_{aws_account_id}"
+            existing_sids = [s.get("Sid", "") for s in policy["Statement"]]
+
+            if new_sid not in existing_sids:
+                policy["Statement"].append({
+                    "Sid": new_sid,
+                    "Effect": "Allow",
+                    "Principal": {"AWS": drift_role_arn},
+                    "Action": "sqs:SendMessage",
+                    "Resource": mirrorops_sqs_arn,
+                })
+                platform_sqs.set_queue_attributes(
+                    QueueUrl=mirrorops_queue_url,
+                    Attributes={"Policy": _json.dumps(policy)},
+                )
+                print(f"[Config] MirrorOps SQS 정책 업데이트 완료: {drift_role_arn}")
+            else:
+                print(f"[Config] MirrorOps SQS 정책 이미 존재: {new_sid}")
+        except Exception as e:
+            print(f"[Config] MirrorOps SQS 정책 업데이트 실패 (무시): {e}")
+
+        # ── 10. autoops-dr-packages S3 버킷 정책 업데이트 ───────────
+        try:
+            platform_s3 = boto3.client("s3", region_name=region)
+            bucket_name_dr = "autoops-dr-packages"
+
+            existing_policy_str = ""
+            try:
+                resp = platform_s3.get_bucket_policy(Bucket=bucket_name_dr)
+                existing_policy_str = resp.get("Policy", "")
+            except Exception:
+                pass
+
+            policy = _json.loads(existing_policy_str) if existing_policy_str else {
+                "Version": "2012-10-17",
+                "Statement": [],
+            }
+
+            new_sid = f"AllowAutoOpsRole_{aws_account_id}"
+            existing_sids = [s.get("Sid", "") for s in policy["Statement"]]
+
+            if new_sid not in existing_sids:
+                autoops_role_arn    = f"arn:aws:iam::{aws_account_id}:role/AutoOpsRole"
+                rds_export_role_arn = f"arn:aws:iam::{aws_account_id}:role/AutoOpsRDSExportRole"
+
+                policy["Statement"].append({
+                    "Sid": new_sid,
+                    "Effect": "Allow",
+                    "Principal": {"AWS": [autoops_role_arn, rds_export_role_arn]},
+                    "Action": [
+                        "s3:PutObject", "s3:GetObject",
+                        "s3:ListBucket", "s3:DeleteObject",
+                        "s3:GetBucketLocation",
+                    ],
+                    "Resource": [
+                        f"arn:aws:s3:::{bucket_name_dr}",
+                        f"arn:aws:s3:::{bucket_name_dr}/*",
+                    ],
+                })
+                platform_s3.put_bucket_policy(
+                    Bucket=bucket_name_dr,
+                    Policy=_json.dumps(policy),
+                )
+                print(f"[Config] DR S3 버킷 정책 업데이트 완료: {aws_account_id}")
+            else:
+                print(f"[Config] DR S3 버킷 정책 이미 존재: {new_sid}")
+        except Exception as e:
+            print(f"[Config] DR S3 버킷 정책 업데이트 실패 (무시): {e}")
+
+        print(f"[Config] 계정 {aws_account_id} 설정 완료")
+
+    except Exception as e:
+        # Config 설정 실패해도 계정 연동 자체는 성공으로 처리
+        print(f"[Config] 설정 중 오류 (무시): {e}")
+
+
 @router.post("/connect")
 def connect_account(
     request: ConnectAccountRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Cross-Account IAM Role을 통해 사용자의 AWS 계정을 AutoOps에 연동한다.
-
-    검증 흐름:
-    1. STS AssumeRole (ExternalId = user_id)
-    2. 임시 자격증명으로 get_caller_identity 호출
-    3. 반환된 Account ID를 DB에 저장
-
-    ExternalId를 user_id로 사용하는 이유:
-    Confused Deputy 공격 방지 — 다른 사용자의 Role을 연동할 수 없도록 한다.
-    사용자가 CloudFormation으로 AutoOpsRole 생성 시 ExternalId에 user_id가 자동 주입된다.
-
-    로컬 개발 시 SKIP_ASSUME_ROLE=true:
-    AutoOps 서버 계정 = 사용자 계정 동일 + MFA 정책으로 AssumeRole 불가
-    → ARN에서 계정 ID 직접 추출하여 bypass
-    ECS Fargate 배포 시 SKIP_ASSUME_ROLE=false:
-    Task IAM Role로 MFA 없이 AssumeRole 정상 동작
-    """
     sts = boto3.client("sts", region_name="us-west-2")
 
-    # 항상 실제 AssumeRole 실행
     try:
         assumed = sts.assume_role(
             RoleArn=request.role_arn,
@@ -68,7 +343,7 @@ def connect_account(
         )
 
     temp_creds = assumed["Credentials"]
-    temp_sts   = boto3.client(
+    temp_sts = boto3.client(
         "sts",
         aws_access_key_id=temp_creds["AccessKeyId"],
         aws_secret_access_key=temp_creds["SecretAccessKey"],
@@ -76,7 +351,7 @@ def connect_account(
         region_name="us-west-2",
     )
     try:
-        identity       = temp_sts.get_caller_identity()
+        identity = temp_sts.get_caller_identity()
         aws_account_id = identity["Account"]
     except ClientError:
         raise HTTPException(
@@ -109,6 +384,9 @@ def connect_account(
     db.commit()
     db.refresh(account)
 
+    # Config + 플랫폼 리소스 설정 (연동 시 즉시 실행)
+    _setup_config_and_drift(temp_creds, aws_account_id)
+
     return {
         "success": True,
         "data": {
@@ -121,12 +399,12 @@ def connect_account(
         },
     }
 
+
 @router.get("")
 def list_accounts(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """연동된 AWS 계정 목록을 반환한다."""
     accounts = db.query(AWSAccount).filter(
         AWSAccount.user_id == current_user.user_id,
         AWSAccount.status == "connected",
@@ -154,7 +432,6 @@ def disconnect_account(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """AWS 계정 연동을 해제한다. status를 disconnected로 변경한다."""
     account = db.query(AWSAccount).filter(
         AWSAccount.account_id == account_id,
         AWSAccount.user_id == current_user.user_id,

--- a/backend/app/api/craft.py
+++ b/backend/app/api/craft.py
@@ -991,6 +991,15 @@ def rescan_resources(
             detail={"code": "NOT_FOUND", "message": "연동된 AWS 계정을 찾을 수 없습니다."},
         )
 
+    if project.gcp_project_id:
+        return {
+            "success": True,
+            "data": {
+                "project_id": project_id,
+                "message": "GCP 연동 프로젝트는 MirrorOps 동기화를 통해 리소스가 갱신됩니다.",
+            },
+        }
+
     background_tasks.add_task(
         _run_detect_all,
         project_id  = project.project_id,

--- a/backend/app/api/metrics.py
+++ b/backend/app/api/metrics.py
@@ -13,6 +13,7 @@ from app.core.auth import get_current_user
 from app.models.project import Project
 from app.models.aws_account import AWSAccount
 from app.models.aws_resource import AWSResource
+from app.models.governance import ResourceBaseline, OnboardingScan
 
 router = APIRouter()
 
@@ -223,7 +224,15 @@ async def get_project_metrics(
     ).first()
     if not project:
         raise HTTPException(status_code=404, detail="프로젝트를 찾을 수 없습니다.")
-    if project.status != "completed":
+
+    is_onboarding_ready = (
+        project.source == "onboarding"
+        and db.query(OnboardingScan).filter(
+            OnboardingScan.project_id == project_id,
+            OnboardingScan.status == "completed",
+        ).first() is not None
+    )
+    if project.status != "completed" and not is_onboarding_ready:
         raise HTTPException(status_code=400, detail="배포 완료된 프로젝트만 모니터링 가능합니다.")
 
     # ── 2. AWS 계정 → role_arn 조회 ───────────────────────────────────────────
@@ -233,12 +242,26 @@ async def get_project_metrics(
     if not aws_account:
         raise HTTPException(status_code=404, detail="연동된 AWS 계정을 찾을 수 없습니다.")
 
-    # ── 3. aws_resources 테이블에서 리소스 조회 ───────────────────────────────
-    aws_res_list = db.query(AWSResource).filter(
-        AWSResource.project_id == project_id,
-    ).all()
+    # ── 3. 리소스 조회 (craftops_deploy → aws_resources / onboarding → resource_baselines) ──
+    normalized: list[dict] = [
+        {
+            "resource_type":   r.resource_type,
+            "resource_name":   r.resource_name,
+            "resource_id_aws": r.resource_id_aws,
+            "region":          project.region,
+        }
+        for r in db.query(AWSResource).filter(AWSResource.project_id == project_id).all()
+    ]
+    for b in db.query(ResourceBaseline).filter(ResourceBaseline.project_id == project_id).all():
+        cfg = b.baseline_config or {}
+        normalized.append({
+            "resource_type":   b.resource_type,
+            "resource_name":   cfg.get("resource_name", ""),
+            "resource_id_aws": b.resource_id_aws,
+            "region":          cfg.get("region", project.region),
+        })
 
-    if not aws_res_list:
+    if not normalized:
         return {
             "project_id": project_id,
             "period": period,
@@ -249,8 +272,8 @@ async def get_project_metrics(
         }
 
     def find_res(keywords: list):
-        for r in aws_res_list:
-            rt = r.resource_type.lower()
+        for r in normalized:
+            rt = r["resource_type"].lower()
             if all(k in rt for k in keywords):
                 return r
         return None
@@ -260,19 +283,12 @@ async def get_project_metrics(
     alb_res         = find_res(["loadbalancer"]) or find_res(["elasticloadbalancing"])
     rds_res = find_res(["rds", "dbinstance"]) or find_res(["rds::dbinstance"])
 
-    # ── 4. 리소스 식별자 정리 ─────────────────────────────────────────────────
-    ecs_cluster_name = ecs_cluster_res.resource_name.lower() if ecs_cluster_res else None
-    ecs_service_name = ecs_service_res.resource_name.lower() if ecs_service_res else None
-    alb_arn          = alb_res.resource_id_aws        if alb_res         else None
-    rds_identifier   = rds_res.resource_name.lower() if rds_res         else None
+    # ── 4. 리소스 식별자 정리 (리소스별 자체 region 사용 — 온보딩은 리전이 섞일 수 있음) ──
+    ecs_cluster_name = ecs_cluster_res["resource_name"].lower() if ecs_cluster_res else None
+    ecs_service_name = ecs_service_res["resource_name"].lower() if ecs_service_res else None
+    alb_arn          = alb_res["resource_id_aws"]        if alb_res         else None
+    rds_identifier   = rds_res["resource_name"].lower() if rds_res         else None
     alb_dimension    = _extract_alb_dimension(alb_arn) if alb_arn        else None
-
-    cw_resources = {
-        "ecs_cluster":    ecs_cluster_name,
-        "ecs_service":    ecs_service_name,
-        "alb_dimension":  alb_dimension,
-        "rds_identifier": rds_identifier,
-    }
 
     if not any([ecs_cluster_name, ecs_service_name, alb_dimension, rds_identifier]):
         return {
@@ -284,70 +300,82 @@ async def get_project_metrics(
             "message": "모니터링 가능한 리소스가 없습니다.",
         }
 
-    # ── 5. 기간 설정 ──────────────────────────────────────────────────────────
+    # ── 5. 리전별로 그룹화 (리소스마다 region이 다를 수 있음) ────────────────────
+    region_groups: dict[str, dict] = {}
+
+    def _assign(region: str, key: str, value):
+        region_groups.setdefault(region, {})[key] = value
+
+    if ecs_cluster_name and ecs_service_name:
+        _assign(ecs_cluster_res["region"], "ecs_cluster", ecs_cluster_name)
+        _assign(ecs_cluster_res["region"], "ecs_service", ecs_service_name)
+    if alb_dimension:
+        _assign(alb_res["region"], "alb_dimension", alb_dimension)
+    if rds_identifier:
+        _assign(rds_res["region"], "rds_identifier", rds_identifier)
+
+    # ── 6. 기간 설정 ──────────────────────────────────────────────────────────
     cfg = PERIOD_CONFIG[period]
     now = datetime.now(timezone.utc)
     start_time = now - timedelta(seconds=cfg["lookback_seconds"])
 
-    # ── 6. CloudWatch 배치 호출 ───────────────────────────────────────────────
-    try:
-        cw = _get_cloudwatch_client(aws_account.role_arn, project.region, str(project.user_id))
-        queries = _build_metric_queries(cw_resources, cfg["stat_period"])
-
-        if not queries:
-            return {
-                "project_id": project_id,
-                "period": period,
-                "region": project.region,
-                "resources": cw_resources,
-                "metrics": {},
-            }
-
-        response = cw.get_metric_data(
-            MetricDataQueries=queries,
-            StartTime=start_time,
-            EndTime=now,
-        )
-        results = response.get("MetricDataResults", [])
-
-    except Exception as e:
-        raise HTTPException(
-            status_code=502,
-            detail=f"CloudWatch 조회 실패: {str(e)}",
-        )
-
-    # ── 7. 응답 구성 ──────────────────────────────────────────────────────────
+    # ── 7. 리전별 CloudWatch 배치 호출 ────────────────────────────────────────
+    cw_resources = {"ecs_cluster": None, "ecs_service": None, "alb_dimension": None, "rds_identifier": None}
     metrics = {}
 
-    if ecs_cluster_name and ecs_service_name:
-        metrics["ecs"] = {
-            "cpu":    _parse_metric_result(results, "ecs_cpu"),
-            "memory": _parse_metric_result(results, "ecs_memory"),
-        }
+    for region, group in region_groups.items():
+        cw_resources.update(group)
+        queries = _build_metric_queries(group, cfg["stat_period"])
+        if not queries:
+            continue
 
-    if alb_dimension:
-        metrics["alb"] = {
-            "request_count":  _parse_metric_result(results, "alb_requests"),
-            "response_time":  _parse_metric_result(results, "alb_response_time"),
-            "error_5xx":      _parse_metric_result(results, "alb_5xx"),
-        }
+        try:
+            cw = _get_cloudwatch_client(aws_account.role_arn, region, str(project.user_id))
+            response = cw.get_metric_data(
+                MetricDataQueries=queries,
+                StartTime=start_time,
+                EndTime=now,
+            )
+            results = response.get("MetricDataResults", [])
+        except Exception as e:
+            if len(region_groups) == 1:
+                # 단일 리전(craftops_deploy 표준 흐름)에서는 기존처럼 에러를 표면화한다.
+                raise HTTPException(status_code=502, detail=f"CloudWatch 조회 실패: {str(e)}")
+            print(f"[metrics] {region} CloudWatch 조회 실패: {e}")
+            continue
 
-    if rds_identifier:
-        rds_storage_raw = _parse_metric_result(results, "rds_storage")
-        rds_storage_gb = [
-            {"timestamp": p["timestamp"], "value": round(p["value"] / (1024**3), 2)}
-            for p in rds_storage_raw
-        ]
-        metrics["rds"] = {
-            "cpu":             _parse_metric_result(results, "rds_cpu"),
-            "connections":     _parse_metric_result(results, "rds_connections"),
-            "storage_free_gb": rds_storage_gb,
-        }
+        if group.get("ecs_cluster") and group.get("ecs_service"):
+            metrics["ecs"] = {
+                "cpu":    _parse_metric_result(results, "ecs_cpu"),
+                "memory": _parse_metric_result(results, "ecs_memory"),
+            }
+
+        if group.get("alb_dimension"):
+            metrics["alb"] = {
+                "request_count":  _parse_metric_result(results, "alb_requests"),
+                "response_time":  _parse_metric_result(results, "alb_response_time"),
+                "error_5xx":      _parse_metric_result(results, "alb_5xx"),
+            }
+
+        if group.get("rds_identifier"):
+            rds_storage_raw = _parse_metric_result(results, "rds_storage")
+            rds_storage_gb = [
+                {"timestamp": p["timestamp"], "value": round(p["value"] / (1024**3), 2)}
+                for p in rds_storage_raw
+            ]
+            metrics["rds"] = {
+                "cpu":             _parse_metric_result(results, "rds_cpu"),
+                "connections":     _parse_metric_result(results, "rds_connections"),
+                "storage_free_gb": rds_storage_gb,
+            }
+
+    used_regions = sorted(region_groups.keys())
+    response_region = used_regions[0] if len(used_regions) == 1 else ",".join(used_regions) or project.region
 
     return {
         "project_id": project_id,
         "period": period,
-        "region": project.region,
+        "region": response_region,
         "resources": {
             "ecs_cluster": ecs_cluster_name,
             "ecs_service": ecs_service_name,

--- a/backend/app/api/onboarding.py
+++ b/backend/app/api/onboarding.py
@@ -143,7 +143,6 @@ def get_onboard_status(
 def confirm_onboard(
     account_id: str,
     body: dict,
-    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -153,49 +152,96 @@ def confirm_onboard(
     if not scan or scan.status != "pending_confirm":
         raise HTTPException(status_code=400, detail={"code": "BAD_REQUEST", "message": "확정 가능한 스캔이 없습니다."})
 
-    groups     = body.get("groups", scan.scan_result)
-    project_id = scan.project_id
+    account = db.query(AWSAccount).filter(AWSAccount.account_id == account_id).first()
+    groups  = body.get("groups", scan.scan_result)
 
-    baselines_created = 0
-    for group_key, group_data in groups.items():
-        for resource in group_data.get("resources", []):
+    # 리전별로 리소스 묶기
+    region_resources: dict[str, list] = {}
+    for group_data in groups.values():
+        region = group_data.get("region")
+        if not region:
+            continue
+        region_resources.setdefault(region, []).extend(group_data.get("resources", []))
+
+    created_projects = []
+    total_baselines  = 0
+
+    for region, resources in region_resources.items():
+        if not resources:
+            continue
+
+        new_project = Project(
+            project_id  = str(uuid.uuid4()),
+            user_id     = current_user.user_id,
+            account_id  = account_id,
+            name        = f"onboard-{account.aws_account_id}-{region}",
+            prefix      = "onboard",
+            environment = "existing",
+            region      = region,
+            status      = "completed",
+            dr_status   = "not_ready",
+            source      = "onboarding",
+        )
+        db.add(new_project)
+        db.flush()  # project_id 확보
+
+        # 모니터링 게이트용 OnboardingScan
+        new_scan = OnboardingScan(
+            id              = str(uuid.uuid4()),
+            project_id      = new_project.project_id,
+            account_id      = account.aws_account_id,
+            status          = "completed",
+            confirmed_at    = datetime.utcnow(),
+            total_resources = len(resources),
+            scanned_regions = [region],
+        )
+        db.add(new_scan)
+
+        for resource in resources:
             baseline = ResourceBaseline(
                 id              = str(uuid.uuid4()),
-                project_id      = project_id,
+                project_id      = new_project.project_id,
                 source          = "onboarding",
                 resource_type   = resource["resource_type"],
                 resource_id_aws = resource["resource_id"],
                 baseline_config = resource,
             )
             db.add(baseline)
-            baselines_created += 1
+            total_baselines += 1
 
-    scan.status       = "completed"
-    scan.confirmed_at = datetime.utcnow()
+        created_projects.append({
+            "project_id":     new_project.project_id,
+            "region":         region,
+            "resource_count": len(resources),
+        })
+
+    # 원본 임시 scan → project 순으로 삭제 (FK 순서)
+    original_project_id = scan.project_id
+    db.delete(scan)
+    db.flush()
+    temp_project = db.query(Project).filter(Project.project_id == original_project_id).first()
+    if temp_project:
+        db.delete(temp_project)
+
     db.commit()
 
-    # Audit Log 기록 추가
     log_platform_action(
         db         = db,
         action     = "onboarding_complete",
         user_id    = current_user.user_id,
-        project_id = project_id,
-        detail     = {"baselines_created": baselines_created},
+        project_id = created_projects[0]["project_id"] if created_projects else original_project_id,
+        detail     = {
+            "baselines_created": total_baselines,
+            "regions":           [p["region"] for p in created_projects],
+        },
     )
     db.commit()
-
-    from app.api.diagram import _generate_diagram_task
-    background_tasks.add_task(
-        _generate_diagram_task,
-        project_id = project_id,
-        source     = "onboarding",
-    )
 
     return {
         "success": True,
         "data": {
-            "project_id":        project_id,
-            "baselines_created": baselines_created,
+            "projects":          created_projects,
+            "baselines_created": total_baselines,
             "status":            "completed",
         },
     }

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -135,9 +135,15 @@ def get_project(
     } if latest_package else None
 
     from app.models.aws_resource import AWSResource
-    result["aws_resource_count"] = db.query(AWSResource).filter(
-        AWSResource.project_id == project_id
-    ).count()
+    from app.models.governance import ResourceBaseline
+    if project.source == "onboarding":
+        result["aws_resource_count"] = db.query(ResourceBaseline).filter(
+            ResourceBaseline.project_id == project_id
+        ).count()
+    else:
+        result["aws_resource_count"] = db.query(AWSResource).filter(
+            AWSResource.project_id == project_id
+        ).count()
     return {"success": True, "data": result}
 
 
@@ -303,6 +309,7 @@ def _get_project_or_404(project_id: str, user_id: str, db: Session) -> Project:
 def _project_to_dict(project: Project) -> dict:
     return {
         "project_id":       project.project_id,
+        "account_id":       project.account_id,
         "name":             project.name,
         "prefix":           project.prefix,
         "environment":      project.environment,

--- a/backend/app/services/mirrorops/detector.py
+++ b/backend/app/services/mirrorops/detector.py
@@ -1,9 +1,23 @@
 import boto3
 import json
-from typing import Any
 from sqlalchemy.orm import Session
 from app.models.aws_resource import AWSResource
-from datetime import datetime
+from datetime import datetime, date
+
+
+def _serialize_config(obj):
+    """boto3 응답의 datetime을 문자열로 변환"""
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+
+def _clean_config(config: dict) -> dict:
+    """config_json 직렬화 가능하도록 변환"""
+    try:
+        return json.loads(json.dumps(config, default=_serialize_config))
+    except Exception:
+        return {}
 
 
 RESOURCE_TYPE_MAP: dict[str, dict] = {
@@ -30,10 +44,78 @@ RESOURCE_TYPE_MAP: dict[str, dict] = {
 }
 
 
+def _extract_name(resource_type: str, item: dict) -> str:
+    """리소스 타입별 Name 태그 또는 식별자 추출"""
+    # Tags에서 Name 추출 (EC2 계열)
+    tags = item.get("Tags", item.get("tags", []))
+    if isinstance(tags, list):
+        for tag in tags:
+            if tag.get("Key", tag.get("key", "")) == "Name":
+                return tag.get("Value", tag.get("value", ""))
+    elif isinstance(tags, dict):
+        name = tags.get("Name", "")
+        if name:
+            return name
+
+    # name 필드 직접 사용 (ECS Service/TaskDefinition 수동 구성)
+    if item.get("name"):
+        return item["name"]
+
+    # 리소스별 이름 필드 (버그 3 수정: GroupName 추가)
+    return (
+        item.get("GroupName") or          # ← v2 추가: SecurityGroup 이름 필드
+        item.get("clusterName") or
+        item.get("logGroupName") or
+        item.get("DBSubnetGroupName") or
+        item.get("DBInstanceIdentifier") or
+        item.get("RoleName") or
+        item.get("LoadBalancerName") or
+        item.get("TargetGroupName") or
+        ""
+    )
+
+
+def _extract_id(resource_type: str, item: dict) -> str:
+    """리소스 타입별 ID 추출 — resource_type 기반으로 정확히 매핑"""
+    id_map = {
+        "AWS::EC2::VPC":                                  "VpcId",
+        "AWS::EC2::Subnet":                               "SubnetId",
+        "AWS::EC2::InternetGateway":                      "InternetGatewayId",
+        "AWS::EC2::NatGateway":                           "NatGatewayId",
+        "AWS::EC2::RouteTable":                           "RouteTableId",
+        "AWS::EC2::SecurityGroup":                        "GroupId",
+        "AWS::ElasticLoadBalancingV2::LoadBalancer":      "LoadBalancerArn",
+        "AWS::ElasticLoadBalancingV2::TargetGroup":       "TargetGroupArn",
+        "AWS::IAM::Role":                                 "RoleName",
+        "AWS::ECS::Cluster":                              "clusterArn",
+        "AWS::ECS::TaskDefinition":                       "taskDefinitionArn",
+        "AWS::ECS::Service":                              "serviceArn",
+        "AWS::Logs::LogGroup":                            "logGroupName",
+        "AWS::RDS::DBSubnetGroup":                        "DBSubnetGroupName",
+        "AWS::RDS::DBInstance":                           "DBInstanceIdentifier",
+        "AWS::KMS::Key":                                  "KeyId",
+    }
+    field = id_map.get(resource_type)
+    if field:
+        return item.get(field, "")
+    return ""
+
+
+def _matches_prefix(resource_type: str, name: str, name_prefix: str) -> bool:
+    """리소스 타입별 prefix 매칭"""
+    name_lower   = name.lower()
+    prefix_lower = name_prefix.lower()
+    # Log Group: "/ecs/test-prod-app" → prefix가 포함되면 매칭
+    if resource_type == "AWS::Logs::LogGroup":
+        return prefix_lower.rstrip("-") in name_lower
+    return name_lower.startswith(prefix_lower)
+
+
 class ResourceDetector:
     """
-    AWS Config + boto3를 활용해 배포된 16개 리소스를 감지하고 정규화한다. (FR-B-003)
+    boto3 직접 호출로 배포된 리소스를 감지하고 정규화한다. (FR-B-003)
     Cross-Account IAM Role Assume 후 사용자 계정의 리소스를 조회한다.
+    AWS Config 의존 제거 → 배포 완료 즉시 스캔 가능.
     """
 
     def __init__(self, role_arn: str, region: str, external_id: str = ""):
@@ -102,67 +184,229 @@ class ResourceDetector:
     def _query_resources(
         self, resource_type: str, name_prefix: str
     ) -> list[dict]:
-        config_client = self.session.client("config", region_name=self.region)
-        results  = []
-        seen_ids: set = set()
+        """
+        RESOURCE_TYPE_MAP 기반 boto3 직접 호출.
+        AWS Config 의존 없이 즉시 리소스 조회 가능.
+        버그 4 수정: IAM/ELB/Logs/RDS 페이지네이션 추가
+        """
+        type_config = RESOURCE_TYPE_MAP.get(resource_type, {})
+        service = type_config.get("service")
+        method  = type_config.get("method")
+        key     = type_config.get("key")
 
-        paginator = config_client.get_paginator("list_discovered_resources")
-        for page in paginator.paginate(resourceType=resource_type):
-            for item in page.get("resourceIdentifiers", []):
-                res_name = item.get("resourceName", "")
-                res_id   = item.get("resourceId", "")
+        if not service or not method:
+            return []
 
-                if res_id in seen_ids:
-                    continue
-                seen_ids.add(res_id)
+        client = self.session.client(service, region_name=self.region)
+        results = []
 
-                detail = config_client.get_resource_config_history(
-                    resourceType=resource_type,
-                    resourceId=res_id,
-                    limit=1,
-                )
-                config_items = detail.get("configurationItems", [])
-                config_json  = {}
+        try:
+            # ── 서비스별 특수 처리 (페이지네이션 포함) ──────────────────
+            if resource_type == "AWS::ECS::Cluster":
+                arns = client.list_clusters().get("clusterArns", [])
+                if not arns:
+                    return []
+                items = client.describe_clusters(clusters=arns).get("clusters", [])
 
-                if config_items:
-                    item_status = config_items[0].get("configurationItemStatus", "")
-                    if item_status == "ResourceDeleted":
-                        continue
+            elif resource_type == "AWS::ECS::TaskDefinition":
+                arns = client.list_task_definitions(status="ACTIVE").get("taskDefinitionArns", [])
+                items = [{"taskDefinitionArn": arn, "name": arn.split("/")[-1].split(":")[0]} for arn in arns]
 
-                    raw = config_items[0].get("configuration", "{}")
+            elif resource_type == "AWS::ECS::Service":
+                cluster_arns = client.list_clusters().get("clusterArns", [])
+                items = []
+                for cluster in cluster_arns:
+                    arns = client.list_services(cluster=cluster).get("serviceArns", [])
+                    items.extend([{"serviceArn": arn, "name": arn.split("/")[-1]} for arn in arns])
+
+            elif resource_type == "AWS::IAM::Role":
+                # ← 버그 4 수정: IAM 페이지네이션
+                items = []
+                paginator = client.get_paginator("list_roles")
+                for page in paginator.paginate():
+                    items.extend(page.get("Roles", []))
+
+            elif resource_type == "AWS::KMS::Key":
+                keys = client.list_keys().get("Keys", [])
+                items = []
+                for k in keys:
                     try:
-                        config_json = json.loads(raw) if isinstance(raw, str) else raw
-                    except json.JSONDecodeError:
-                        config_json = {}
+                        meta = client.describe_key(KeyId=k["KeyId"])["KeyMetadata"]
+                        if meta.get("KeyState") == "Enabled" and meta.get("KeyManager") == "CUSTOMER":
+                            items.append(meta)
+                    except Exception:
+                        pass
 
-                    top_tags = config_items[0].get("tags", {})
-                    config_json["tags"] = top_tags
+            elif resource_type == "AWS::EC2::NatGateway":
+                items = client.describe_nat_gateways(
+                    Filters=[{"Name": "state", "Values": ["available"]}]
+                ).get("NatGateways", [])
 
-                name_tag = ""
-                tags = config_json.get("tags", {})
-                if isinstance(tags, dict):
-                    name_tag = tags.get("Name", "")
-                elif isinstance(tags, list):
-                    for tag in tags:
-                        if tag.get("key") == "Name":
-                            name_tag = tag.get("value", "")
-                            break
+            elif resource_type == "AWS::ElasticLoadBalancingV2::LoadBalancer":
+                # ← 버그 4 수정: ELB 페이지네이션
+                items = []
+                paginator = client.get_paginator("describe_load_balancers")
+                for page in paginator.paginate():
+                    items.extend(page.get("LoadBalancers", []))
 
-                effective_name = name_tag or res_name
-                if not effective_name.lower().startswith(name_prefix.lower()):
+            elif resource_type == "AWS::ElasticLoadBalancingV2::TargetGroup":
+                # ← 버그 4 수정: TargetGroup 페이지네이션
+                items = []
+                paginator = client.get_paginator("describe_target_groups")
+                for page in paginator.paginate():
+                    items.extend(page.get("TargetGroups", []))
+
+            elif resource_type == "AWS::Logs::LogGroup":
+                # ← 버그 4 수정: LogGroup 페이지네이션
+                items = []
+                paginator = client.get_paginator("describe_log_groups")
+                for page in paginator.paginate():
+                    items.extend(page.get("logGroups", []))
+
+            elif resource_type == "AWS::RDS::DBInstance":
+                # ← 버그 4 수정: RDS 페이지네이션
+                items = []
+                paginator = client.get_paginator("describe_db_instances")
+                for page in paginator.paginate():
+                    items.extend(page.get("DBInstances", []))
+
+            elif resource_type == "AWS::RDS::DBSubnetGroup":
+                # ← 버그 4 수정: RDS SubnetGroup 페이지네이션
+                items = []
+                paginator = client.get_paginator("describe_db_subnet_groups")
+                for page in paginator.paginate():
+                    items.extend(page.get("DBSubnetGroups", []))
+
+            else:
+                response = getattr(client, method)()
+                items = response.get(key, [])
+
+            # ── 이름/ID 추출 + prefix 필터링 ────────────────────────────
+            for item in items:
+                name        = _extract_name(resource_type, item)
+                resource_id = _extract_id(resource_type, item)
+
+                if not resource_id:
+                    continue
+
+                if not name:
+                    name = resource_id
+
+                if not _matches_prefix(resource_type, name, name_prefix):
                     continue
 
                 results.append({
-                    "id":     res_id,
-                    "name":   effective_name,
-                    "config": config_json,
+                    "id":     resource_id,
+                    "name":   name,
+                    "config": _clean_config(item),
                 })
+
+        except Exception as e:
+            print(f"[경고] {resource_type} boto3 직접 조회 실패: {e}")
 
         return results
 
-    def scan_all(self, role_arn: str, region: str = "us-west-2", external_id: str = "") -> dict:
-        import boto3
+    def _enabled_regions(self, session: boto3.Session) -> list[str]:
+        """계정에서 활성화된(opt-in 제외) 전체 리전 목록 조회"""
+        ec2 = session.client("ec2", region_name="us-west-2")
+        try:
+            regions = ec2.describe_regions(
+                Filters=[{"Name": "opt-in-status", "Values": ["opt-in-not-required", "opted-in"]}]
+            )["Regions"]
+            return [r["RegionName"] for r in regions]
+        except Exception as e:
+            print(f"[scan_all] 리전 목록 조회 실패, us-west-2만 스캔: {e}")
+            return ["us-west-2"]
 
+    def _scan_region(self, session: boto3.Session, region: str) -> list[dict]:
+        """단일 리전 내 EC2/ECS/RDS/ALB/Logs 리소스 스캔"""
+        ec2   = session.client("ec2",   region_name=region)
+        ecs   = session.client("ecs",   region_name=region)
+        rds   = session.client("rds",   region_name=region)
+        elbv2 = session.client("elbv2", region_name=region)
+        logs  = session.client("logs",  region_name=region)
+
+        all_resources = []
+
+        # ── EC2 ──────────────────────────────────────────────────────
+        try:
+            for vpc in ec2.describe_vpcs()["Vpcs"]:
+                if vpc.get("IsDefault"): continue
+                name = next((t["Value"] for t in vpc.get("Tags", []) if t["Key"] == "Name"), vpc["VpcId"])
+                all_resources.append({"resource_type": "AWS::EC2::VPC", "resource_id": vpc["VpcId"], "resource_name": name, "region": region, "vpc_id": vpc["VpcId"]})
+        except Exception as e:
+            print(f"[scan_all] {region} VPC 조회 실패: {e}")
+
+        try:
+            for sn in ec2.describe_subnets()["Subnets"]:
+                if sn.get("DefaultForAz"): continue
+                name = next((t["Value"] for t in sn.get("Tags", []) if t["Key"] == "Name"), sn["SubnetId"])
+                all_resources.append({"resource_type": "AWS::EC2::Subnet", "resource_id": sn["SubnetId"], "resource_name": name, "region": region, "vpc_id": sn.get("VpcId")})
+        except Exception as e:
+            print(f"[scan_all] {region} Subnet 조회 실패: {e}")
+
+        try:
+            for sg in ec2.describe_security_groups()["SecurityGroups"]:
+                if sg.get("GroupName") == "default": continue
+                name = next((t["Value"] for t in sg.get("Tags", []) if t["Key"] == "Name"), sg.get("GroupName", sg["GroupId"]))
+                all_resources.append({"resource_type": "AWS::EC2::SecurityGroup", "resource_id": sg["GroupId"], "resource_name": name, "region": region, "vpc_id": sg.get("VpcId")})
+        except Exception as e:
+            print(f"[scan_all] {region} SecurityGroup 조회 실패: {e}")
+
+        # ── ECS ──────────────────────────────────────────────────────
+        try:
+            cluster_arns = ecs.list_clusters().get("clusterArns", [])
+            if cluster_arns:
+                for c in ecs.describe_clusters(clusters=cluster_arns).get("clusters", []):
+                    all_resources.append({"resource_type": "AWS::ECS::Cluster", "resource_id": c["clusterArn"], "resource_name": c["clusterName"], "region": region, "vpc_id": None})
+        except Exception as e:
+            print(f"[scan_all] {region} ECS Cluster 조회 실패: {e}")
+
+        # ── RDS ──────────────────────────────────────────────────────
+        try:
+            paginator = rds.get_paginator("describe_db_instances")
+            for page in paginator.paginate():
+                for db in page.get("DBInstances", []):
+                    all_resources.append({"resource_type": "AWS::RDS::DBInstance", "resource_id": db["DBInstanceIdentifier"], "resource_name": db["DBInstanceIdentifier"], "region": region, "vpc_id": None})
+        except Exception as e:
+            print(f"[scan_all] {region} RDS 조회 실패: {e}")
+
+        # ── ALB ──────────────────────────────────────────────────────
+        try:
+            paginator = elbv2.get_paginator("describe_load_balancers")
+            for page in paginator.paginate():
+                for lb in page.get("LoadBalancers", []):
+                    all_resources.append({"resource_type": "AWS::ElasticLoadBalancingV2::LoadBalancer", "resource_id": lb["LoadBalancerArn"], "resource_name": lb["LoadBalancerName"], "region": region, "vpc_id": lb.get("VpcId")})
+        except Exception as e:
+            print(f"[scan_all] {region} ALB 조회 실패: {e}")
+
+        # ── NAT Gateway ───────────────────────────────────────────────
+        try:
+            for nat in ec2.describe_nat_gateways(Filters=[{"Name": "state", "Values": ["available"]}])["NatGateways"]:
+                name = next((t["Value"] for t in nat.get("Tags", []) if t["Key"] == "Name"), nat["NatGatewayId"])
+                all_resources.append({"resource_type": "AWS::EC2::NatGateway", "resource_id": nat["NatGatewayId"], "resource_name": name, "region": region, "vpc_id": nat.get("VpcId")})
+        except Exception as e:
+            print(f"[scan_all] {region} NAT Gateway 조회 실패: {e}")
+
+        # ── Log Groups ───────────────────────────────────────────────
+        try:
+            paginator = logs.get_paginator("describe_log_groups")
+            for page in paginator.paginate():
+                for lg in page.get("logGroups", []):
+                    all_resources.append({"resource_type": "AWS::Logs::LogGroup", "resource_id": lg["logGroupName"], "resource_name": lg["logGroupName"], "region": region, "vpc_id": None})
+        except Exception as e:
+            print(f"[scan_all] {region} LogGroup 조회 실패: {e}")
+
+        return all_resources
+
+    def scan_all(self, role_arn: str, region: str = "", external_id: str = "") -> dict:
+        """
+        온보딩용 전체 계정 리소스 스캔.
+        버그 1 수정: AWS Config 의존 제거 → boto3 직접 호출로 전환.
+        Config 초기 탐색 지연(수십 분) 없이 즉시 스캔 가능.
+        멀티 리전: 계정에 활성화된 전체 리전을 순회 (IAM Role은 글로벌이라 1회만 조회).
+        region을 명시하면 해당 리전만 스캔(테스트/디버그용, 기존 동작 유지).
+        """
         sts = boto3.client("sts")
         kwargs = {
             "RoleArn":         role_arn,
@@ -178,64 +422,26 @@ class ResourceDetector:
             aws_access_key_id=creds["AccessKeyId"],
             aws_secret_access_key=creds["SecretAccessKey"],
             aws_session_token=creds["SessionToken"],
-            region_name=region,
         )
 
-        config_client = session.client("config")
-        ec2_client    = session.client("ec2")
-
-        resource_types = [
-            "AWS::EC2::VPC",
-            "AWS::EC2::Subnet",
-            "AWS::EC2::SecurityGroup",
-            "AWS::ECS::Cluster",
-            "AWS::RDS::DBInstance",
-            "AWS::ElasticLoadBalancingV2::LoadBalancer",
-            "AWS::EC2::NatGateway",
-            "AWS::IAM::Role",
-            "AWS::S3::Bucket",
-            "AWS::Logs::LogGroup",
-        ]
+        regions = [region] if region else self._enabled_regions(session)
 
         all_resources = []
-        for resource_type in resource_types:
-            paginator = config_client.get_paginator("list_discovered_resources")
-            for page in paginator.paginate(resourceType=resource_type):
-                for r in page.get("resourceIdentifiers", []):
-                    all_resources.append({
-                        "resource_type": resource_type,
-                        "resource_id":   r["resourceId"],
-                        "resource_name": r.get("resourceName", r["resourceId"]),
-                        "region":        r.get("resourceRegion", region),
-                    })
+        for r in regions:
+            all_resources.extend(self._scan_region(session, r))
 
-        vpc_names = {}
+        # ── IAM Role (글로벌, 1회만 조회) ───────────────────────────────
         try:
-            vpcs = ec2_client.describe_vpcs()["Vpcs"]
-            for vpc in vpcs:
-                name = next(
-                    (t["Value"] for t in vpc.get("Tags", []) if t["Key"] == "Name"),
-                    vpc["VpcId"],
-                )
-                vpc_names[vpc["VpcId"]] = name
-        except Exception:
-            pass
+            iam = session.client("iam", region_name="us-west-2")
+            paginator = iam.get_paginator("list_roles")
+            for page in paginator.paginate():
+                for role in page.get("Roles", []):
+                    all_resources.append({"resource_type": "AWS::IAM::Role", "resource_id": role["RoleName"], "resource_name": role["RoleName"], "region": "global", "vpc_id": None})
+        except Exception as e:
+            print(f"[scan_all] IAM Role 조회 실패: {e}")
 
-        subnet_vpc_map = {}
-        try:
-            subnets = ec2_client.describe_subnets()["Subnets"]
-            for s in subnets:
-                subnet_vpc_map[s["SubnetId"]] = s["VpcId"]
-        except Exception:
-            pass
-
-        sg_vpc_map = {}
-        try:
-            sgs = ec2_client.describe_security_groups()["SecurityGroups"]
-            for sg in sgs:
-                sg_vpc_map[sg["GroupId"]] = sg.get("VpcId", "")
-        except Exception:
-            pass
+        # ── VPC 기반 그룹화 ───────────────────────────────────────────
+        vpc_names = {r["resource_id"]: r["resource_name"] for r in all_resources if r["resource_type"] == "AWS::EC2::VPC"}
 
         groups: dict = {}
 
@@ -251,16 +457,6 @@ class ResourceDetector:
             groups[key]["resources"].append(resource)
 
         for r in all_resources:
-            rtype = r["resource_type"]
-            rid   = r["resource_id"]
-
-            if rtype == "AWS::EC2::VPC":
-                _add_to_group(r, rid)
-            elif rtype == "AWS::EC2::Subnet":
-                _add_to_group(r, subnet_vpc_map.get(rid))
-            elif rtype == "AWS::EC2::SecurityGroup":
-                _add_to_group(r, sg_vpc_map.get(rid))
-            else:
-                _add_to_group(r, None)
+            _add_to_group(r, r.get("vpc_id"))
 
         return groups

--- a/backend/app/services/mirrorops/dr_packager.py
+++ b/backend/app/services/mirrorops/dr_packager.py
@@ -46,7 +46,7 @@ class DRPackager:
 
         # ② RDS CreateSnapshot 호출
         snapshot_id  = f"autoops-{project_id[:8]}-{int(datetime.now().timestamp())}"
-        rds_id       = f"{prefix}-{environment}-rds"
+        rds_id       = f"{prefix}-{environment}-rds".lower()
         snapshot_arn = self._create_rds_snapshot(rds_id, snapshot_id)
 
         snapshot_ref = {
@@ -197,7 +197,7 @@ class DRPackager:
 
             account_id = self.user_session.client("sts").get_caller_identity()["Account"]
 
-            ecr_uri = f"{account_id}.dkr.ecr.us-west-2.amazonaws.com/autoops-sample-app:latest".lower()
+            ecr_uri = f"611058323802.dkr.ecr.us-west-2.amazonaws.com/autoops-sample-app:latest"
             gcr_uri = (
                 f"us-west1-docker.pkg.dev/{gcp_project}"
                 f"/autoops-repo/autoops-sample-app:latest"

--- a/backend/app/services/mirrorops/mapper.py
+++ b/backend/app/services/mirrorops/mapper.py
@@ -13,10 +13,21 @@ NOT_REQUIRED_RESOURCES = {
 
 
 # ── terraform 참조 헬퍼 ──────────────────────────────────────────────
+def _get_name_tag(cfg: dict) -> str:
+    """boto3 응답의 tags (list 또는 dict) 에서 Name 태그 값 추출"""
+    tags = cfg.get("tags") or cfg.get("Tags") or []
+    if isinstance(tags, list):
+        for tag in tags:
+            if tag.get("Key") == "Name":
+                return tag.get("Value", "")
+    elif isinstance(tags, dict):
+        return tags.get("Name", "")
+    return ""
+
 
 def _vpc_ref(cfg: dict) -> str:
     """이름 태그에서 VPC terraform 참조 생성 (network 필드용)"""
-    name_tag = (cfg.get("tags") or {}).get("Name", "")
+    name_tag = _get_name_tag(cfg)
     if name_tag:
         vpc_name = "-".join(name_tag.lower().replace("_", "-").split("-")[:2]) + "-vpc"
     else:
@@ -26,7 +37,7 @@ def _vpc_ref(cfg: dict) -> str:
 
 def _router_ref(cfg: dict) -> str:
     """이름 태그에서 Router terraform 참조 생성 (NAT router 필드용)"""
-    name_tag = (cfg.get("tags") or {}).get("Name", "")
+    name_tag = _get_name_tag(cfg)
     if name_tag:
         router_name = "-".join(name_tag.lower().replace("_", "-").split("-")[:2]) + "-rt-public"
     else:
@@ -41,8 +52,8 @@ RULE_BASED_MAP: dict[str, dict] = {
         "confidence": "auto",
         "mapping":    lambda cfg: {
             "name": (
-                (cfg.get("tags") or {}).get("Name", "") or
-                cfg.get("vpcId", "default-vpc")
+                _get_name_tag(cfg) or
+                cfg.get("VpcId") or cfg.get("vpcId", "default-vpc")
             ).lower().replace("_", "-"),
             "auto_create_subnetworks": False,
             "routing_mode":            "REGIONAL",
@@ -53,10 +64,10 @@ RULE_BASED_MAP: dict[str, dict] = {
         "confidence": "auto",
         "mapping":    lambda cfg: {
             "name": (
-                (cfg.get("tags") or {}).get("Name", "") or
-                cfg.get("subnetId", "default-subnet")
+                _get_name_tag(cfg) or
+                cfg.get("SubnetId") or cfg.get("subnetId", "default-subnet")
             ).lower().replace("_", "-"),
-            "ip_cidr_range": cfg.get("cidrBlock", ""),
+            "ip_cidr_range": cfg.get("CidrBlock") or cfg.get("cidrBlock", "10.0.0.0/24"),
             "region":        "us-west1",
             # [수정] terraform 참조 — VPC 생성 완료 후 서브넷 생성되도록 의존성 설정
             "network": _vpc_ref(cfg),
@@ -67,8 +78,8 @@ RULE_BASED_MAP: dict[str, dict] = {
         "confidence": "auto",
         "mapping":    lambda cfg: {
             "name": (
-                (cfg.get("tags") or {}).get("Name", "") or
-                "router-" + cfg.get("routeTableId", "default")
+                _get_name_tag(cfg) or
+                "router-" + (cfg.get("RouteTableId") or cfg.get("routeTableId", "default"))
             ).lower().replace("_", "-"),
             "region": "us-west1",
             # [수정] terraform 참조
@@ -80,7 +91,7 @@ RULE_BASED_MAP: dict[str, dict] = {
         "confidence": "auto",
         "mapping":    lambda cfg: {
             "name": (
-                (cfg.get("tags") or {}).get("Name", "") or
+                _get_name_tag(cfg) or
                 "cloud-nat"
             ).lower().replace("_", "-"),
             # [수정] terraform 참조 — Router 생성 완료 후 NAT 생성되도록 의존성 설정
@@ -296,10 +307,16 @@ class MappingEngine:
     protocol = "{rule.get('protocol', 'all')}"{ports_line}
   }}"""
 
-        source_ranges = json.dumps(
+        raw_ranges = (
             rules[0].get("source_ranges", ["0.0.0.0/0"])
             if rules and isinstance(rules[0], dict) else ["0.0.0.0/0"]
         )
+        # AWS SG ID(sg-xxx) 또는 PL ID(pl-xxx) 필터링 → CIDR만 허용
+        cidr_ranges = [
+            r for r in raw_ranges
+            if r and not r.startswith("sg-") and not r.startswith("pl-")
+        ] or ["0.0.0.0/0"]
+        source_ranges = json.dumps(cidr_ranges)
 
         return f'''resource "google_compute_firewall" "{tf_name}" {{
   name          = "{gcp_name}"
@@ -350,7 +367,7 @@ class MappingEngine:
       containers {{
         image = "{image}"
         ports {{
-          container_port = {port}
+          container_port = {port or 8080}
         }}
         resources {{
           limits = {{

--- a/failover-runner/entrypoint.sh
+++ b/failover-runner/entrypoint.sh
@@ -103,5 +103,12 @@ if [ "${TF_EXIT}" -eq 0 ]; then
           -H "X-Internal-Secret: ${INTERNAL_SECRET}" \
           -d "{\"action\":\"${ACTION}\",\"status\":\"success\",\"resources_created\":${RESOURCES_ADDED}}"
     fi
+else
+    _log "❌ terraform ${ACTION} 실패 (exit code: ${TF_EXIT})"
+    curl -s -X POST "${BACKEND_API_URL}/api/mirror/${PROJECT_ID}/failover/${FAILOVER_ID}/internal-complete" \
+      -H "Content-Type: application/json" \
+      -H "X-Internal-Secret: ${INTERNAL_SECRET}" \
+      -d "{\"action\":\"${ACTION}\",\"status\":\"failed\"}"
+fi
 
 echo "[Failover Runner] 완료"

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -1,8 +1,8 @@
 // frontend/app/onboarding/page.tsx
 'use client'
 
-import { useState, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { Suspense, useState, useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { apiClient } from '@/lib/api'
 
 type ScanStatus = 'idle' | 'scanning' | 'pending_confirm' | 'confirming' | 'completed' | 'failed'
@@ -15,7 +15,16 @@ interface ScanGroup {
 }
 
 export default function OnboardingPage() {
+  return (
+    <Suspense fallback={null}>
+      <OnboardingPageInner />
+    </Suspense>
+  )
+}
+
+function OnboardingPageInner() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [accountId, setAccountId]   = useState<string>('')
   const [scanId, setScanId]         = useState<string>('')
   const [projectId, setProjectId]   = useState<string>('')
@@ -28,9 +37,14 @@ export default function OnboardingPage() {
   useEffect(() => {
     apiClient.get('/api/accounts').then(res => {
       const accounts = res.data.data
-      if (accounts.length > 0) setAccountId(accounts[0].account_id)
+      const fromQuery = searchParams.get('accountId')
+      if (fromQuery && accounts.some((a: any) => a.account_id === fromQuery)) {
+        setAccountId(fromQuery)
+      } else if (accounts.length > 0) {
+        setAccountId(accounts[0].account_id)
+      }
     })
-  }, [])
+  }, [searchParams])
 
   const handleStartScan = async () => {
     if (!accountId) return
@@ -74,7 +88,7 @@ export default function OnboardingPage() {
       })
       setStatus('completed')
       // ⚠️ v3 변경: 거버넌스 통합 허브로 리다이렉트
-      setTimeout(() => router.push(`/projects/${projectId}`), 1500)
+      setTimeout(() => router.push('/dashboard'), 1500)
     } catch (e: any) {
       setStatus('failed')
       setError(e.response?.data?.detail?.message || '확정 실패')

--- a/frontend/app/projects/[id]/page.tsx
+++ b/frontend/app/projects/[id]/page.tsx
@@ -35,6 +35,7 @@ interface AuditLog {
 
 interface ProjectInfo {
   project_id:     string
+  account_id:     string
   name:           string
   prefix:         string
   environment:    string
@@ -238,6 +239,13 @@ export default function GovernancePage() {
                 <path d="M8.5 5H10V3.5C10 2.67 9.33 2 8.5 2S7 2.67 7 3.5 7.67 5 8.5 5z"/>
               </svg>
               Slack 연동
+            </button>
+            <button className="gv-btn" onClick={() => router.push(`/onboarding?accountId=${project.account_id}`)}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
+                <path d="M3.27 6.96 12 12.01l8.73-5.05M12 22.08V12"/>
+              </svg>
+              온보딩 스캔
             </button>
             <button className="gv-btn" onClick={() => router.push(`/projects/${projectId}/mirror`)}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">

--- a/frontend/components/InfraMetrics.tsx
+++ b/frontend/components/InfraMetrics.tsx
@@ -301,7 +301,7 @@ export default function InfraMetrics({ projectId }: Props) {
 
             <MetricPanel title="CPU 사용률" subtitle="%" isEmpty={!data.metrics.ecs?.cpu?.length}>
               <ResponsiveContainer width="100%" height={150}>
-                <AreaChart data={toChartData(data.metrics.ecs!.cpu, period, 'v')}>
+                <AreaChart data={toChartData(data.metrics.ecs?.cpu ?? [], period, 'v')}>
                   <defs>
                     <linearGradient id="gc1" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%"  stopColor={C.cpu} stopOpacity={0.25} />
@@ -319,7 +319,7 @@ export default function InfraMetrics({ projectId }: Props) {
 
             <MetricPanel title="Memory 사용률" subtitle="%" isEmpty={!data.metrics.ecs?.memory?.length}>
               <ResponsiveContainer width="100%" height={150}>
-                <AreaChart data={toChartData(data.metrics.ecs!.memory, period, 'v')}>
+                <AreaChart data={toChartData(data.metrics.ecs?.memory ?? [], period, 'v')}>
                   <defs>
                     <linearGradient id="gc2" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%"  stopColor={C.memory} stopOpacity={0.25} />
@@ -346,7 +346,7 @@ export default function InfraMetrics({ projectId }: Props) {
 
             <MetricPanel title="요청 수" subtitle="건/구간" isEmpty={!data.metrics.alb?.request_count?.length}>
               <ResponsiveContainer width="100%" height={150}>
-                <LineChart data={toChartData(data.metrics.alb!.request_count, period, 'v')}>
+                <LineChart data={toChartData(data.metrics.alb?.request_count ?? [], period, 'v')}>
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
                   <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
                   <YAxis tick={{ fill: '#334155', fontSize: 10 }} />
@@ -358,7 +358,7 @@ export default function InfraMetrics({ projectId }: Props) {
 
             <MetricPanel title="응답 시간" subtitle="ms" isEmpty={!data.metrics.alb?.response_time?.length}>
               <ResponsiveContainer width="100%" height={150}>
-                <LineChart data={toChartData(data.metrics.alb!.response_time, period, 'v')}>
+                <LineChart data={toChartData(data.metrics.alb?.response_time ?? [], period, 'v')}>
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
                   <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
                   <YAxis tick={{ fill: '#334155', fontSize: 10 }} />
@@ -370,7 +370,7 @@ export default function InfraMetrics({ projectId }: Props) {
 
             <MetricPanel title="5xx 에러" subtitle="건/구간" isEmpty={!data.metrics.alb?.error_5xx?.length}>
               <ResponsiveContainer width="100%" height={150}>
-                <LineChart data={toChartData(data.metrics.alb!.error_5xx, period, 'v')}>
+                <LineChart data={toChartData(data.metrics.alb?.error_5xx ?? [], period, 'v')}>
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
                   <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
                   <YAxis tick={{ fill: '#334155', fontSize: 10 }} />
@@ -391,7 +391,7 @@ export default function InfraMetrics({ projectId }: Props) {
 
             <MetricPanel title="CPU 사용률" subtitle="%" isEmpty={!data.metrics.rds?.cpu?.length}>
               <ResponsiveContainer width="100%" height={150}>
-                <AreaChart data={toChartData(data.metrics.rds!.cpu, period, 'v')}>
+                <AreaChart data={toChartData(data.metrics.rds?.cpu ?? [], period, 'v')}>
                   <defs>
                     <linearGradient id="gc3" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%"  stopColor={C.cpu} stopOpacity={0.25} />
@@ -409,7 +409,7 @@ export default function InfraMetrics({ projectId }: Props) {
 
             <MetricPanel title="DB 커넥션" subtitle="개" isEmpty={!data.metrics.rds?.connections?.length}>
               <ResponsiveContainer width="100%" height={150}>
-                <LineChart data={toChartData(data.metrics.rds!.connections, period, 'v')}>
+                <LineChart data={toChartData(data.metrics.rds?.connections ?? [], period, 'v')}>
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.04)" />
                   <XAxis dataKey="time" tick={{ fill: '#334155', fontSize: 10 }} />
                   <YAxis tick={{ fill: '#334155', fontSize: 10 }} />
@@ -421,7 +421,7 @@ export default function InfraMetrics({ projectId }: Props) {
 
             <MetricPanel title="여유 스토리지" subtitle="GB" isEmpty={!data.metrics.rds?.storage_free_gb?.length}>
               <ResponsiveContainer width="100%" height={150}>
-                <AreaChart data={toChartData(data.metrics.rds!.storage_free_gb, period, 'v')}>
+                <AreaChart data={toChartData(data.metrics.rds?.storage_free_gb ?? [], period, 'v')}>
                   <defs>
                     <linearGradient id="gc4" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%"  stopColor={C.storage} stopOpacity={0.25} />

--- a/infra/autoops-role.yaml
+++ b/infra/autoops-role.yaml
@@ -1,0 +1,218 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AutoOps Cross-Account IAM Role + Governance Setup
+Parameters:
+  ExternalId:
+    Type: String
+    Description: AutoOps User ID (ExternalId for AssumeRole)
+  AutoOpsAccountId:
+    Type: String
+    Description: AutoOps Platform AWS Account ID
+    Default: '611058323802'
+  PlatformDriftSQSArn:
+    Type: String
+    Description: AutoOps Platform Drift SQS ARN
+    Default: 'arn:aws:sqs:us-west-2:611058323802:autoops-drift-events'
+  PlatformMirrorOpsSQSArn:
+    Type: String
+    Description: AutoOps Platform MirrorOps SQS ARN
+    Default: 'arn:aws:sqs:us-west-2:611058323802:autoops-mirrorops-trigger'
+
+Resources:
+  # ── AutoOps 크로스 계정 역할 ──────────────────────────────────────
+  AutoOpsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AutoOpsRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AutoOpsAccountId}:role/AutoOpsTaskRole'
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref ExternalId
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/PowerUserAccess
+      Policies:
+        - PolicyName: AutoOpsIAMPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - iam:CreateRole
+                  - iam:DeleteRole
+                  - iam:AttachRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:PutRolePolicy
+                  - iam:DeleteRolePolicy
+                  - iam:PassRole
+                  - iam:TagRole
+                  - iam:UntagRole
+                  - iam:TagInstanceProfile
+                  - iam:UntagInstanceProfile
+                  - iam:GetRole
+                  - iam:ListRoles
+                  - iam:GetRolePolicy
+                  - iam:ListRolePolicies
+                  - iam:ListAttachedRolePolicies
+                  - iam:UpdateRole
+                  - iam:CreateInstanceProfile
+                  - iam:DeleteInstanceProfile
+                  - iam:GetInstanceProfile
+                  - iam:ListInstanceProfiles
+                  - iam:ListInstanceProfilesForRole
+                  - iam:AddRoleToInstanceProfile
+                  - iam:RemoveRoleFromInstanceProfile
+                Resource: '*'
+
+  # ── RDS Export 역할 ───────────────────────────────────────────────
+  AutoOpsRDSExportRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AutoOpsRDSExportRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: export.rds.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AutoOpsRDSExportPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:DeleteObject
+                  - s3:GetBucketLocation
+                Resource:
+                  - arn:aws:s3:::autoops-dr-packages
+                  - arn:aws:s3:::autoops-dr-packages/*
+              - Effect: Allow
+                Action:
+                  - kms:Encrypt
+                  - kms:Decrypt
+                  - kms:ReEncrypt*
+                  - kms:GenerateDataKey*
+                  - kms:DescribeKey
+                Resource: !GetAtt AutoOpsRDSExportKMSKey.Arn
+
+  # ── EventBridge → SQS 전송 역할 ──────────────────────────────────
+  AutoOpsDriftEventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AutoOpsDriftEventRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AllowSQSSend
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: sqs:SendMessage
+                Resource:
+                  - !Ref PlatformDriftSQSArn
+                  - !Ref PlatformMirrorOpsSQSArn
+
+  # ── KMS Key (RDS Export 암호화용) ─────────────────────────────────
+  AutoOpsRDSExportKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: AutoOps RDS Export Encryption Key
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+          - Sid: AllowRDSExportRole
+            Effect: Allow
+            Principal:
+              AWS: !GetAtt AutoOpsRDSExportRole.Arn
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: '*'
+
+  AutoOpsRDSExportKMSAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: alias/autoops-rds-export
+      TargetKeyId: !Ref AutoOpsRDSExportKMSKey
+
+  # ── EventBridge Rule — Drift 감지 ─────────────────────────────────
+  AutoOpsDriftDetectionRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: autoops-drift-detection
+      EventPattern:
+        source:
+          - aws.config
+        detail-type:
+          - Config Configuration Item Change
+      State: ENABLED
+      Targets:
+        - Id: DriftSQS
+          Arn: !Ref PlatformDriftSQSArn
+          RoleArn: !GetAtt AutoOpsDriftEventRole.Arn
+
+  # ── EventBridge Rule — RDS 스냅샷 완료 ───────────────────────────
+  AutoOpsRDSSnapshotCompleteRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: autoops-rds-snapshot-complete
+      EventPattern:
+        source:
+          - aws.rds
+        detail-type:
+          - RDS DB Snapshot Event
+        detail:
+          EventCategories:
+            - creation
+      State: ENABLED
+      Targets:
+        - Id: MirrorOpsSQS
+          Arn: !Ref PlatformMirrorOpsSQSArn
+          RoleArn: !GetAtt AutoOpsDriftEventRole.Arn
+
+Outputs:
+  AutoOpsRoleArn:
+    Description: AutoOps Cross-Account Role ARN
+    Value: !GetAtt AutoOpsRole.Arn
+    Export:
+      Name: AutoOpsRoleArn
+  AutoOpsRDSExportRoleArn:
+    Description: AutoOps RDS Export Role ARN
+    Value: !GetAtt AutoOpsRDSExportRole.Arn
+    Export:
+      Name: AutoOpsRDSExportRoleArn
+  AutoOpsDriftEventRoleArn:
+    Description: AutoOps Drift Event Role ARN
+    Value: !GetAtt AutoOpsDriftEventRole.Arn
+    Export:
+      Name: AutoOpsDriftEventRoleArn
+  AutoOpsRDSExportKMSKeyArn:
+    Description: AutoOps RDS Export KMS Key ARN
+    Value: !GetAtt AutoOpsRDSExportKMSKey.Arn
+    Export:
+      Name: AutoOpsRDSExportKMSKeyArn


### PR DESCRIPTION
feat(onboarding): 멀티리전 스캔 + 리전별 프로젝트 분리 + 모니터링 연동

feat(detector): 멀티리전 스캔 지원 + 디폴트 리소스 필터링
- scan_all()에서 describe_regions로 계정 전체 활성 리전 순회
- 실패 시 us-west-2 폴백 처리
- 디폴트 VPC(IsDefault), 디폴트 Subnet(DefaultForAz), 디폴트 SG(GroupName==default) 필터링

feat(onboarding): confirm 시 리전별 Project 분리 생성
- confirm_onboard에서 scan_result를 리전 단위로 분리
- 리전마다 별도 Project + OnboardingScan(completed) + ResourceBaseline 생성
- 프로젝트명 컨벤션: onboard-{aws_account_id}-{region}
- 원본 임시 project/scan FK 순서로 삭제 (scan → project)
- 다이어그램 생성 태스크 제거 (온보딩 프로젝트 불필요)
- confirm 완료 후 /dashboard 리다이렉트

fix(metrics): 온보딩 프로젝트 모니터링 게이트 및 리소스 조회 수정
- 모니터링 게이트를 status==completed OR (source==onboarding AND OnboardingScan.completed)로 확장
- AWSResource(deploy) + ResourceBaseline(onboarding) 양쪽 리소스 조회 통합
- 리소스별 자체 region으로 CloudWatch 호출 (멀티리전 대응)

fix(projects): 온보딩 프로젝트 리소스 개수 카운트 수정
- source==onboarding이면 ResourceBaseline 카운트
- 기존 craftops 배포는 AWSResource 카운트 유지

fix(InfraMetrics): metrics 옵셔널 체이닝 추가
- data.metrics.ecs!.cpu 등 Non-null assertion → ?.  ?? [] 로 교체
- 리소스 없는 리전 프로젝트에서 TypeError 방지

---

feat(detector): resource_type 기반 _extract_id() 리팩터링 — ALB VpcId 오반환 버그 수정
- _extract_id()를 resource_type 기반 id_map 딕셔너리로 교체
- ALB가 VpcId를 먼저 반환해 ARN 대신 VPC ID로 저장되던 버그 해결
- _extract_name()에 GroupName 추가 (SecurityGroup 이름 추출)
- IAM/ELB/Logs/RDS 페이지네이션 추가 (리소스 21개 초과 시 누락 방지)
- _clean_config()에 datetime → isoformat 직렬화 처리 추가

feat(mapper): AWS→GCP 매핑 크로스 계정 버그 수정
- _get_name_tag() 헬퍼 추가 — boto3 list/dict Tags 형식 모두 처리
- VPC/Subnet/RouteTable 필드명 PascalCase 우선 조회로 수정
- Firewall source_ranges에서 sg-/pl- 접두사 필터링 → CIDR만 허용
- Cloud Run container_port None 방지 처리 추가

fix(dr_packager): ECR URI 플랫폼 계정 고정 + RDS 식별자 소문자 처리
- ECR URI를 611058323802 고정 (샘플 이미지는 플랫폼 ECR에만 존재)
- rds_id = f"{prefix}-{environment}-rds".lower() 추가

fix(sqs_worker): KMS 키 alias/autoops-rds-export (CMK) 고정
- alias/aws/rds → alias/autoops-rds-export
- AWS 관리형 키는 RDS StartExportTask 불가 (InvalidParameterValue)

feat(craft): rescan_resources에서 GCP 연동 프로젝트 스킵 처리
- project.gcp_project_id 존재 시 _run_detect_all 스킵

feat(accounts): _setup_config_and_drift 10섹션 자동화 완성
- 섹션 9: autoops-mirrorops-trigger SQS 정책 업데이트 추가
- 섹션 10: autoops-dr-packages S3 버킷 정책에 AutoOpsRDSExportRole + GetBucketLocation 추가
- 기존 섹션 6~10이 except 블록 안에 있던 버그 수정 → try 블록 정상 흐름으로 이동
- CF 스택으로 이전된 AutoOpsDriftEventRole 생성/EventBridge Rule 생성 제거

feat(infra): autoops-role.yaml CF 스택 확장
- AutoOpsDriftEventRole 추가 (EventBridge → Drift SQS + MirrorOps SQS)
- AutoOpsRDSExportKMSKey + alias/autoops-rds-export 추가
- AutoOpsDriftDetectionRule 추가 (Config 변경 → Drift SQS)
- AutoOpsRDSSnapshotCompleteRule 추가 (RDS 스냅샷 완료 → MirrorOps SQS)
- AutoOpsRDSExportRole에 s3:GetBucketLocation + KMS 권한 추가
- 파라미터 추가: PlatformDriftSQSArn, PlatformMirrorOpsSQSArn

fix(failover-runner): entrypoint.sh if/fi 구조 오류 수정
- destroy 분기 fi 누락으로 syntax error 발생하던 버그 수정
- 전체 스크립트 재작성, 실패 시 status:failed 콜백 추가

fix(Dockerfile): tfsec/infracost 버전 고정
- tfsec: master 스크립트 → v1.28.11 바이너리 직접 다운로드
- infracost: master 스크립트 → v0.10.39 바이너리 직접 다운로드
- GitHub API rate limit으로 빌드 실패하던 문제 해결